### PR TITLE
fix(tui): anchor chat to bottom after toggling verbose (ctrl+o)

### DIFF
--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -883,6 +883,13 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 			case verboseExtended:
 				m.verbose = verboseOff
 			}
+			// Re-render immediately and anchor to bottom so the user
+			// sees the latest output after the verbose level changes.
+			if m.ready {
+				m.viewport.SetContent(m.renderMessages(m.visibleMessages()))
+				m.viewport.GotoBottom()
+				return m, nil
+			}
 			return m, m.refreshMail
 
 		case "ctrl+u":


### PR DESCRIPTION
## Summary

When cycling verbose display via `Ctrl+O` (off → thinking → extended), the chat viewport `YOffset` stayed at the pre-toggle position, stranding the user far from the latest output. Fixing this exposed a second, undocumented symptom: each `ctrl+o` press was firing an extra backend poll, producing a small latency spike on every toggle. Both are fixed by the same one-frame refactor.

Reproduction (issue #468):
1. Open the TUI mail pane with a session that has several messages containing tool calls or soul flow entries.
2. Scroll to or near the bottom.
3. Press `ctrl+o` once to enter `verboseThinking`.
4. Before this PR: viewport jumps upward (YOffset unchanged, but content height changed because `soul_flow` lines expanded); also a brief backend-poll hang. After this PR: viewport stays anchored at the bottom, no extra poll.

Fixes #468.

## Why this approach

**Root cause.** `tui/internal/tui/mail.go` — the `ctrl+o` handler cycled `m.verbose` and returned `m, m.refreshMail`, but never re-anchored the viewport. Two consequences:

- The pre-toggle `YOffset` no longer pointed at the bottom after content re-rendered (because `soul_flow`, `tool_call`, `tool_result` blocks expand/collapse by different line counts at each verbose level).
- Returning `m, m.refreshMail` on every press forced an async backend poll even though all needed data was already in `m.messages`.

The `ctrl+d` handler (`mail.go:813-823`) already solved both problems for the page-down case: when `m.ready`, it does an inline `SetContent(renderMessages(visibleMessages())) + GotoBottom()` and returns `m, nil`. We deliberately mirror that pattern for symmetry and to avoid introducing a new convention.

### Why inline `SetContent + GotoBottom`, not patching `refreshMail`

A reviewer may ask: why not just put `GotoBottom()` inside `refreshMail()` itself? Two reasons rooted in the sync/async boundary:

1. `refreshMail()` is a `tea.Cmd` (`mail.go:327`) — it runs in a goroutine and returns a `tea.Msg`. By the time the result lands back in `Update()`, the user's "scroll me to the bottom" intent has already been consumed. Worse, when `m.ready` is false (first paint, viewport not yet sized), calling `GotoBottom()` from inside `refreshMail` races with `WindowSizeMsg`.
2. The inline path executes **synchronously in `Update()`**, in the same frame as the keypress. Once `m.ready` is true (viewport has dimensions), `SetContent` + `GotoBottom` is deterministic. `refreshMail` is kept as the fallback only for the `!m.ready` window where an async disk read is genuinely needed.

Rejected alternatives:

- *Add `GotoBottom()` to `refreshMail()`.* Rejected: async timing, races with `WindowSizeMsg`, and would also change behavior for every other caller of `refreshMail()` (initial load, interval polls).
- *Force `tea.WindowSize()` to re-layout before `GotoBottom()`.* Rejected: `m.ready` already encodes "viewport is sized" — that's the precondition we actually need.

### Side-effect bug fix (the second symptom)

The old `return m, m.refreshMail` was quietly triggering one async backend poll per `ctrl+o` press, even though `verbose` is a purely local rendering concern. The new `return m, nil` (in the `m.ready` branch) eliminates this. Observable wins: no latency spike after toggling, no extra load on rapid cycling, and `ctrl+d` and `ctrl+o` are now consistent in returning `nil` when the viewport is in good shape. Calling this out explicitly so reviewers don't read `return m, nil` and think "is that a typo?" — no, the omission of the refresh is intentional.

`visibleMessages()` is recomputed on the new `m.verbose` value (verified at `mail.go:600-640`), so the inline-rendered content is correct without going back to disk. The async `m.refreshMail` is retained only as the pre-`ready` fallback.

## Test results

- `gofmt -d tui/internal/tui/mail.go` — no diff (clean)
- `go vet ./tui/internal/tui/` — no warnings
- `go build ./tui/cmd/lingtai` — exits 0 (verified at commit 1a75bb03)
- **Caveat on `go test`:** `tui/internal/tui/` currently has **zero test files** (verified via `find` — no `*_test.go` in the package). So `go test ./tui/internal/tui/ -run CtrlO -count=1` returns exit 0 with no test output, i.e. **green-by-vacuum**. This is acknowledged honestly here; a real `TestCtrlOAnchorToBottom` is owed as a follow-up (file a tracking issue). Not faking a test in this PR — the diff is small, the manual repro is convincing, and overstating test coverage is worse than admitting it's missing.
- **Manual before/after:**
  - *Before fix* (HEAD = commit before 1a75bb03): open mixed-message session, scroll near bottom, press `ctrl+o` → viewport jumps upward, brief backend-poll hang.
  - *After fix* (commit 1a75bb03 + this PR): same steps → viewport stays anchored at bottom, no extra poll.
- **Regression scope:** the only touched code path is `case "ctrl+o":` in `mail.go`. `ctrl+d` (`mail.go:813-823`) and `ctrl+u` (`mail.go:802+`) handlers are unchanged. The async `m.refreshMail` fallback for the `!m.ready` branch is byte-for-byte the same as before.
- **Pre-merge independent review:** PR #576 lesson (kernel side) — a maintainer ran a GLM-5.2 post-patch review. Requesting the same on this PR if any reviewer has bandwidth; not blocking on it.

### Follow-ups owed (not in this PR)

- `TestCtrlOAnchorToBottom` in `tui/internal/tui/mail_ctrl_o_test.go` — mock viewport, assert `YOffset` lands at bottom after `Update(tea.KeyCtrlO)` and `cmd == nil`. Trivial once a `newTestMailModel(t)` helper exists.
- Confirm with issue #468 reporter whether the eliminated backend-poll latency was the "secondary symptom" they vaguely mentioned. If yes, the side-effect fix may deserve its own changelog bullet.