### PR TITLE
fix(tui): return setup credentials Esc to setup

### DIFF
--- a/tui/internal/tui/login.go
+++ b/tui/internal/tui/login.go
@@ -615,7 +615,15 @@ func (m LoginModel) updateNormal(msg tea.KeyPressMsg) (LoginModel, tea.Cmd) {
 			m.message = i18n.T("login.codex_cancelled")
 			return m, nil
 		}
-		return m, func() tea.Msg { return ViewChangeMsg{View: "mail"} }
+		// Idle Esc should back out one navigation level. The shared
+		// credentials model is a /setup subpage, so return there instead
+		// of dumping a user who entered from /setup back to chat. A bare
+		// LoginModel keeps the historical mail fallback for tests/compat.
+		backView := "mail"
+		if m.setupSubpage {
+			backView = "setup"
+		}
+		return m, func() tea.Msg { return ViewChangeMsg{View: backView} }
 	case "up", "k":
 		if m.cursor > 0 {
 			m.cursor--

--- a/tui/internal/tui/login_test.go
+++ b/tui/internal/tui/login_test.go
@@ -331,6 +331,24 @@ func TestLoginModel_EscWithNoLoginExitsToMail(t *testing.T) {
 	}
 }
 
+// TestLoginModel_SetupSubpageEscReturnsToSetup verifies that credentials
+// opened from /setup back out to the setup wizard instead of dumping the
+// user to chat/mail. This covers /setup credentials and the setup-mode
+// Codex auth row, both of which use NewSetupCredentialsModel.
+func TestLoginModel_SetupSubpageEscReturnsToSetup(t *testing.T) {
+	dir := t.TempDir()
+	m := NewSetupCredentialsModel("", dir)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("setup-subpage Esc should emit a ViewChangeMsg command")
+	}
+	msg := cmd()
+	vc, ok := msg.(ViewChangeMsg)
+	if !ok || vc.View != "setup" {
+		t.Fatalf("setup-subpage Esc should return to setup; got %T %+v", msg, msg)
+	}
+}
+
 // TestLoginModel_CodexRowShownWithExistingEntry verifies the multi-Codex
 // unblock: an "Add another Codex account" row is shown even when a Codex
 // credential already exists, so adding a SECOND account is always reachable


### PR DESCRIPTION
## Summary
- Make idle `Esc` from the setup credentials/OAuth auth subpage return to `setup` instead of dropping back to mail/chat.
- Preserve the legacy bare `LoginModel` idle `Esc` fallback to `mail`.
- Preserve in-flight OAuth `Esc` behavior: cancel the login and stay on the credentials screen.

## Problem / reproduction
From `/setup`, the Codex OAuth credentials/auth entry opens the shared setup credentials subpage. Pressing `Esc` while no OAuth login is in flight returned to `mail`/chat, even though the user entered from setup and the expected back target is the setup first page.

## Fix
`LoginModel` already distinguishes setup credentials via `setupSubpage`. The idle `Esc` branch now chooses:
- `setup` when `m.setupSubpage` is true;
- `mail` for a bare `LoginModel`.

The existing mid-login `Esc` branch still cancels the current OAuth attempt, clears transient OAuth UI state, and stays on credentials.

## Tests
- `go test ./internal/tui -run 'TestLoginModel_(EscDuringLoginStaysOnCredentials|EscWithNoLoginExitsToMail|SetupSubpageEscReturnsToSetup)|TestSetupModeCodexRowOpensSetupCredentials' -count=1`
- `git diff --check v0.10.3..HEAD`
- `go test ./...`

## Local validation
A local hotpatch built from this change was installed and validated on Pu Cheng's machine:
- version: `lingtai-tui v0.10.3-1-g16039d83`
- sha256: `41dedc446c1dd53b23d6164826d22a2290fe441a73882b8dee58d7d594465c4e`
