### PR TITLE
Fix #507: Tighten config.json permissions to 0o600

### DIFF
--- a/tui/internal/config/global.go
+++ b/tui/internal/config/global.go
@@ -152,12 +152,17 @@ func GlobalDir() (string, error) {
 }
 
 func LoadConfig(dir string) (Config, error) {
-	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	configPath := filepath.Join(dir, "config.json")
+	data, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) {
 		return Config{}, nil
 	}
 	if err != nil {
 		return Config{}, err
+	}
+	// Tighten permissions on existing config.json (migration from 0o644)
+	if info, statErr := os.Stat(configPath); statErr == nil && info.Mode().Perm() != 0o600 {
+		_ = os.Chmod(configPath, 0o600)
 	}
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
@@ -173,7 +178,7 @@ func SaveConfig(dir string, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
 		return err
 	}
 	return WriteEnvFile(dir, cfg)


### PR DESCRIPTION
## Summary

Fixes #507

`config.json` contains `Config.Keys` — a map of API key env-var names to values (e.g., `{"OPENAI_API_KEY": "sk-..."}`). It was written with `0o644` permissions, making it world-readable on multi-user systems.

The `.env` file already correctly uses `0o600`. This PR makes `config.json` match.

## Changes

1. **`SaveConfig`** (line 176): Changed `0o644` → `0o600`
2. **`LoadConfig`** (line 154): Added permission migration — existing `config.json` files with permissive modes are tightened to `0o600` on load

## Verification

- `go build ./internal/config/` — compiles cleanly
- Existing tests pass (`go test ./internal/config/`)

## Impact

- **Multi-user systems**: API keys no longer readable by other users
- **Single-user systems**: No behavior change
- **Migration**: Existing files are automatically tightened on next load