### PR TITLE
Fix #510: Add rehydrateDone flag to prevent deadlock with 0 workers

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -198,6 +198,7 @@ type FirstRunModel struct {
 	rehydrateOrchName string // existing orchestrator agent_name from its .agent.json
 	rehydrateWorkers  int    // count of workers propagated (set at stepPropagate completion)
 	rehydrateErr      string // non-empty if RehydrateNetwork failed
+	rehydrateDone     bool   // true when rehydrateDoneMsg has arrived
 	// Bootstrap state (venv + assets install)
 	setupDone   bool        // true when bootstrap goroutine finishes
 	setupErr    string      // non-empty if bootstrap failed
@@ -879,6 +880,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 	case rehydrateDoneMsg:
 		m.rehydrateWorkers = msg.workers
 		m.rehydrateErr = msg.err
+		m.rehydrateDone = true
 		// User presses Enter on the propagate page to advance to stepLaunching,
 		// see the KeyPressMsg handler for stepPropagate below.
 		return m, nil
@@ -2137,7 +2139,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 			// Ignore Enter until rehydrateDoneMsg has arrived.
 			switch msg.String() {
 			case "enter":
-				if m.rehydrateWorkers == 0 && m.rehydrateErr == "" {
+				if !m.rehydrateDone {
 					return m, nil // still running
 				}
 				if m.rehydrateErr != "" {


### PR DESCRIPTION
## Summary

Fixes #510

When `RehydrateNetwork` returns `(0, nil)` — which is legitimate for orchestrator-only networks or networks where all workers already have `init.json` — the `stepPropagate` handler could not distinguish the completed state from the initial zero-value state, causing Enter to be blocked forever (deadlock).

## Root Cause

The state machine used two fields:
- `rehydrateWorkers` (int, zero-value = 0)
- `rehydrateErr` (string, zero-value = "")

Both before completion AND after successful completion with 0 workers:
```
rehydrateWorkers == 0 && rehydrateErr == "" → true → "still running"
```

The user could never advance past the propagate step.

## Changes

1. Added `rehydrateDone bool` field to `FirstRunModel`
2. Set `m.rehydrateDone = true` in `rehydrateDoneMsg` handler
3. Changed the Enter check from zero-value sentinel to explicit flag:
   ```go
   // Before:
   if m.rehydrateWorkers == 0 && m.rehydrateErr == "" {
       return m, nil // still running
   }
   // After:
   if !m.rehydrateDone {
       return m, nil // still running
   }
   ```

## Verification

- `go build ./internal/tui/` — compiles cleanly
- 3 insertions, 1 deletion — minimal change