### PR TITLE
Share portal replay cache writer

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -72,7 +72,7 @@ The repo root holds two binary trees plus shared infrastructure. Each binary is 
 
 | Package | LOC | Role |
 |---------|-----|------|
-| `portal/internal/api/` | ~1.5k | HTTP server (`server.go`), handlers (`handlers.go`), and replay endpoint (`replay.go` — 655 lines, the largest single API surface). Listens on a randomly-chosen port (or `--port`), writes the bound port to `.portal/port` so the TUI can find it. |
+| `portal/internal/api/` | ~1.5k | HTTP server (`server.go`), handlers (`handlers.go`), and replay endpoint (`replay.go` — 680 lines, the largest single API surface). Listens on a randomly-chosen port (or `--port`), writes the bound port to `.portal/port` so the TUI can find it. |
 | `portal/internal/fs/` | ~2.2k | Same shape as `tui/internal/fs/` but tailored to portal's needs: agent reading, heartbeat, mail, network/topology reconstruction (`reconstruct.go`, 326 lines), location resolution. |
 | `portal/internal/migrate/` | — | Versioned migrations for portal-readable state. Shares `meta.json` version space with the TUI; portal-only migrations get a TUI no-op stub and vice versa. Currently mirrors m001 / m002 / m003 / m004 / m006 / m015 / m026–m031 / m035 / m038 / m039 (the entries that touch shared on-disk state). |
 | `portal/web/` | — | React 19 + TypeScript + Vite frontend. Source under `portal/web/src/` (`App.tsx`, `Graph.tsx`, `BottomBar.tsx`, `FilterPanel.tsx`, etc.). Builds to `portal/web/dist/` then `embed.go` (`//go:embed all:web/dist`) compiles it into the Go binary. |

--- a/portal/ANATOMY.md
+++ b/portal/ANATOMY.md
@@ -42,7 +42,7 @@ The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` 
 - **`portal/embed.go:8-9`** — `//go:embed all:web/dist` compiles the React frontend build output into `webDist embed.FS`. No runtime Node dependency.
 - **`portal/embed.go:11-17`** — `WebFS()` returns `fs.Sub(webDist, "web/dist")` so the HTTP server mounts from the `web/dist/` root.
 - **`Makefile:1-24`** — Build pipeline. `web-build` runs `npm install && npm run build` in `web/`; `go-build` depends on it and stamps `main.version` via `-ldflags`. `cross-compile` targets darwin/linux × arm64/amd64.
-- **`internal/api/`** — HTTP server, handlers, and the 655-line replay endpoint. See `portal/internal/api/ANATOMY.md`.
+- **`internal/api/`** — HTTP server, handlers, and the 680-line replay endpoint. See `portal/internal/api/ANATOMY.md`.
 - **`internal/fs/`** — Filesystem readers: agent manifests, heartbeat, mailbox, network reconstruction (`reconstruct.go`), topology types (`types.go`). Same shape as `tui/internal/fs/` but Portal-specific.
 - **`internal/migrate/`** — Migration registry sharing the `meta.json` version space with the TUI. Each migration mirrors its TUI counterpart (or is a no-op stub). See `portal/internal/migrate/migrate.go`.
 - **`web/`** — React 19 + TypeScript + Vite frontend. Source under `web/src/`; builds to `web/dist/`.
@@ -67,14 +67,14 @@ The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` 
 ## State
 
 - **`.portal/port`** — Written on server start (`portal/main.go:73` → `portal/internal/api/server.go:54`). Contains the bound TCP port as an ASCII integer. Read by the TUI to know where to open the browser.
-- **`.portal/topology.jsonl`** — JSONL tape of network snapshots. Each line is `{"t": <unix_ms>, "net": <Network>}`. Appended every 3 seconds by `StartRecording` (`portal/internal/api/server.go:152-157`); also appended by the live handlers on each request.
+- **`.portal/topology.jsonl`** — JSONL tape of network snapshots. Each line is `{"t": <unix_ms>, "net": <Network>}`. Appended every 3 seconds by `StartRecording` (`portal/internal/api/server.go:88-102`); also appended by the live handlers on each request.
 - **`.portal/replay/chunks/`** — Compressed hourly replay chunks (`<hourMs>.json.gz`), each containing delta-encoded frames with keyframes every 100 frames. Plus `manifest.json` indexing all chunks.
-- **`.portal/reconstruct.progress`** — Temporary `"N/M"` progress file during tape reconstruction (`portal/internal/api/server.go:116`). Deleted when reconstruction completes (`portal/internal/api/server.go:139`).
+- **`.portal/reconstruct.progress`** — Temporary `"N/M"` progress file during tape reconstruction. Startup creates/deletes it in `StartRecording` (`portal/internal/api/server.go:76-85`); the shared replay writer updates it while caching reconstructed frames (`portal/internal/api/replay.go:417-446`).
 - **`meta.json`** — Migration version stamp under `.lingtai/`. Shared with the TUI; portal bumps its own `CurrentVersion` in lockstep.
 
 ## Notes
 
 - **Random port is the default.** `--port 0` (the default, `portal/main.go:40`) lets the OS pick an available port (`portal/internal/api/server.go:44-48`). The bound port is written to `.portal/port` so callers can discover it.
-- **Live recording begins at startup.** `StartRecording` (`portal/internal/api/server.go:62-159`) runs in a background goroutine. On first call it checks whether the tape needs reconstruction (`needsReconstruction`, `portal/internal/api/server.go:180-203`), rebuilds from source events if needed, then records a snapshot every 3 seconds.
-- **`needsReconstruction` detects format migration.** If `topology.jsonl` is missing, empty, or uses the pre-`direct/cc/bcc` format, the recorder triggers a full rebuild (`portal/internal/api/server.go:179-203`).
+- **Live recording begins at startup.** `StartRecording` (`portal/internal/api/server.go:62-106`) runs in a background goroutine. On first call it checks whether the tape needs reconstruction (`needsReconstruction`, `portal/internal/api/server.go:126-150`), rebuilds from source events if needed, then records a snapshot every 3 seconds.
+- **`needsReconstruction` detects format migration.** If `topology.jsonl` is missing, empty, or uses the pre-`direct/cc/bcc` format, the recorder triggers a full rebuild (`portal/internal/api/server.go:126-150`).
 - **Dev-mode rebuild gotcha.** After ANY migration bump, rebuild both binaries: `cd tui && make build && cd ../portal && make build`. A stale portal against a migrated project fails with "data version N is newer than this binary supports."

--- a/portal/internal/api/ANATOMY.md
+++ b/portal/internal/api/ANATOMY.md
@@ -30,9 +30,9 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 - **`portal/internal/api/server.go:18-24`** — `Server` struct. Wraps `http.Server` with `port`, `baseDir`, `cancel`/`done` for the recording goroutine.
 - **`portal/internal/api/server.go:26-41`** — `NewServer(baseDir, staticFS)`. Registers 6 API routes (`portal/internal/api/server.go:28-33`) and mounts `staticFS` at `/` (`portal/internal/api/server.go:35`). Routes fixed before the Server is returned.
 - **`portal/internal/api/server.go:43-58`** — `Start(portFile, fixedPort)`. Listens on `0.0.0.0:0` (random port) unless `fixedPort > 0` (`portal/internal/api/server.go:44-48`). Writes bound port to `portFile` (`portal/internal/api/server.go:53-54`). Serves in a goroutine (`portal/internal/api/server.go:56`).
-- **`portal/internal/api/server.go:62-159`** — `StartRecording(baseDir)`. Background goroutine with a 3-second ticker (`portal/internal/api/server.go:70`). On first run: checks `needsReconstruction`, rebuilds tape from source via `agentfs.ReconstructTape` if needed, streams frames into hourly compressed chunks (`portal/internal/api/server.go:73-139`). Then records `agentfs.BuildNetwork` snapshots on every tick via `AppendTopology` (`portal/internal/api/server.go:152-157`).
-- **`portal/internal/api/server.go:170-176`** — `Stop(ctx)`. Cancels the recording goroutine, waits for `s.done`, shuts down the HTTP server.
-- **`portal/internal/api/server.go:180-203`** — `needsReconstruction(path)`. Returns true if `topology.jsonl` is missing, empty, or uses the old format (lacking `direct`/`cc`/`bcc` fields on mail edges).
+- **`portal/internal/api/server.go:62-106`** — `StartRecording(baseDir)`. Background goroutine with a 3-second ticker (`portal/internal/api/server.go:70`). On first run: checks `needsReconstruction`, rebuilds tape from source via `agentfs.ReconstructTape`, writes replay caches through `writeReconstructedReplay` (`portal/internal/api/server.go:73-85`), then records `agentfs.BuildNetwork` snapshots on every tick via `AppendTopology` (`portal/internal/api/server.go:88-102`).
+- **`portal/internal/api/server.go:116-122`** — `Stop(ctx)`. Cancels the recording goroutine, waits for `s.done`, shuts down the HTTP server.
+- **`portal/internal/api/server.go:126-150`** — `needsReconstruction(path)`. Returns true if `topology.jsonl` is missing, empty, or uses the old format (lacking `direct`/`cc`/`bcc` fields on mail edges).
 
 ### Handlers (`handlers.go`)
 
@@ -42,19 +42,19 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 - **`portal/internal/api/handlers.go:93-136`** — `AppendTopology(path, network)` / `AppendTopologyAt`. Writes one JSONL line `{"t":<unix_ms>,"net":<network>}`. Normalises nil slices to `[]`. Opens the file with `O_APPEND`; creates parent dirs on first write.
 - **`portal/internal/api/handlers.go:140-159`** — `NewProgressHandler(baseDir)`. `GET /api/topology/progress` — reads `reconstruct.progress` (`"N/M"` format), returns `{"current":N,"total":M}` or `{}`.
 
-### Replay (`replay.go`, 709 lines)
+### Replay (`replay.go`, 680 lines)
 
 - **`portal/internal/api/replay.go:18-56`** — Wire types: `ReplayChunk` (delta-encoded hour range), `ReplayFrame` (keyframe or delta), `FrameDelta` (only-changed fields), `ChunkInfo` (manifest entry), `ReplayManifest` (tape bounds + chunk list).
 - **`portal/internal/api/replay.go:60-87`** — `deltaEncode(frames, keyframeInterval)`. Converts `[]TapeFrame` into a `ReplayChunk` with full keyframes every N frames and `FrameDelta` in between.
 - **`portal/internal/api/replay.go:91-178`** — `computeDelta(prev, curr)`. Field-by-field diff of two `Network` values: nodes (with `__REMOVED__` tombstones), avatar/contact/mail edges (keyed by identifier pairs), and stats. Returns nil if nothing changed.
-- **`portal/internal/api/replay.go:220-338`** — `buildManifest(topologyPath, replayDir)`. Fast path: reads cached `manifest.json`, scans only new JSONL frames after the last completed chunk, caches newly-completed hours as `.json.gz`. O(new_frames). `manifest.TapeStart` is the first real frame timestamp (preferred from the cached manifest, then `firstFrameForChunk`, then the bucket floor as last-resort) — NOT `chunks[0].Start`, which is the hour-bucket floor and would render as ~55min of empty scrubber padding.
-- **`portal/internal/api/replay.go:340-375`** — `firstFrameForChunk(info, replayDir, topologyPath)`. Returns the earliest frame timestamp in a chunk, reading `<hourMs>.json.gz` first and falling back to a JSONL scan within the chunk's hour window. Used by `buildManifest` when no cached `TapeStart` is available.
-- **`portal/internal/api/replay.go:407-475`** — `fullCompile(topologyPath, replayDir)`. Slow path: full re-scan of `topology.jsonl`, rebuilds all hourly caches. O(all_frames).
-- **`portal/internal/api/replay.go:477-510`** — `writeChunkCache` / `readChunkCache`. Gzip-compressed JSON encode/decode of `ReplayChunk` to/from `<hourMs>.json.gz`.
-- **`portal/internal/api/replay.go:512-552`** — `loadChunk(replayDir, topologyPath, hourStart)`. Tries cached `.json.gz` first; falls back to scanning JSONL for that hour's frames if cache missing.
-- **`portal/internal/api/replay.go:556-579`** — `NewManifestHandler`. `GET /api/topology/manifest` — calls `buildManifest`, returns chunk index.
-- **`portal/internal/api/replay.go:584-668`** — `NewRebuildHandler`. `POST /api/topology/rebuild` — reconstructs the full tape from `fs.ReconstructTape`, replaces `topology.jsonl` with the last frame, rebuilds all hourly caches. `manifest.TapeStart` is set to `frames[0].T` (the real first frame timestamp), not `chunks[0].Start`.
-- **`portal/internal/api/replay.go:671-709`** — `NewChunkHandler`. `GET /api/topology/chunk?start=<hourMs>` — serves one delta-encoded chunk. Supports `Accept-Encoding: gzip` for transparent compression.
+- **`portal/internal/api/replay.go:217-335`** — `buildManifest(topologyPath, replayDir)`. Fast path: reads cached `manifest.json`, scans only new JSONL frames after the last completed chunk, caches newly-completed hours as `.json.gz`. O(new_frames). `manifest.TapeStart` is the first real frame timestamp (preferred from the cached manifest, then `firstFrameForChunk`, then the bucket floor as last-resort) — NOT `chunks[0].Start`, which is the hour-bucket floor and would render as ~55min of empty scrubber padding.
+- **`portal/internal/api/replay.go:337-372`** — `firstFrameForChunk(info, replayDir, topologyPath)`. Returns the earliest frame timestamp in a chunk, reading `<hourMs>.json.gz` first and falling back to a JSONL scan within the chunk's hour window. Used by `buildManifest` when no cached `TapeStart` is available.
+- **`portal/internal/api/replay.go:405-489`** — `writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)`. Shared writer for already-reconstructed tapes: replaces replay chunks, writes `manifest.json` with `TapeStart = frames[0].T`, truncates `topology.jsonl` to the last reconstructed frame, and updates optional `"N/M"` progress.
+- **`portal/internal/api/replay.go:491-524`** — `writeChunkCache` / `readChunkCache`. Gzip-compressed JSON encode/decode of `ReplayChunk` to/from `<hourMs>.json.gz`.
+- **`portal/internal/api/replay.go:526-566`** — `loadChunk(replayDir, topologyPath, hourStart)`. Tries cached `.json.gz` first; falls back to scanning JSONL for that hour's frames if cache missing.
+- **`portal/internal/api/replay.go:568-593`** — `NewManifestHandler`. `GET /api/topology/manifest` — calls `buildManifest`, returns chunk index.
+- **`portal/internal/api/replay.go:595-639`** — `NewRebuildHandler`. `POST /api/topology/rebuild` — reconstructs the full tape from `fs.ReconstructTape`, then calls `writeReconstructedReplay` while holding `TopologyMu`.
+- **`portal/internal/api/replay.go:641-680`** — `NewChunkHandler`. `GET /api/topology/chunk?start=<hourMs>` — serves one delta-encoded chunk. Supports `Accept-Encoding: gzip` for transparent compression.
 
 ## Connections
 
@@ -66,15 +66,15 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 ## Composition
 
 - **Parent:** `portal/internal/`. Sibling packages: `fs/`, `migrate/`.
-- **Files:** `server.go` (~204 lines), `handlers.go` (~175 lines), `replay.go` (~709 lines), plus `*_test.go` files.
+- **Files:** `server.go` (~150 lines), `handlers.go` (~175 lines), `replay.go` (~680 lines), plus `*_test.go` files.
 - **No sub-packages.** All API logic is in this flat package.
 
 ## State
 
 - **`.portal/topology.jsonl`** — Always written with `TopologyMu` held. Appended by `AppendTopology` (live recording) and overwritten by `NewRebuildHandler` (reconstruction).
-- **`.portal/replay/chunks/<hourMs>.json.gz`** — Gzip-compressed delta-encoded hourly chunks. Written during reconstruction (`portal/internal/api/server.go:102-104`) and on every `buildManifest` call when a new hour completes.
-- **`.portal/replay/chunks/manifest.json`** — Chunk index (`ReplayManifest`). Written by `fullCompile` and `buildManifest`.
-- **`.portal/reconstruct.progress`** — Temporary `"N/M"` file. Written by the reconstruction loop; deleted on completion. Read by `/api/topology/progress`.
+- **`.portal/replay/chunks/<hourMs>.json.gz`** — Gzip-compressed delta-encoded hourly chunks. Written by `writeReconstructedReplay` for reconstructed tapes (`portal/internal/api/replay.go:454-466`) and by `buildManifest` when a new live-recorded hour completes (`portal/internal/api/replay.go:282-298`).
+- **`.portal/replay/chunks/manifest.json`** — Chunk index (`ReplayManifest`). Written by `writeReconstructedReplay` (`portal/internal/api/replay.go:480-485`) and `buildManifest` (`portal/internal/api/replay.go:329-331`).
+- **`.portal/reconstruct.progress`** — Temporary `"N/M"` file. Written by `StartRecording` / `writeReconstructedReplay` during reconstruction (`portal/internal/api/server.go:76-85`, `portal/internal/api/replay.go:417-446`) and read by `/api/topology/progress`.
 
 ## Notes
 

--- a/portal/internal/api/replay.go
+++ b/portal/internal/api/replay.go
@@ -27,9 +27,9 @@ type ReplayChunk struct {
 
 // ReplayFrame is either a keyframe (Net set) or a delta (Delta set).
 type ReplayFrame struct {
-	T     int64        `json:"t"`
-	Net   *fs.Network  `json:"net,omitempty"`
-	Delta *FrameDelta  `json:"d,omitempty"`
+	T     int64       `json:"t"`
+	Net   *fs.Network `json:"net,omitempty"`
+	Delta *FrameDelta `json:"d,omitempty"`
 }
 
 // FrameDelta holds only the fields that changed relative to the previous frame.
@@ -402,18 +402,26 @@ func scanJSONLFrom(topologyPath string, fromMs int64) ([]fs.TapeFrame, error) {
 	return frames, nil
 }
 
-// fullCompile does a complete re-scan of topology.jsonl, rebuilding all caches.
-// Used by the rebuild endpoint. This is the slow path — O(all_frames).
-func fullCompile(topologyPath, replayDir string) (ReplayManifest, error) {
-	// Clear existing caches
-	os.RemoveAll(replayDir)
-	os.MkdirAll(replayDir, 0o755)
-
-	f, err := os.Open(topologyPath)
-	if err != nil {
+// writeReconstructedReplay replaces the replay cache from already-reconstructed
+// frames and truncates topology.jsonl to the last frame for live appends.
+func writeReconstructedReplay(topologyPath, replayDir, progressPath string, frames []fs.TapeFrame) (ReplayManifest, error) {
+	if len(frames) == 0 {
+		return ReplayManifest{}, nil
+	}
+	if err := os.RemoveAll(replayDir); err != nil {
 		return ReplayManifest{}, err
 	}
-	defer f.Close()
+	if err := os.MkdirAll(replayDir, 0o755); err != nil {
+		return ReplayManifest{}, err
+	}
+	if progressPath != "" {
+		if err := os.MkdirAll(filepath.Dir(progressPath), 0o755); err != nil {
+			return ReplayManifest{}, err
+		}
+		if err := os.WriteFile(progressPath, []byte(fmt.Sprintf("0/%d", len(frames))), 0o644); err != nil {
+			return ReplayManifest{}, err
+		}
+	}
 
 	type hourGroup struct {
 		start  int64
@@ -422,17 +430,7 @@ func fullCompile(topologyPath, replayDir string) (ReplayManifest, error) {
 	var hours []*hourGroup
 	hourIndex := make(map[int64]*hourGroup)
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		var frame fs.TapeFrame
-		if err := json.Unmarshal([]byte(line), &frame); err != nil {
-			continue
-		}
+	for i, frame := range frames {
 		bucket := hourBucket(frame.T)
 		g, ok := hourIndex[bucket]
 		if !ok {
@@ -441,16 +439,15 @@ func fullCompile(topologyPath, replayDir string) (ReplayManifest, error) {
 			hours = append(hours, g)
 		}
 		g.frames = append(g.frames, frame)
+		if progressPath != "" && (i%1000 == 0 || i == len(frames)-1) {
+			if err := os.WriteFile(progressPath, []byte(fmt.Sprintf("%d/%d", i+1, len(frames))), 0o644); err != nil {
+				return ReplayManifest{}, err
+			}
+		}
 	}
-
-	if len(hours) == 0 {
-		return ReplayManifest{}, nil
-	}
-
-	lastHourStart := hours[len(hours)-1].start
 
 	manifest := ReplayManifest{
-		TapeStart: hours[0].frames[0].T,
+		TapeStart: frames[0].T,
 		TapeEnd:   hours[len(hours)-1].frames[len(hours[len(hours)-1].frames)-1].T,
 	}
 
@@ -462,13 +459,30 @@ func fullCompile(topologyPath, replayDir string) (ReplayManifest, error) {
 		}
 		manifest.Chunks = append(manifest.Chunks, info)
 
-		if g.start != lastHourStart {
-			cachePath := filepath.Join(replayDir, strconv.FormatInt(g.start, 10)+".json.gz")
-			chunk := deltaEncode(g.frames, defaultKeyframeInterval)
-			if err := writeChunkCache(cachePath, chunk); err != nil {
-				return ReplayManifest{}, fmt.Errorf("cache chunk %d: %w", g.start, err)
-			}
+		cachePath := filepath.Join(replayDir, strconv.FormatInt(g.start, 10)+".json.gz")
+		chunk := deltaEncode(g.frames, defaultKeyframeInterval)
+		if err := writeChunkCache(cachePath, chunk); err != nil {
+			return ReplayManifest{}, fmt.Errorf("cache chunk %d: %w", g.start, err)
 		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(topologyPath), 0o755); err != nil {
+		return ReplayManifest{}, err
+	}
+	lastFrame := frames[len(frames)-1]
+	line, err := json.Marshal(lastFrame)
+	if err != nil {
+		return ReplayManifest{}, err
+	}
+	if err := os.WriteFile(topologyPath, append(line, '\n'), 0o644); err != nil {
+		return ReplayManifest{}, err
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return ReplayManifest{}, err
+	}
+	if err := os.WriteFile(filepath.Join(replayDir, "manifest.json"), data, 0o644); err != nil {
+		return ReplayManifest{}, err
 	}
 
 	return manifest, nil
@@ -584,6 +598,7 @@ func NewManifestHandler(baseDir string) http.HandlerFunc {
 func NewRebuildHandler(baseDir string) http.HandlerFunc {
 	topologyPath := filepath.Join(baseDir, ".portal", "topology.jsonl")
 	replayDir := filepath.Join(baseDir, ".portal", "replay", "chunks")
+	progressPath := filepath.Join(baseDir, ".portal", "reconstruct.progress")
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -604,58 +619,14 @@ func NewRebuildHandler(baseDir string) http.HandlerFunc {
 			return
 		}
 
-		// Clear old caches
-		os.RemoveAll(replayDir)
-		os.MkdirAll(replayDir, 0o755)
-
-		// Stream into hourly compressed chunks
-		var currentHour int64 = -1
-		var hourFrames []fs.TapeFrame
-		var chunks []ChunkInfo
-
-		flushHour := func() {
-			if len(hourFrames) == 0 {
-				return
-			}
-			info := ChunkInfo{
-				Start:  currentHour,
-				End:    hourFrames[len(hourFrames)-1].T,
-				Frames: len(hourFrames),
-			}
-			chunks = append(chunks, info)
-			cachePath := filepath.Join(replayDir, strconv.FormatInt(currentHour, 10)+".json.gz")
-			chunk := deltaEncode(hourFrames, defaultKeyframeInterval)
-			writeChunkCache(cachePath, chunk)
-			hourFrames = nil
-		}
-
-		for _, f := range frames {
-			bucket := hourBucket(f.T)
-			if bucket != currentHour {
-				flushHour()
-				currentHour = bucket
-			}
-			hourFrames = append(hourFrames, f)
-		}
-		flushHour()
-
-		// Write minimal topology.jsonl (last frame for live recording)
 		TopologyMu.Lock()
-		lastFrame := frames[len(frames)-1]
-		line, _ := json.Marshal(lastFrame)
-		os.WriteFile(topologyPath, append(line, '\n'), 0o644)
+		manifest, err := writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)
 		TopologyMu.Unlock()
-
-		// Write manifest. TapeStart is the first real frame timestamp, NOT the
-		// first chunk's hour-bucket floor — otherwise the scrubber shows ~55min
-		// of empty padding before the first event ("orphan first hour").
-		manifest := ReplayManifest{
-			TapeStart: frames[0].T,
-			TapeEnd:   chunks[len(chunks)-1].End,
-			Chunks:    chunks,
+		os.Remove(progressPath)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-		mdata, _ := json.Marshal(manifest)
-		os.WriteFile(filepath.Join(replayDir, "manifest.json"), mdata, 0o644)
 
 		if manifest.Chunks == nil {
 			manifest.Chunks = []ChunkInfo{}

--- a/portal/internal/api/replay_test.go
+++ b/portal/internal/api/replay_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/anthropics/lingtai-portal/internal/fs"
@@ -123,7 +125,7 @@ func TestDeltaEncode_NodeChanges(t *testing.T) {
 	}
 }
 
-func TestCompileChunks_CreatesCache(t *testing.T) {
+func TestBuildManifest_CachesCompletedHour(t *testing.T) {
 	dir := t.TempDir()
 	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
 	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
@@ -139,9 +141,9 @@ func TestCompileChunks_CreatesCache(t *testing.T) {
 		AppendTopologyAt(topologyPath, net, ts)
 	}
 
-	manifest, err := fullCompile(topologyPath, replayDir)
+	manifest, err := buildManifest(topologyPath, replayDir)
 	if err != nil {
-		t.Fatalf("fullCompile: %v", err)
+		t.Fatalf("buildManifest: %v", err)
 	}
 
 	if manifest.TapeStart != 3600000 {
@@ -165,6 +167,78 @@ func TestCompileChunks_CreatesCache(t *testing.T) {
 	}
 }
 
+func TestWriteReconstructedReplay_UsesFirstFrameForTapeStartAndTruncatesTopology(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
+	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
+	progressPath := filepath.Join(dir, ".portal", "reconstruct.progress")
+
+	net := fs.Network{
+		Nodes:        []fs.AgentNode{{Address: "a", State: "ACTIVE"}},
+		AvatarEdges:  []fs.AvatarEdge{},
+		ContactEdges: []fs.ContactEdge{},
+		MailEdges:    []fs.MailEdge{},
+		Stats:        fs.NetworkStats{Active: 1},
+	}
+	frames := []fs.TapeFrame{
+		{T: 3_900_000, Net: net},
+		{T: 3_903_000, Net: net},
+		{T: 7_201_000, Net: net},
+	}
+
+	manifest, err := writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)
+	if err != nil {
+		t.Fatalf("writeReconstructedReplay: %v", err)
+	}
+
+	if manifest.TapeStart != 3_900_000 {
+		t.Errorf("TapeStart = %d, want 3900000", manifest.TapeStart)
+	}
+	if manifest.Chunks[0].Start != 3_600_000 {
+		t.Errorf("Chunks[0].Start = %d, want 3600000", manifest.Chunks[0].Start)
+	}
+	for _, start := range []int64{3_600_000, 7_200_000} {
+		if _, err := os.Stat(filepath.Join(replayDir, strconv.FormatInt(start, 10)+".json.gz")); err != nil {
+			t.Errorf("cache %d missing: %v", start, err)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(replayDir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var cached ReplayManifest
+	if err := json.Unmarshal(data, &cached); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if cached.TapeStart != manifest.TapeStart {
+		t.Errorf("cached TapeStart = %d, want %d", cached.TapeStart, manifest.TapeStart)
+	}
+
+	topologyData, err := os.ReadFile(topologyPath)
+	if err != nil {
+		t.Fatalf("read topology: %v", err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(topologyData), []byte("\n"))
+	if len(lines) != 1 {
+		t.Fatalf("topology lines = %d, want 1", len(lines))
+	}
+	var last fs.TapeFrame
+	if err := json.Unmarshal(lines[0], &last); err != nil {
+		t.Fatalf("decode topology frame: %v", err)
+	}
+	if last.T != 7_201_000 {
+		t.Errorf("topology frame T = %d, want 7201000", last.T)
+	}
+	progress, err := os.ReadFile(progressPath)
+	if err != nil {
+		t.Fatalf("read progress: %v", err)
+	}
+	if string(progress) != "3/3" {
+		t.Errorf("progress = %q, want 3/3", progress)
+	}
+}
+
 func TestBuildManifest_UsesExistingCache(t *testing.T) {
 	dir := t.TempDir()
 	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
@@ -181,8 +255,8 @@ func TestBuildManifest_UsesExistingCache(t *testing.T) {
 		AppendTopologyAt(topologyPath, net, ts)
 	}
 
-	// First: fullCompile to seed caches
-	m1, err := fullCompile(topologyPath, replayDir)
+	// First: buildManifest should seed completed-hour caches.
+	m1, err := buildManifest(topologyPath, replayDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +299,9 @@ func TestLoadChunk_FromCache(t *testing.T) {
 		AppendTopologyAt(topologyPath, n, ts)
 	}
 
-	fullCompile(topologyPath, replayDir)
+	if _, err := buildManifest(topologyPath, replayDir); err != nil {
+		t.Fatalf("buildManifest: %v", err)
+	}
 
 	chunk, err := loadChunk(replayDir, topologyPath, 3600000)
 	if err != nil {
@@ -263,32 +339,13 @@ func TestBuildManifest_SingleHourAfterRebuild(t *testing.T) {
 		AppendTopologyAt(topologyPath, net, ts)
 	}
 
-	// Simulate what the rebuild handler does:
-	// 1. Cache the chunk as .json.gz (rebuild caches ALL hours including last)
-	os.MkdirAll(replayDir, 0o755)
 	frames := make([]fs.TapeFrame, 4)
 	for i, ts := range []int64{3600000, 3603000, 3606000, 3609000} {
 		frames[i] = fs.TapeFrame{T: ts, Net: net}
 	}
-	chunk := deltaEncode(frames, defaultKeyframeInterval)
-	cachePath := filepath.Join(replayDir, "3600000.json.gz")
-	if err := writeChunkCache(cachePath, chunk); err != nil {
-		t.Fatal(err)
+	if _, err := writeReconstructedReplay(topologyPath, replayDir, "", frames); err != nil {
+		t.Fatalf("writeReconstructedReplay: %v", err)
 	}
-
-	// 2. Write manifest with one chunk
-	manifest := ReplayManifest{
-		TapeStart: 3600000,
-		TapeEnd:   3609000,
-		Chunks:    []ChunkInfo{{Start: 3600000, End: 3609000, Frames: 4}},
-	}
-	mdata, _ := json.Marshal(manifest)
-	os.WriteFile(filepath.Join(replayDir, "manifest.json"), mdata, 0o644)
-
-	// 3. Truncate topology.jsonl to just the last frame (as rebuild does)
-	lastFrame := frames[3]
-	line, _ := json.Marshal(lastFrame)
-	os.WriteFile(topologyPath, append(line, '\n'), 0o644)
 
 	// Now buildManifest should still report 4 frames, not 1
 	m, err := buildManifest(topologyPath, replayDir)
@@ -360,10 +417,13 @@ func TestChunkHandler(t *testing.T) {
 	}
 	AppendTopologyAt(topologyPath, net, 3600000)
 	AppendTopologyAt(topologyPath, net, 3601000)
+	AppendTopologyAt(topologyPath, net, 7200000)
 
 	// Compile first so cache exists
 	replayDir := filepath.Join(baseDir, ".portal", "replay", "chunks")
-	fullCompile(topologyPath, replayDir)
+	if _, err := buildManifest(topologyPath, replayDir); err != nil {
+		t.Fatalf("buildManifest: %v", err)
+	}
 
 	handler := NewChunkHandler(baseDir)
 	req := httptest.NewRequest("GET", "/api/topology/chunk?start=3600000", nil)

--- a/portal/internal/api/server.go
+++ b/portal/internal/api/server.go
@@ -78,63 +78,9 @@ func (s *Server) StartRecording(baseDir string) {
 
 			frames, err := agentfs.ReconstructTape(baseDir)
 			if err == nil && len(frames) > 0 {
-				os.MkdirAll(filepath.Dir(topologyPath), 0o755)
-				os.Remove(topologyPath)
-				os.RemoveAll(filepath.Join(baseDir, ".portal", "replay"))
-				os.MkdirAll(replayDir, 0o755)
-
-				// Stream frames directly into hourly compressed chunks
-				total := len(frames)
-				var currentHour int64 = -1
-				var hourFrames []agentfs.TapeFrame
-				var chunks []ChunkInfo
-
-				flushHour := func() {
-					if len(hourFrames) == 0 {
-						return
-					}
-					info := ChunkInfo{
-						Start:  currentHour,
-						End:    hourFrames[len(hourFrames)-1].T,
-						Frames: len(hourFrames),
-					}
-					chunks = append(chunks, info)
-					cachePath := filepath.Join(replayDir, fmt.Sprintf("%d.json.gz", currentHour))
-					chunk := deltaEncode(hourFrames, defaultKeyframeInterval)
-					writeChunkCache(cachePath, chunk)
-					hourFrames = nil
-				}
-
-				for i, f := range frames {
-					bucket := hourBucket(f.T)
-					if bucket != currentHour {
-						flushHour()
-						currentHour = bucket
-					}
-					hourFrames = append(hourFrames, f)
-					if i%1000 == 0 || i == total-1 {
-						os.WriteFile(progressPath, []byte(fmt.Sprintf("%d/%d", i+1, total)), 0o644)
-					}
-				}
-				flushHour()
-
-				// Write minimal topology.jsonl with just the last frame (for live recording to append to)
-				if len(frames) > 0 {
-					lastFrame := frames[len(frames)-1]
-					line, _ := json.Marshal(lastFrame)
-					os.WriteFile(topologyPath, append(line, '\n'), 0o644)
-				}
-
-				// Write manifest cache
-				if len(chunks) > 0 {
-					manifest := ReplayManifest{
-						TapeStart: chunks[0].Start,
-						TapeEnd:   chunks[len(chunks)-1].End,
-						Chunks:    chunks,
-					}
-					mdata, _ := json.Marshal(manifest)
-					os.WriteFile(filepath.Join(replayDir, "manifest.json"), mdata, 0o644)
-				}
+				TopologyMu.Lock()
+				_, _ = writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)
+				TopologyMu.Unlock()
 			}
 			os.Remove(progressPath)
 		}


### PR DESCRIPTION
## Summary

- Add a shared portal replay-cache writer for reconstructed topology frames.
- Reuse the shared writer from both startup reconstruction and manual replay rebuild.
- Remove the production-dead `fullCompile` path and update replay tests/anatomy accordingly.

## Why

The portal had two paths that performed closely related replay-cache work. The manual rebuild path and startup reconstruction path could drift, and the old `fullCompile` helper was no longer part of production flow. Sharing the writer keeps the cache replacement semantics in one place and makes tests exercise the live manifest/chunk path instead of a dead helper.

## Validation

After rebasing onto `main` (`449753705af14d79056e4924b3135d1d62894887`):

```bash
git diff --check origin/main...HEAD
cd portal && go test ./internal/api ./internal/fs
```

Both passed.

Independent Claude and GLM reviews found no blockers.
