### PR TITLE
Add Requesty as a model provider

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -256,6 +256,7 @@
   "setup.provider_deepseek": "DeepSeek V4 (1M context, tool calls)",
   "setup.provider_nvidia": "NVIDIA NIM (free OpenAI-compatible catalog, tool calls)",
   "setup.provider_openrouter": "OpenRouter (gateway to many models)",
+  "setup.provider_requesty": "Requesty (OpenAI-compatible router to many models)",
   "setup.provider_codex": "OpenAI Codex (ChatGPT OAuth)",
   "setup.provider_custom": "Custom",
   "codex.press_enter": "Press Enter to choose login method...",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -251,6 +251,7 @@
   "setup.provider_deepseek": "DeepSeek V4（百万之文，能唤具）",
   "setup.provider_nvidia": "NVIDIA NIM（免资之库，兼容 OpenAI，能唤具）",
   "setup.provider_openrouter": "OpenRouter（众模型之关）",
+  "setup.provider_requesty": "Requesty（兼容 OpenAI 之众模型之关）",
   "setup.provider_codex": "OpenAI Codex（ChatGPT 帐登）",
   "setup.provider_custom": "自设",
   "codex.press_enter": "按 Enter 启览器以登帐...",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -251,6 +251,7 @@
   "setup.provider_deepseek": "DeepSeek V4（1M 上下文，支持工具调用）",
   "setup.provider_nvidia": "NVIDIA NIM（免费 OpenAI 兼容模型库，支持工具调用）",
   "setup.provider_openrouter": "OpenRouter（多模型聚合网关）",
+  "setup.provider_requesty": "Requesty（兼容 OpenAI 的多模型路由网关）",
   "setup.provider_codex": "OpenAI Codex（ChatGPT 账号登录）",
   "setup.provider_custom": "自定义",
   "codex.press_enter": "按 Enter 选择登录方式...",

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -820,6 +820,8 @@ func DeriveLedgerProvider(endpoint, model string) string {
 		return "gemini"
 	case strings.Contains(ep, "openrouter.ai"):
 		return "openrouter"
+	case strings.Contains(ep, "requesty.ai"):
+		return "requesty"
 	case strings.Contains(ep, "api.nvidia.com"):
 		return "nvidia"
 	case ep != "":

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -215,8 +215,8 @@ func List() ([]Preset, error) {
 	})
 	templateOrder := map[string]int{
 		"minimax": 0, "zhipu": 1, "mimo": 2, "deepseek": 3,
-		"kimi": 4, "nvidia": 5, "openrouter": 6, "codex": 7,
-		"claude-agent-sdk": 8, "custom": 9,
+		"kimi": 4, "nvidia": 5, "openrouter": 6, "requesty": 7, "codex": 8,
+		"claude-agent-sdk": 9, "custom": 10,
 	}
 	sort.Slice(templates, func(i, j int) bool {
 		return templateOrder[templates[i].Name] < templateOrder[templates[j].Name]
@@ -478,6 +478,7 @@ func BuiltinPresets() []Preset {
 		kimiPreset(),
 		nvidiaPreset(),
 		openrouterPreset(),
+		requestyPreset(),
 		codexPreset(),
 		claudeAgentSDKPreset(),
 		customPreset(),
@@ -497,6 +498,7 @@ var builtinNames = map[string]bool{
 	"kimi":             true,
 	"nvidia":           true,
 	"openrouter":       true,
+	"requesty":         true,
 	"codex":            true,
 	"codex_oauth":      true,
 	"claude-agent-sdk": true,
@@ -1056,6 +1058,27 @@ func openrouterPreset() Preset {
 				"base_url": nil,
 			},
 			// OpenRouter is a text-only /chat/completions gateway — no media
+			// generation. For audio analysis use the `listen` skill; for
+			// media creation register a provider's MCP server via `mcp-manual`.
+			"capabilities": map[string]interface{}{
+				"web_search": map[string]interface{}{"provider": "duckduckgo"},
+				"skills":     skillsDefault(),
+			},
+		},
+	}
+}
+
+func requestyPreset() Preset {
+	return Preset{
+		Name:        "requesty",
+		Description: PresetDescription{Summary: "Requesty — OpenAI-compatible router to DeepSeek, GLM, Qwen, MiniMax, Kimi, Claude, ..."},
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{
+				"provider": "requesty", "model": "openai/gpt-4o-mini",
+				"api_key": nil, "api_key_env": "REQUESTY_API_KEY",
+				"base_url": "https://router.requesty.ai/v1",
+			},
+			// Requesty is a text-only /chat/completions router — no media
 			// generation. For audio analysis use the `listen` skill; for
 			// media creation register a provider's MCP server via `mcp-manual`.
 			"capabilities": map[string]interface{}{

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -114,8 +114,8 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 			t.Fatalf("RefreshTemplates() error: %v", err)
 		}
 		presets, _ := List()
-		if len(presets) != 11 {
-			t.Fatalf("expected 11 presets, got %d", len(presets))
+		if len(presets) != 12 {
+			t.Fatalf("expected 12 presets, got %d", len(presets))
 		}
 		names := map[string]bool{}
 		for _, p := range presets {
@@ -124,7 +124,7 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 				t.Errorf("preset %q: Source = %v, want SourceTemplate", p.Name, p.Source)
 			}
 		}
-		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "nvidia", "openrouter", "codex", "claude-agent-sdk", "custom"} {
+		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "nvidia", "openrouter", "requesty", "codex", "claude-agent-sdk", "custom"} {
 			if !names[want] {
 				t.Errorf("missing preset %q", want)
 			}

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -934,7 +934,7 @@ func classifyWire(provider, apiCompat string) wireProtocol {
 	switch provider {
 	case "anthropic", "minimax":
 		return wireAnthropic
-	case "openai", "openrouter", "deepseek", "kimi", "mimo", "zhipu", "codex", "nvidia":
+	case "openai", "openrouter", "requesty", "deepseek", "kimi", "mimo", "zhipu", "codex", "nvidia":
 		return wireOpenAI
 	case "custom":
 		switch apiCompat {

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -1056,7 +1056,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feProvider:
 		// Order matches the builtin presets (preset.go BuiltinPresets).
 		// Keep this in sync when adding a new provider/builtin.
-		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "codex", "custom"}
+		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "requesty", "codex", "custom"}
 		newProvider := cycleString(opts, m.fieldString(f), dir)
 		m.llmMap()["provider"] = newProvider
 		if newProvider != "codex" {

--- a/tui/internal/tui/setup.go
+++ b/tui/internal/tui/setup.go
@@ -36,6 +36,7 @@ var providers = []struct {
 	{"deepseek", "setup.provider_deepseek", "DEEPSEEK_API_KEY"},
 	{"nvidia", "setup.provider_nvidia", "NVIDIA_API_KEY"},
 	{"openrouter", "setup.provider_openrouter", "OPENROUTER_API_KEY"},
+	{"requesty", "setup.provider_requesty", "REQUESTY_API_KEY"},
 	{"custom", "setup.provider_custom", "LLM_API_KEY"},
 }
 


### PR DESCRIPTION
Adds Requesty as a model provider, mirroring the existing OpenRouter provider as closely as possible.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `REQUESTY_API_KEY` Bearer auth.

Changes:
- `tui/internal/preset/preset.go`: `requestyPreset()` mirroring `openrouterPreset()` (provider `requesty`, `api_key_env` `REQUESTY_API_KEY`, default model `openai/gpt-4o-mini`, `base_url` `https://router.requesty.ai/v1`, same web-search + skills capabilities), registered in `BuiltinPresets()`, `builtinNames`, and `templateOrder`.
- `tui/internal/tui/setup.go`: Requesty in the provider setup list.
- `tui/internal/tui/doctor.go`: Requesty classified as an OpenAI-compatible wire.
- `tui/internal/tui/preset_editor.go`: Requesty in the provider cycle options.
- `tui/internal/fs/agent.go`: endpoint→provider detection for `requesty.ai`.
- `tui/i18n/en.json`, `zh.json`, `wen.json`: `setup.provider_requesty` label mirroring OpenRouter.
- `tui/internal/preset/preset_test.go`: updated the builtin-preset count/name assertions to include Requesty.

The default model id is verified live on Requesty. `go build ./...` passes and `go test ./internal/config/... ./internal/preset/...` is green.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.