### PR TITLE
docs(skills): link skill size guidance through dev guide

### DIFF
--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -17,6 +17,8 @@ related_files:
   - tui/internal/preset/preset_allowed_revoke_test.go
   - tui/internal/preset/preset_propagate_test.go
   - tui/internal/preset/preset_agent_json_merge_test.go
+  - tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+  - tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -51,6 +53,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 | `ResolveRefsWithAuth(refs, keys, auth)` / `ResolveRefs(refs, keys)` | `tui/internal/preset/preset.go` | health-check: Source, Exists, HasKey (+ `CodexAuthRef`) for each preset path; credential validity requires configured `api_key_env`, Codex OAuth, or Claude Code CLI auth for `claude-agent-sdk`. For codex, when `AuthState.CodexAuthDir` is set, validity is judged per-preset against the preset's own `manifest.llm.codex_auth_path` token file (empty → legacy `codex-auth.json` fallback) so multiple Codex accounts are independent; without the dir it falls back to the global `CodexOAuthConfigured` bool |
 | `Validate()` | `tui/internal/preset/preset.go:282` | mirrors kernel-side validation; `summary` non-empty, `tier` 1..5, `llm.provider`/`model` non-empty |
 | `//go:embed` directives | `tui/internal/preset/preset.go:16-47` | covenant, principle, procedures, templates, soul, recipe_assets, skills |
+| `skills/lingtai-dev-guide/` | `tui/internal/preset/skills/lingtai-dev-guide/SKILL.md:1`, `tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md:1` | Bundled developer guide utility skill and its skill-stewardship nested reference, including the rule that skill authors keep routers lean and link dense content through progressive disclosure rather than encoding stale hard caps. |
 | `CopyBundle` | `tui/internal/preset/recipe_apply.go:59` | copies `.recipe/` (replace) + recipe skill library sibling (merge) + `.lingtai/` (merge) into project |
 | `RecipeNeedsApply` | `tui/internal/preset/recipe_apply.go:133` | diffs `.recipe/` vs last-applied snapshot under `.tui-asset/.recipe/` |
 | `ApplyRecipe` | `tui/internal/preset/recipe_apply.go:179` | writes `.prompt` + patches `skills.paths` per agent; snapshots `.recipe/` |

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -8,8 +8,8 @@ description: >
   publication-bound release workflow, run a runtime self-check, get a PR
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
-version: 2.6.0
-last_changed_at: "2026-06-28T22:46:25-07:00"
+version: 2.6.1
+last_changed_at: "2026-07-03T08:05:00Z"
 ---
 
 # LingTai Developer Guide
@@ -42,6 +42,11 @@ stays short on purpose; the detailed procedures live under `reference/<topic>/`.
   refreshed, and a live in-situ probe confirms the new behaviour. For kernel
   fixes, always identify the actual import path and git HEAD first; do not
   assume the repo you edited is the one this agent imports.
+- **Skill-size/progressive-disclosure rule:** when writing or updating skills,
+  treat read/context limits as a reason to keep the router lean and link onward,
+  not as a reason to paste large content into `SKILL.md`. Put dense material in
+  related/nested reference files and link to `skills-manual` for current
+  authoring mechanics and limit-aware structure.
 
 ## ANATOMY frontmatter contract
 
@@ -193,7 +198,7 @@ drill-down files, not standalone top-level skills.
 | Navigate Go TUI/portal code structurally | `lingtai-tui-anatomy` |
 | Navigate Python kernel code structurally | `lingtai-kernel-anatomy` |
 | Develop, register, or troubleshoot MCP servers/addons | `mcp-manual` first, then `lingtai-kernel-anatomy` `reference/mcp-protocol.md` |
-| Author or publish skills | `skills-manual` |
+| Author or publish skills, including limit-aware router/reference structure | `skills-manual`, then `reference/skill-stewardship/SKILL.md` for LingTai-dev stewardship |
 | Customize, export, or package project methodology as a recipe | `lingtai-recipe` |
 | Work on portal APIs, topology recording, replay, or `.portal/` state | `lingtai-portal-guide` |
 | Prepare for a consequential molt during long dev work | `psyche-manual` |

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
@@ -7,8 +7,8 @@ description: >
   triggered/executable SKILL.md files, de-privatizing and parameterizing local
   paths and human-specific details, a lightweight pre-publish benchmark/checklist,
   grooming shared-library candidates, and PR-ready skill cleanup.
-version: 1.0.0
-last_changed_at: "2026-06-29T08:41:45Z"
+version: 1.0.1
+last_changed_at: "2026-07-03T08:05:00Z"
 ---
 
 # Skill Stewardship
@@ -56,6 +56,14 @@ shared-library candidate (§5) until the pattern repeats.
 
 LingTai utility skills use progressive disclosure: a short **router** SKILL.md at
 the root plus focused **nested references** under `reference/<topic>/SKILL.md`.
+
+Read/context limits are a design signal, not a global hard-cap issue to keep
+open forever. Do not encode an old tool threshold as a blanket character limit,
+and do not paste dense material into the root just because a reader might need
+it later. The root should carry only the progressive-disclosure link; the
+related/reference file carries the detail and can be loaded on demand. For the
+current mechanics (frontmatter, layout, validator, and limit-aware structure),
+load `skills-manual` rather than duplicating that manual here.
 
 - Keep the router compact: a nested-reference catalog, a routing table, and
   cross-links. Detailed procedures live in the nested files, not the router.
@@ -115,7 +123,8 @@ heavy framework:
       `git log -1 --format=%cI -- path/to/SKILL.md`; for substantive skill
       edits, update it in the same commit.
 - [ ] Document structure is scannable: overview/core principle, when-to-use,
-      steps, related references.
+      steps, related references. Root routers contain links, not bulk; dense
+      content lives in related/nested reference files.
 - [ ] Declared dependencies/cross-linked skills exist and are named correctly.
 - [ ] Any commands/snippets were actually executed and produce the claimed output
       (the skill-benchmark practice caught real API breakage this way).
@@ -150,8 +159,9 @@ Bundle skill changes into a reviewable PR with:
 ## Related references
 
 - `skills-manual` — generic skill authoring: frontmatter spec, trigger syntax,
-  file layout, testing skills. Defer to it for mechanics; this reference covers
-  LingTai-specific stewardship.
+  file layout, testing skills, and current limit-aware router/reference
+  structure. Defer to it for mechanics; this reference covers LingTai-specific
+  stewardship and links to the manual instead of copying it.
 - `reference/pr-review-deliverables/SKILL.md` — review gates and the HTML
   explainer for a skill-changing PR.
 - `reference/contributing/SKILL.md` — issue → worktree → PR → merge loop and the

--- a/tui/internal/tui/skill_files_test.go
+++ b/tui/internal/tui/skill_files_test.go
@@ -394,6 +394,7 @@ func TestBuildSkillFolderEntries_DevGuideNestedReferences(t *testing.T) {
 		"reference/runtime-self-check/SKILL.md",
 		"reference/pr-review-deliverables/SKILL.md",
 		"reference/skill-stewardship/SKILL.md",
+		"Skill-size/progressive-disclosure rule",
 	} {
 		if !strings.Contains(rootBody, want) {
 			t.Errorf("lingtai-dev-guide root missing %q", want)
@@ -502,6 +503,9 @@ func TestBuildSkillFolderEntries_DevGuideNestedReferences(t *testing.T) {
 		"router",
 		"nested-reference",
 		"skills-manual",
+		"Read/context limits",
+		"progressive-disclosure link",
+		"related/reference file",
 		"de-priv",
 	} {
 		if !strings.Contains(stewardshipBody, want) {


### PR DESCRIPTION
## Summary
- add a dev-guide non-negotiable rule for limit-aware skill authoring: keep router `SKILL.md` lean and link onward instead of encoding stale hard caps
- update the skill-stewardship nested reference to make read/context limits a progressive-disclosure design signal and point to `skills-manual` for current mechanics
- update `tui/internal/preset/ANATOMY.md` plus focused dev-guide skill tests so the bundled guidance remains covered

## Validation
- `git diff --check`
- `(cd tui && go test ./internal/tui -run TestBuildSkillFolderEntries_DevGuideNestedReferences -count=1)`
- `(cd tui && go test ./internal/preset -run 'TestBundledSkillsHaveLastChangedAt|TestPopulateBundledLibrary_DevGuideNestedReferences' -count=1)`
- `(cd tui && go test ./internal/preset ./internal/tui)`

## Context
- Follow-up to closing Lingtai-AI/lingtai-kernel#358 in its old hard-cap form: the current direction is progressive disclosure and related/reference files, not a blanket 9.5k character cap.