### PR TITLE
Fix portal startup timeout cleanup

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -851,11 +852,15 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 	case "viz":
-		url := a.portalURL()
-		if url != "" {
+		url, err := a.portalURL()
+		switch {
+		case err == nil:
 			openBrowser(url)
-		} else {
+		case errors.Is(err, errPortalNotFound):
 			addMsg("lingtai-portal not found on PATH. Run: brew link --overwrite lingtai-tui")
+		default:
+			// Start failure or readiness timeout: the error carries the log path.
+			addMsg(err.Error())
 		}
 		return a, nil
 	case "mcp":
@@ -1574,10 +1579,43 @@ func (a App) View() tea.View {
 	return v
 }
 
-// portalURL kills any existing portal and spawns a fresh one.
-// Returns the URL or empty string if lingtai-portal is not on PATH.
-func (a *App) portalURL() string {
-	portFile := filepath.Join(a.projectDir, ".portal", "port")
+// Portal startup tuning. Overridable in tests to keep the readiness poll fast.
+var (
+	portalReadyTimeout = 3 * time.Second
+	portalReadyPoll    = 200 * time.Millisecond
+)
+
+// errPortalNotFound signals lingtai-portal is not on PATH; portalStartError
+// wraps an exec.Start failure; portalTimeoutError signals the portal started
+// but never became ready. The caller distinguishes these to show an accurate
+// message.
+var errPortalNotFound = errors.New("lingtai-portal not found on PATH")
+
+type portalStartError struct {
+	err     error
+	logPath string
+}
+
+func (e *portalStartError) Error() string {
+	return "failed to start lingtai-portal: " + e.err.Error() + "; see " + e.logPath
+}
+func (e *portalStartError) Unwrap() error { return e.err }
+
+type portalTimeoutError struct{ logPath string }
+
+func (e *portalTimeoutError) Error() string {
+	return "lingtai-portal did not become ready in time; see " + e.logPath
+}
+
+// portalURL kills any existing portal and spawns a fresh one, returning its URL
+// once the portal writes .portal/port. Ownership of the child is retained until
+// readiness succeeds: on timeout or failure the child is killed and reaped so a
+// slow portal is never left detached (issue #489). Only after a URL is ready is
+// the process released, so a healthy portal survives TUI exit.
+func (a *App) portalURL() (string, error) {
+	portalRoot := filepath.Join(a.projectDir, ".portal")
+	portFile := filepath.Join(portalRoot, "port")
+	logPath := filepath.Join(portalRoot, "portal.log")
 
 	// Kill existing portal so we always get a fresh instance with the latest binary
 	exec.Command("pkill", "-f", "lingtai-portal.*--dir.*"+filepath.Dir(a.projectDir)).Run()
@@ -1587,26 +1625,45 @@ func (a *App) portalURL() string {
 	// Spawn fresh portal
 	portalCmd, _ := exec.LookPath("lingtai-portal")
 	if portalCmd == "" {
-		return ""
+		return "", errPortalNotFound
 	}
-	cmd := exec.Command(portalCmd, "--dir", filepath.Dir(a.projectDir))
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	if err := cmd.Start(); err != nil {
-		return ""
-	}
-	// Release the process so it survives TUI exit
-	cmd.Process.Release()
 
-	// Wait for port file to appear (up to 3 seconds)
-	deadline := time.Now().Add(3 * time.Second)
+	// Route portal output to a local log so startup failures are inspectable.
+	os.MkdirAll(portalRoot, 0o755)
+	logFile, logErr := os.Create(logPath)
+
+	cmd := exec.Command(portalCmd, "--dir", filepath.Dir(a.projectDir))
+	if logErr == nil {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
+	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			logFile.Close()
+		}
+		return "", &portalStartError{err: err, logPath: logPath}
+	}
+	// Our copy of the log fd is no longer needed; the child holds its own.
+	if logFile != nil {
+		logFile.Close()
+	}
+
+	// Wait for the port file to appear, holding the process handle so we can
+	// reap it on failure instead of leaking a detached portal.
+	deadline := time.Now().Add(portalReadyTimeout)
 	for time.Now().Before(deadline) {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(portalReadyPoll)
 		if data, err := os.ReadFile(portFile); err == nil {
-			return "http://localhost:" + strings.TrimSpace(string(data))
+			// Ready: release so the portal survives TUI exit.
+			cmd.Process.Release()
+			return "http://localhost:" + strings.TrimSpace(string(data)), nil
 		}
 	}
-	return ""
+
+	// Timed out: kill and reap the child we started.
+	cmd.Process.Kill()
+	cmd.Wait()
+	return "", &portalTimeoutError{logPath: logPath}
 }
 
 func isWSL() bool {

--- a/tui/internal/tui/portal_url_test.go
+++ b/tui/internal/tui/portal_url_test.go
@@ -1,0 +1,153 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestHelperFakePortal is not a real test — it is the body of the fake
+// lingtai-portal executable. When invoked with GO_WANT_FAKE_PORTAL=1 it writes
+// its own pid to GO_FAKE_PORTAL_PID_FILE (so the test can reap-check it), never
+// writes .portal/port, and blocks — simulating a portal that hangs during
+// startup so portalURL()'s readiness poll times out.
+func TestHelperFakePortal(t *testing.T) {
+	if os.Getenv("GO_WANT_FAKE_PORTAL") != "1" {
+		return
+	}
+	if pidFile := os.Getenv("GO_FAKE_PORTAL_PID_FILE"); pidFile != "" {
+		os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o644)
+	}
+	// Block "forever" — the parent must kill us. Cap the sleep so a leaked
+	// process still exits on its own and never wedges CI.
+	time.Sleep(60 * time.Second)
+	os.Exit(0)
+}
+
+// writeFakePortal drops a lingtai-portal wrapper into dir that re-executes the
+// current test binary in TestHelperFakePortal mode. The wrapper exec's the test
+// binary, so the running process keeps the wrapper's pid — the same pid
+// portalURL() sees via cmd.Process.Pid and the helper records to pidFile.
+func writeFakePortal(t *testing.T, dir, pidFile string) {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	name := "lingtai-portal"
+	var script string
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		script = "@echo off\r\n" +
+			"set GO_WANT_FAKE_PORTAL=1\r\n" +
+			"set GO_FAKE_PORTAL_PID_FILE=" + pidFile + "\r\n" +
+			`"` + self + `" -test.run=TestHelperFakePortal` + "\r\n"
+	} else {
+		script = "#!/bin/sh\n" +
+			"exec env GO_WANT_FAKE_PORTAL=1 " +
+			"GO_FAKE_PORTAL_PID_FILE=" + shellQuote(pidFile) + " " +
+			shellQuote(self) + " -test.run=TestHelperFakePortal\n"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake portal: %v", err)
+	}
+}
+
+func shellQuote(s string) string {
+	return "'" + s + "'"
+}
+
+// processAlive reports whether pid names a live process. On Unix, signal 0
+// probes without delivering a signal.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, Signal(0) returns nil for a live process and an error once
+	// reaped. On Windows FindProcess already fails for dead pids.
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+// TestPortalURLTimeoutKillsChild proves the #489 regression fix: when the
+// portal never writes .portal/port, portalURL() must return an error AND must
+// not leave the just-started portal process alive.
+func TestPortalURLTimeoutKillsChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-alive probe via signal 0 is Unix-only")
+	}
+
+	// Fake portal on PATH; it records its pid to pidFile before blocking.
+	binDir := t.TempDir()
+	pidFile := filepath.Join(t.TempDir(), "portal.pid")
+	writeFakePortal(t, binDir, pidFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Shrink the timeout so the test is fast.
+	oldTimeout, oldPoll := portalReadyTimeout, portalReadyPoll
+	portalReadyTimeout = 400 * time.Millisecond
+	portalReadyPoll = 50 * time.Millisecond
+	t.Cleanup(func() {
+		portalReadyTimeout, portalReadyPoll = oldTimeout, oldPoll
+	})
+
+	projectDir := filepath.Join(t.TempDir(), "proj", ".lingtai")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	a := &App{projectDir: projectDir}
+
+	url, err := a.portalURL()
+	if err == nil {
+		t.Fatalf("expected timeout error, got url=%q", url)
+	}
+	if url != "" {
+		t.Fatalf("expected empty url on timeout, got %q", url)
+	}
+
+	// Read the pid the fake portal recorded for itself.
+	pid := readPidFile(t, pidFile)
+	if pid <= 0 {
+		t.Fatal("fake portal never wrote its pid; cannot verify it was reaped")
+	}
+
+	// It must have been killed/reaped by portalURL's timeout path. Give the
+	// kill+wait a brief moment to complete reaping.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && processAlive(pid) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if processAlive(pid) {
+		t.Fatalf("portal pid %d still alive after timeout; it should have been killed", pid)
+	}
+}
+
+// readPidFile reads the pid the fake portal wrote. The child writes the file
+// asynchronously after exec, so poll briefly for it to appear.
+func readPidFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if data, err := os.ReadFile(path); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			return 0
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
- keep ownership of the `lingtai-portal` child process until `/viz` readiness succeeds
- kill and wait/reap the just-started portal on readiness timeout so failed startups do not leave a detached process behind
- route portal stdout/stderr to `.portal/portal.log` and distinguish missing binary vs startup/timeout errors in the `/viz` status message
- add a regression test with a fake `lingtai-portal` that never writes `.portal/port` and verifies the child process is gone after timeout

Fixes #489.

## Validation
- `gofmt -l internal/tui/app.go internal/tui/portal_url_test.go`
- `go test ./internal/tui -run 'TestPortal|Test.*Viz|TestHelpView|TestSetupCommand'`
- `go test ./internal/tui`
- `go test ./...`
- `go vet ./internal/tui`
- `git diff --check -- tui/internal/tui/app.go tui/internal/tui/portal_url_test.go`

## Local explainer
- `reports/pr489-portal-timeout/pr489-portal-timeout-explainer.html` (local-only, not committed)
