### PR TITLE
docs: route issue reporting consent through issue-report skill

### DIFF
--- a/tui/internal/preset/procedures/procedures.md
+++ b/tui/internal/preset/procedures/procedures.md
@@ -80,5 +80,5 @@ summary.
 ### Reporting Issues
 
 If you notice a LingTai bug, stale doc, broken URL, silent failure, or missing
-capability, load `lingtai-issue-report`, assemble evidence, and ask the human
-before filing unless already authorized.
+capability, load `lingtai-issue-report`, assemble evidence, and follow that
+skill's filing/consent flow.


### PR DESCRIPTION
## Summary
- make the resident `procedures.md` issue-reporting hook route agents to `lingtai-issue-report` for filing/consent details
- remove the `unless already authorized` wording from the resident prompt layer so it no longer conflicts with the issue-report skill's consent flow

## Validation
- `git diff --check`
- `go test ./internal/preset/`

## Notes
- Follow-up to the #472 discussion; scoped standing authorization is not implemented here.
- The YAML frontmatter prompt-section work is intentionally left for a follow-up PR.
