### PR TITLE
Make home telemetry asynchronous

### DIFF
--- a/tui/internal/sqlitelog/molt.go
+++ b/tui/internal/sqlitelog/molt.go
@@ -1,59 +1,234 @@
 package sqlitelog
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
+
+// moltSessionWindowQueryTimeout is a WORKER-LOCAL BACKSTOP that bounds how long
+// the molt-session-window sqlite3 subprocess may run before it is killed. It is
+// NOT the mechanism that protects the UI thread: home telemetry is gathered on a
+// background tea.Cmd (tui: fetchHomeTelemetry), never on the render (View) or
+// keypress (syncViewportHeight) path, so the UI never waits on this query. This
+// deadline exists only so a pathological sidecar — e.g. the kernel wedged holding
+// the write lock indefinitely — cannot pin a background worker forever; on expiry
+// the query degrades to the last cached window (see moltWindowCache). It is
+// deliberately CONSERVATIVE (1s, far above a normal write's brief lock) precisely
+// because it no longer sits on a latency-sensitive path: a tight deadline here
+// would only cause spurious stale reads with no UI-responsiveness benefit.
+const moltSessionWindowQueryTimeout = 1 * time.Second
+
+// moltSessionWindowBusyTimeoutMS is the sqlite busy_timeout (milliseconds) applied
+// to the molt-session-window read. A concurrent kernel writer briefly holds the
+// database lock; without busy_timeout the read fails instantly with SQLITE_BUSY,
+// which the caller (fs.SumMoltSessionTokenLedger) treats as "no sqlite result"
+// and falls back to an expensive full events.jsonl parse. A short busy_timeout
+// lets the read wait out a normal write and still return promptly, well within
+// moltSessionWindowQueryTimeout. This too runs on the background worker, not the
+// UI thread.
+const moltSessionWindowBusyTimeoutMS = 150
+
+// moltSessionWindowCacheTTL is the minimum interval between two live sqlite
+// subprocess launches for the same agent's molt-session windows. It is a
+// secondary optimization: the TUI already debounces telemetry fetches at the
+// model level (tui: homeTelemetryTTL), so in practice this rarely fires, but it
+// keeps any other caller (and back-to-back background fetches) from relaunching
+// the subprocess needlessly. The molt window itself only moves when the kernel
+// writes a new psyche_molt row (minutes apart at most), so a sub-second staleness
+// on the boundary is invisible to the token totals, which are separately re-summed
+// from the ledger by the caller.
+const moltSessionWindowCacheTTL = 750 * time.Millisecond
+
+// moltWindow is a resolved molt-session-window result plus enough freshness
+// metadata to decide when a cached copy may be reused without re-querying.
+type moltWindow struct {
+	currentSince time.Time
+	lastSince    time.Time
+	lastBefore   time.Time
+	ok           bool
+
+	dbSize    int64     // sidecar size at query time — a cheap change detector
+	dbModTime time.Time // sidecar mtime at query time
+	queriedAt time.Time // wall clock of the successful query, for the TTL floor
+}
+
+// moltWindowCache holds the last successful molt-window query per agent. It is a
+// process-global cache shared across background telemetry fetches — the caller
+// (fs.SumMoltSessionTokenLedger, reached from the fetchHomeTelemetry tea.Cmd)
+// copies the model by value and so cannot hold the cache itself, exactly like
+// fs.moltSessionTokenLedgerCache. Its two jobs: (1) skip the subprocess entirely
+// within moltSessionWindowCacheTTL when the sidecar is unchanged, and (2) serve a
+// STALE window if a live query times out or errors, so a locked/slow database
+// degrades to stale-but-cheap telemetry instead of the expensive events.jsonl
+// fallback path.
+var moltWindowCache = struct {
+	sync.Mutex
+	byDir map[string]moltWindow
+
+	// now is overridable in tests so TTL behavior is deterministic without
+	// sleeping. Production always uses time.Now.
+	now func() time.Time
+}{byDir: map[string]moltWindow{}, now: time.Now}
+
+func moltWindowNow() time.Time {
+	moltWindowCache.Lock()
+	fn := moltWindowCache.now
+	moltWindowCache.Unlock()
+	if fn == nil {
+		return time.Now()
+	}
+	return fn()
+}
 
 // QueryMoltSessionWindows fetches the latest two psyche_molt timestamps from
 // the sqlite sidecar. It returns the current session lower bound, the previous
 // session lower bound, and the previous session upper bound.
+//
+// It is called from the background telemetry fetch (tui: fetchHomeTelemetry),
+// NOT from the render/keypress path, so it does not need to protect the UI
+// thread. It is nonetheless guarded so a single stuck sidecar cannot pin a
+// background worker: the sqlite3 subprocess runs under a conservative worker-local
+// deadline (moltSessionWindowQueryTimeout) with a sqlite busy timeout, and a
+// process-global cache (moltWindowCache) both skips the subprocess for unchanged
+// sidecars within moltSessionWindowCacheTTL and serves the last good result when
+// a live query times out or errors. On such a degradation it returns ok=true,
+// err=nil so the caller uses the (stale) cached window rather than falling back
+// to an expensive full events.jsonl parse.
 func QueryMoltSessionWindows(agentDir string) (currentSince, lastSince, lastBefore time.Time, ok bool, err error) {
 	db := DBPath(agentDir)
-	if _, err := os.Stat(db); err != nil {
+	info, statErr := os.Stat(db)
+	if statErr != nil {
 		return time.Time{}, time.Time{}, time.Time{}, false, fmt.Errorf("sqlite sidecar not found: %s", db)
 	}
+
+	// Fast path: a recent cached window for an unchanged sidecar. Skips the
+	// subprocess entirely for back-to-back background fetches.
+	if w, hit := cachedMoltWindow(agentDir, info); hit {
+		return w.currentSince, w.lastSince, w.lastBefore, w.ok, nil
+	}
+
 	bin, err := findSQLite3()
 	if err != nil {
 		return time.Time{}, time.Time{}, time.Time{}, false, err
 	}
 
+	w, qErr := queryMoltWindowLive(bin, db)
+	if qErr != nil {
+		// Degrade to the last good window (however stale) rather than surfacing
+		// an error, which would send the caller into the expensive events.jsonl
+		// fallback. Only when we have never had a good result do
+		// we propagate the error so the caller can do a correct first-time parse.
+		if stale, has := lastMoltWindow(agentDir); has {
+			return stale.currentSince, stale.lastSince, stale.lastBefore, stale.ok, nil
+		}
+		return time.Time{}, time.Time{}, time.Time{}, false, qErr
+	}
+
+	w.dbSize = info.Size()
+	w.dbModTime = info.ModTime()
+	w.queriedAt = moltWindowNow()
+	storeMoltWindow(agentDir, w)
+	return w.currentSince, w.lastSince, w.lastBefore, w.ok, nil
+}
+
+// queryMoltWindowLive runs the actual sqlite3 subprocess under a deadline and a
+// busy_timeout. Errors (including a killed-on-deadline subprocess) are returned
+// for the caller to degrade to cache.
+func queryMoltWindowLive(bin, db string) (moltWindow, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), moltSessionWindowQueryTimeout)
+	defer cancel()
+
+	// The `.timeout` dot-command sets sqlite's busy_timeout for the session so the
+	// read waits out a concurrent kernel writer instead of failing instantly with
+	// SQLITE_BUSY. It runs via -cmd (before the SELECT) rather than as an inline
+	// `PRAGMA busy_timeout=N;` statement because setting that pragma emits its new
+	// value as a result row, which would corrupt the ts parsing below. Both the
+	// timeout and the SELECT are fixed constants — never user input.
 	const sql = `SELECT ts FROM events WHERE type='psyche_molt' ORDER BY ts DESC LIMIT 2`
-	out, err := exec.Command(bin, "-separator", "\x1f", db, sql).Output()
+	out, err := exec.CommandContext(ctx, bin,
+		"-separator", "\x1f",
+		"-cmd", fmt.Sprintf(".timeout %d", moltSessionWindowBusyTimeoutMS),
+		db, sql,
+	).Output()
 	if err != nil {
-		msg := ""
+		if ctx.Err() == context.DeadlineExceeded {
+			return moltWindow{}, fmt.Errorf("sqlite3 molt-window query timed out after %s", moltSessionWindowQueryTimeout)
+		}
 		if ee, ok := err.(*exec.ExitError); ok {
-			msg = strings.TrimSpace(string(ee.Stderr))
+			if msg := strings.TrimSpace(string(ee.Stderr)); msg != "" {
+				return moltWindow{}, fmt.Errorf("sqlite3: %s", msg)
+			}
 		}
-		if msg != "" {
-			return time.Time{}, time.Time{}, time.Time{}, false, fmt.Errorf("sqlite3: %s", msg)
-		}
-		return time.Time{}, time.Time{}, time.Time{}, false, fmt.Errorf("sqlite3 query failed: %w", err)
+		return moltWindow{}, fmt.Errorf("sqlite3 query failed: %w", err)
 	}
 
 	raw := strings.TrimSpace(string(out))
 	if raw == "" {
-		return time.Time{}, time.Time{}, time.Time{}, true, nil
+		return moltWindow{ok: true}, nil
 	}
 	lines := strings.Split(raw, "\n")
 	latest, err := strconv.ParseFloat(strings.TrimSpace(lines[0]), 64)
 	if err != nil || latest <= 0 {
-		return time.Time{}, time.Time{}, time.Time{}, false, fmt.Errorf("invalid psyche_molt ts %q", strings.TrimSpace(lines[0]))
+		return moltWindow{}, fmt.Errorf("invalid psyche_molt ts %q", strings.TrimSpace(lines[0]))
 	}
-	currentSince = unixFloatTimeUTC(latest)
+	w := moltWindow{ok: true, currentSince: unixFloatTimeUTC(latest)}
 	if len(lines) > 1 {
 		previous, err := strconv.ParseFloat(strings.TrimSpace(lines[1]), 64)
 		if err != nil || previous <= 0 {
-			return time.Time{}, time.Time{}, time.Time{}, false, fmt.Errorf("invalid previous psyche_molt ts %q", strings.TrimSpace(lines[1]))
+			return moltWindow{}, fmt.Errorf("invalid previous psyche_molt ts %q", strings.TrimSpace(lines[1]))
 		}
-		lastSince = unixFloatTimeUTC(previous)
-		lastBefore = currentSince
+		w.lastSince = unixFloatTimeUTC(previous)
+		w.lastBefore = w.currentSince
 	}
-	return currentSince, lastSince, lastBefore, true, nil
+	return w, nil
+}
+
+// cachedMoltWindow returns a cached window that is safe to reuse without a live
+// query: the sidecar is byte-identical (size+mtime) to when it was cached AND
+// the cache entry is younger than moltSessionWindowCacheTTL. The size+mtime gate
+// means a kernel write (new psyche_molt) invalidates the cache immediately; the
+// TTL floor keeps back-to-back background fetches from re-launching the subprocess
+// even while a write is streaming in.
+func cachedMoltWindow(agentDir string, info os.FileInfo) (moltWindow, bool) {
+	moltWindowCache.Lock()
+	defer moltWindowCache.Unlock()
+	w, ok := moltWindowCache.byDir[agentDir]
+	if !ok {
+		return moltWindow{}, false
+	}
+	if w.dbSize != info.Size() || !w.dbModTime.Equal(info.ModTime()) {
+		return moltWindow{}, false
+	}
+	nowFn := moltWindowCache.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if nowFn().Sub(w.queriedAt) >= moltSessionWindowCacheTTL {
+		return moltWindow{}, false
+	}
+	return w, true
+}
+
+// lastMoltWindow returns the last stored window for agentDir regardless of age
+// or sidecar changes — the stale-degradation source used when a live query
+// times out or errors.
+func lastMoltWindow(agentDir string) (moltWindow, bool) {
+	moltWindowCache.Lock()
+	defer moltWindowCache.Unlock()
+	w, ok := moltWindowCache.byDir[agentDir]
+	return w, ok
+}
+
+func storeMoltWindow(agentDir string, w moltWindow) {
+	moltWindowCache.Lock()
+	defer moltWindowCache.Unlock()
+	moltWindowCache.byDir[agentDir] = w
 }
 
 // QueryRecentMoltTimes fetches the most recent psyche_molt (context rebuild)

--- a/tui/internal/sqlitelog/molt_cache_test.go
+++ b/tui/internal/sqlitelog/molt_cache_test.go
@@ -1,0 +1,226 @@
+package sqlitelog
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// resetMoltWindowCache clears the process-global molt-window cache and installs a
+// controllable clock so TTL behavior is deterministic. It restores the real
+// time.Now clock on test cleanup so it cannot leak into other tests.
+func resetMoltWindowCache(t *testing.T, clock func() time.Time) {
+	t.Helper()
+	moltWindowCache.Lock()
+	moltWindowCache.byDir = map[string]moltWindow{}
+	prev := moltWindowCache.now
+	moltWindowCache.now = clock
+	moltWindowCache.Unlock()
+	t.Cleanup(func() {
+		moltWindowCache.Lock()
+		moltWindowCache.byDir = map[string]moltWindow{}
+		moltWindowCache.now = prev
+		moltWindowCache.Unlock()
+	})
+}
+
+// Instead of intercepting exec, the cache tests assert query behavior via the
+// returned windows and the stored cache entry's queriedAt stamp.
+
+// TestQueryMoltSessionWindowsCachesWithinTTL asserts that a second call within
+// the TTL for an unchanged sidecar reuses the cached window: the stored
+// queriedAt stamp does not advance, proving no second subprocess ran.
+func TestQueryMoltSessionWindowsCachesWithinTTL(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1000.0,'psyche_molt','{}');`,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1002.5,'psyche_molt','{}');`,
+	)
+
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	resetMoltWindowCache(t, func() time.Time { return clock })
+
+	// First call: cold cache, runs the real query and stamps queriedAt=base.
+	cur1, _, _, ok1, err1 := QueryMoltSessionWindows(agentDir)
+	if err1 != nil || !ok1 {
+		t.Fatalf("first query: ok=%v err=%v", ok1, err1)
+	}
+	firstStamp := storedQueriedAt(t, agentDir)
+	if !firstStamp.Equal(base) {
+		t.Fatalf("first queriedAt = %v, want %v", firstStamp, base)
+	}
+
+	// Advance the clock but stay within the TTL. The sidecar is unchanged, so the
+	// second call must be a cache hit: same window, and queriedAt unchanged
+	// (no fresh subprocess launched).
+	clock = base.Add(moltSessionWindowCacheTTL - time.Millisecond)
+	cur2, _, _, ok2, err2 := QueryMoltSessionWindows(agentDir)
+	if err2 != nil || !ok2 {
+		t.Fatalf("second query: ok=%v err=%v", ok2, err2)
+	}
+	if !cur2.Equal(cur1) {
+		t.Fatalf("cached window changed: %v != %v", cur2, cur1)
+	}
+	if got := storedQueriedAt(t, agentDir); !got.Equal(firstStamp) {
+		t.Fatalf("cache miss within TTL: queriedAt advanced to %v (want %v)", got, firstStamp)
+	}
+}
+
+// TestQueryMoltSessionWindowsRequeriesAfterTTL asserts that once the TTL has
+// elapsed, an unchanged sidecar is re-queried (queriedAt advances).
+func TestQueryMoltSessionWindowsRequeriesAfterTTL(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1002.5,'psyche_molt','{}');`,
+	)
+
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	resetMoltWindowCache(t, func() time.Time { return clock })
+
+	if _, _, _, ok, err := QueryMoltSessionWindows(agentDir); err != nil || !ok {
+		t.Fatalf("first query: ok=%v err=%v", ok, err)
+	}
+	firstStamp := storedQueriedAt(t, agentDir)
+
+	clock = base.Add(moltSessionWindowCacheTTL)
+	if _, _, _, ok, err := QueryMoltSessionWindows(agentDir); err != nil || !ok {
+		t.Fatalf("second query: ok=%v err=%v", ok, err)
+	}
+	if got := storedQueriedAt(t, agentDir); !got.After(firstStamp) {
+		t.Fatalf("expected re-query after TTL: queriedAt=%v did not advance past %v", got, firstStamp)
+	}
+}
+
+// TestQueryMoltSessionWindowsInvalidatesOnSidecarChange asserts that a changed
+// sidecar (new mtime/size) forces a re-query even within the TTL, so a fresh
+// psyche_molt is picked up promptly.
+func TestQueryMoltSessionWindowsInvalidatesOnSidecarChange(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1000.0,'psyche_molt','{}');`,
+	)
+
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	resetMoltWindowCache(t, func() time.Time { return clock })
+
+	cur1, _, _, ok, err := QueryMoltSessionWindows(agentDir)
+	if err != nil || !ok {
+		t.Fatalf("first query: ok=%v err=%v", ok, err)
+	}
+	if got := cur1.Unix(); got != 1000 {
+		t.Fatalf("first current = %d, want 1000", got)
+	}
+
+	// Append a newer molt and bump mtime forward so the size/mtime gate trips
+	// even though we are still within the TTL window.
+	appendMolt(t, agentDir, 2000.0)
+	bumpModTime(t, DBPath(agentDir), base.Add(time.Second))
+	clock = base.Add(moltSessionWindowCacheTTL / 4) // still within TTL
+
+	cur2, _, _, ok, err := QueryMoltSessionWindows(agentDir)
+	if err != nil || !ok {
+		t.Fatalf("second query: ok=%v err=%v", ok, err)
+	}
+	if got := cur2.Unix(); got != 2000 {
+		t.Fatalf("sidecar change not picked up: current = %d, want 2000", got)
+	}
+}
+
+// TestQueryMoltSessionWindowsDegradesToStaleOnError is the core regression guard:
+// when a live query cannot succeed, QueryMoltSessionWindows must return the last
+// good (stale) window with ok=true and err=nil, so the caller does NOT fall back
+// to the expensive events.jsonl parse on the UI path.
+func TestQueryMoltSessionWindowsDegradesToStaleOnError(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1500.0,'psyche_molt','{}');`,
+	)
+
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	resetMoltWindowCache(t, func() time.Time { return clock })
+
+	cur1, _, _, ok, err := QueryMoltSessionWindows(agentDir)
+	if err != nil || !ok {
+		t.Fatalf("first query: ok=%v err=%v", ok, err)
+	}
+	if got := cur1.Unix(); got != 1500 {
+		t.Fatalf("first current = %d, want 1500", got)
+	}
+
+	// Corrupt the sidecar so any live query fails, and change its mtime/size so the
+	// cache's freshness gate forces a live attempt (which will error).
+	db := DBPath(agentDir)
+	if err := os.WriteFile(db, []byte("not a sqlite database at all"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bumpModTime(t, db, base.Add(time.Second))
+	clock = base.Add(2 * moltSessionWindowCacheTTL) // past TTL: must attempt live
+
+	cur2, _, _, ok, err := QueryMoltSessionWindows(agentDir)
+	if err != nil {
+		t.Fatalf("degradation should not surface an error, got %v", err)
+	}
+	if !ok {
+		t.Fatal("degradation should report ok=true so the caller trusts the stale window")
+	}
+	if got := cur2.Unix(); got != 1500 {
+		t.Fatalf("expected stale window 1500, got %d", got)
+	}
+}
+
+// TestQueryMoltSessionWindowsErrorsWithoutPriorCache asserts that when there is
+// no prior good window to fall back to, a failing live query still propagates an
+// error/ok=false — the first-ever query must be honest so the caller can do a
+// correct (one-time, off-hot-path) parse.
+func TestQueryMoltSessionWindowsErrorsWithoutPriorCache(t *testing.T) {
+	agentDir := makeTestDB(t)
+	base := time.Unix(1_700_000_000, 0)
+	resetMoltWindowCache(t, func() time.Time { return base })
+
+	// Corrupt before the first-ever query so there is nothing cached.
+	db := DBPath(agentDir)
+	if err := os.WriteFile(db, []byte("corrupt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, ok, err := QueryMoltSessionWindows(agentDir)
+	if err == nil || ok {
+		t.Fatalf("expected error/ok=false with no prior cache, got ok=%v err=%v", ok, err)
+	}
+}
+
+// --- test helpers ---
+
+func storedQueriedAt(t *testing.T, agentDir string) time.Time {
+	t.Helper()
+	moltWindowCache.Lock()
+	defer moltWindowCache.Unlock()
+	w, ok := moltWindowCache.byDir[agentDir]
+	if !ok {
+		t.Fatalf("no cache entry for %s", agentDir)
+	}
+	return w.queriedAt
+}
+
+func appendMolt(t *testing.T, agentDir string, ts float64) {
+	t.Helper()
+	bin, err := findSQLite3()
+	if err != nil {
+		t.Skip("sqlite3 not available:", err)
+	}
+	db := DBPath(agentDir)
+	sql := "INSERT INTO events(ts,type,fields_json) VALUES(" +
+		strconv.FormatFloat(ts, 'f', 1, 64) + ",'psyche_molt','{}');"
+	if out, err := exec.Command(bin, db, sql).CombinedOutput(); err != nil {
+		t.Fatalf("appendMolt: %v\n%s", err, out)
+	}
+}
+
+func bumpModTime(t *testing.T, path string, mod time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tui/internal/tui/home_telemetry.go
+++ b/tui/internal/tui/home_telemetry.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"image/color"
 	"strings"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/anthropics/lingtai-tui/i18n"
@@ -53,6 +55,89 @@ type homeTelemetry struct {
 	contextLimit  int64   // model context window; 0 = unknown
 	contextUsed   int64   // context tokens in use (.status.json TotalTokens); 0 = unknown
 	contextUsage  float64 // latest context-usage fraction 0..1; <0 = unknown
+}
+
+// --- Async scheduling ------------------------------------------------------
+//
+// gatherHomeTelemetry does real I/O: it reaches fs.SumMoltSessionTokenLedger
+// (sqlite sidecar via /usr/bin/sqlite3, plus a possible events.jsonl parse) and
+// fs.ReadStatus/ReadInitManifest. On a locked or slow-volume sidecar that work
+// can stall for seconds. It therefore MUST NOT run on the Bubble Tea render
+// (View) or input (Update/syncViewportHeight) paths — a stall there freezes the
+// whole TUI.
+//
+// Instead the UI paths read a last-known snapshot cached on the model
+// (m.homeTelemetry), and the I/O runs in the background as a tea.Cmd
+// (fetchHomeTelemetry) that returns a homeTelemetryMsg to refresh the snapshot.
+// The snapshot only moves when the kernel writes new ledger/status data (seconds
+// to minutes apart), so a sub-second staleness on the boundary is invisible.
+//
+// Fetches are debounced by two model flags checked in maybeScheduleHomeTelemetry:
+//   - homeTelemetryInFlight: at most one background fetch runs at a time, so a
+//     burst of keypresses/renders cannot spawn a pile of sqlite subprocesses.
+//   - homeTelemetryLastFetch + homeTelemetryTTL: after a completed fetch we skip
+//     re-fetching until the TTL elapses, so the steady-state 1s poll doesn't
+//     hammer the sidecar and rapid typing costs nothing.
+
+// homeTelemetryTTL is the minimum wall-clock interval between two completed
+// background telemetry fetches. It is deliberately close to the mail poll cadence
+// (m.pollRate, ~1s): the underlying data (token ledger, .status.json) is rewritten
+// by the kernel on a similar cadence, so fetching faster only burns I/O without
+// showing newer numbers. Repeated render/keypress within the TTL reuses the cached
+// snapshot with no I/O at all.
+const homeTelemetryTTL = 1 * time.Second
+
+// homeTelemetryMsg carries a freshly-gathered telemetry snapshot from the
+// background fetch back into the model on the Update path.
+type homeTelemetryMsg struct {
+	t homeTelemetry
+}
+
+// fetchHomeTelemetry is the background worker: it performs all telemetry I/O
+// (sqlite/ledger/status/manifest) off the UI thread and returns a homeTelemetryMsg.
+// It is a value-receiver tea.Cmd, so it captures a snapshot of the model (orchestrator
+// path + session cache) exactly like refreshMail/initialRebuild — the running
+// command never touches live model state.
+func (m MailModel) fetchHomeTelemetry() tea.Msg {
+	return homeTelemetryMsg{t: m.gatherHomeTelemetry()}
+}
+
+// maybeScheduleHomeTelemetry returns a fetchHomeTelemetry command when a new
+// background fetch is warranted, or nil to reuse the cached snapshot. It is the
+// single debounce/TTL/in-flight gate: callers (the poll tick and post-refresh)
+// funnel through it so no other path spawns telemetry I/O. It mutates only the
+// in-flight/last-fetch bookkeeping, never the snapshot itself (that lands via
+// homeTelemetryMsg), so it is safe to call from the Update path.
+func (m *MailModel) maybeScheduleHomeTelemetry(now time.Time) tea.Cmd {
+	if m.homeTelemetryInFlight {
+		return nil
+	}
+	// Honor the TTL only once we have a snapshot to fall back on; the very first
+	// fetch (nothing cached yet) is always allowed so the row can appear promptly.
+	if m.homeTelemetryLoaded && now.Sub(m.homeTelemetryLastFetch) < homeTelemetryTTL {
+		return nil
+	}
+	m.homeTelemetryInFlight = true
+	return m.fetchHomeTelemetry
+}
+
+// applyHomeTelemetry lands a background fetch result: it stores the snapshot,
+// clears the in-flight flag, and stamps the completion time for the TTL. It
+// returns true when the telemetry row's VISIBILITY flipped (row ⇄ no-row), which
+// is the only telemetry change that affects layout height — the caller re-syncs
+// the viewport only then, avoiding layout thrash on every numeric tick.
+//
+// "was visible" uses hasHomeTelemetry() (the loaded-aware predicate), NOT a bare
+// hasData() on the old snapshot: before the first fetch the row is not visible
+// even though the zero snapshot's hasData() reports true (the contextUsage==0
+// sentinel trap). So the first real landing correctly reports false→true.
+func (m *MailModel) applyHomeTelemetry(t homeTelemetry, now time.Time) (visibilityChanged bool) {
+	was := m.hasHomeTelemetry()
+	m.homeTelemetry = t
+	m.homeTelemetryLoaded = true
+	m.homeTelemetryInFlight = false
+	m.homeTelemetryLastFetch = now
+	return m.hasHomeTelemetry() != was
 }
 
 // gatherHomeTelemetry resolves the telemetry scalars for the orchestrator agent
@@ -172,8 +257,20 @@ func (t homeTelemetry) hasData() bool {
 // It is the single predicate shared by the height budget (syncViewportHeight)
 // and the renderer (View) so they can never disagree about whether the row
 // occupies a line — a disagreement is exactly what clipped the status bar.
+//
+// It reads the last-known cached snapshot (m.homeTelemetry) ONLY — never
+// gatherHomeTelemetry — so it stays on the UI hot path without touching
+// sqlite/filesystem/JSONL. The snapshot is refreshed asynchronously by the
+// fetchHomeTelemetry background command (see the Async scheduling note above).
+//
+// The homeTelemetryLoaded gate matters: a zero-value homeTelemetry has
+// contextUsage == 0, and hasData() treats contextUsage >= 0 as "present" (the
+// unknown sentinel is -1, set only inside gatherHomeTelemetry). So before the
+// first fetch lands we must NOT trust the zero snapshot — we render without the
+// row rather than showing a spurious "ctx 0%". Once a fetch has completed, the
+// snapshot carries the real -1/≥0 sentinel and hasData() is authoritative.
 func (m MailModel) hasHomeTelemetry() bool {
-	return m.gatherHomeTelemetry().hasData()
+	return m.homeTelemetryLoaded && m.homeTelemetry.hasData()
 }
 
 // mailFooterHeight returns how many terminal rows the mail-view footer block

--- a/tui/internal/tui/home_telemetry_async_test.go
+++ b/tui/internal/tui/home_telemetry_async_test.go
@@ -1,0 +1,133 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+// The home telemetry row is resolved asynchronously: gathering it does sqlite +
+// token-ledger + .status.json I/O that must never run on the Bubble Tea render
+// (View) or input (syncViewportHeight) path. These tests pin the scheduling and
+// state machine that keeps that I/O off the UI thread — debounce (in-flight),
+// TTL, first-load, and the visibility-change gate that avoids layout thrash.
+
+// A freshly constructed model must render NO telemetry row: no fetch has landed,
+// so hasHomeTelemetry() is false regardless of the zero-value snapshot. This is
+// the guard against the contextUsage==0 sentinel trap: hasData() treats
+// contextUsage>=0 as "present", and the zero value is 0, so without the
+// homeTelemetryLoaded gate a brand-new model would spuriously show "ctx 0%".
+func TestHomeTelemetryHiddenBeforeFirstFetch(t *testing.T) {
+	m := MailModel{}
+	if m.homeTelemetry.hasData() != true {
+		// Document the trap explicitly: the zero snapshot DOES report hasData()
+		// (contextUsage==0 passes the >=0 test), which is exactly why the loaded
+		// gate is required.
+		t.Fatal("precondition changed: zero homeTelemetry no longer reports hasData(); the loaded gate may be unnecessary — re-check hasHomeTelemetry")
+	}
+	if m.hasHomeTelemetry() {
+		t.Fatal("hasHomeTelemetry() must be false before the first async fetch lands (homeTelemetryLoaded gate), even though the zero snapshot reports hasData()")
+	}
+}
+
+// maybeScheduleHomeTelemetry is the single debounce/TTL/in-flight gate. The first
+// call (nothing loaded, nothing in flight) must schedule a fetch and mark it
+// in-flight.
+func TestMaybeScheduleFirstFetch(t *testing.T) {
+	m := MailModel{}
+	cmd := m.maybeScheduleHomeTelemetry(time.Unix(1000, 0))
+	if cmd == nil {
+		t.Fatal("first schedule must return a fetch command")
+	}
+	if !m.homeTelemetryInFlight {
+		t.Fatal("scheduling must mark the fetch in-flight so concurrent renders don't double-schedule")
+	}
+}
+
+// While a fetch is in flight, no new fetch may be scheduled — a burst of
+// keypresses/renders must not spawn a pile of sqlite subprocesses.
+func TestMaybeScheduleDebouncesInFlight(t *testing.T) {
+	m := MailModel{homeTelemetryInFlight: true}
+	if cmd := m.maybeScheduleHomeTelemetry(time.Unix(1000, 0)); cmd != nil {
+		t.Fatal("must not schedule a second fetch while one is in flight")
+	}
+}
+
+// After a completed fetch, a second fetch within the TTL is skipped (reuse the
+// cached snapshot); once the TTL elapses a new fetch is allowed again.
+func TestMaybeScheduleHonorsTTL(t *testing.T) {
+	base := time.Unix(1000, 0)
+	m := MailModel{
+		homeTelemetryLoaded:    true,
+		homeTelemetryLastFetch: base,
+	}
+
+	// Within the TTL: no fetch.
+	within := base.Add(homeTelemetryTTL - time.Millisecond)
+	if cmd := m.maybeScheduleHomeTelemetry(within); cmd != nil {
+		t.Fatal("must not re-fetch within the TTL — the cached snapshot should be reused")
+	}
+	if m.homeTelemetryInFlight {
+		t.Fatal("a TTL-skipped schedule must not flip the in-flight flag")
+	}
+
+	// At/after the TTL: fetch allowed.
+	after := base.Add(homeTelemetryTTL)
+	if cmd := m.maybeScheduleHomeTelemetry(after); cmd == nil {
+		t.Fatal("must re-fetch once the TTL has elapsed")
+	}
+}
+
+// The very first fetch is exempt from the TTL: with nothing loaded yet, the row
+// should appear as promptly as possible rather than waiting a full TTL.
+func TestMaybeScheduleFirstFetchIgnoresTTL(t *testing.T) {
+	// Not loaded, and a lastFetch stamp that would otherwise be "too recent".
+	now := time.Unix(1000, 0)
+	m := MailModel{homeTelemetryLastFetch: now}
+	if cmd := m.maybeScheduleHomeTelemetry(now); cmd == nil {
+		t.Fatal("the first fetch (nothing loaded) must not be blocked by the TTL floor")
+	}
+}
+
+// applyHomeTelemetry lands a fetch result: it stores the snapshot, marks it
+// loaded, clears in-flight, stamps the completion time, and reports whether the
+// row's VISIBILITY flipped (the only telemetry change that affects layout).
+func TestApplyHomeTelemetryStateTransitions(t *testing.T) {
+	m := MailModel{homeTelemetryInFlight: true}
+	now := time.Unix(2000, 0)
+
+	// First landing with real data: visibility flips false→true.
+	data := homeTelemetry{contextUsage: 0.5, sessionTokens: 100}
+	changed := m.applyHomeTelemetry(data, now)
+	if !changed {
+		t.Fatal("first data landing must report a visibility change (no row → row)")
+	}
+	if !m.homeTelemetryLoaded {
+		t.Fatal("applyHomeTelemetry must mark the snapshot loaded")
+	}
+	if m.homeTelemetryInFlight {
+		t.Fatal("applyHomeTelemetry must clear the in-flight flag so the next tick can re-fetch")
+	}
+	if !m.homeTelemetryLastFetch.Equal(now) {
+		t.Fatalf("applyHomeTelemetry must stamp the completion time for the TTL, got %v want %v", m.homeTelemetryLastFetch, now)
+	}
+	if !m.hasHomeTelemetry() {
+		t.Fatal("after landing real data hasHomeTelemetry() must be true")
+	}
+
+	// Second landing with the same visibility (still has data): no layout change,
+	// so the caller must NOT re-sync the viewport (avoids thrash on numeric ticks).
+	data2 := homeTelemetry{contextUsage: 0.6, sessionTokens: 200}
+	if changed := m.applyHomeTelemetry(data2, now.Add(time.Second)); changed {
+		t.Fatal("a data→data update with unchanged visibility must NOT report a layout change")
+	}
+
+	// Landing empty data (contextUsage sentinel -1, no tokens): visibility flips
+	// true→false, so the row must be removed and the caller re-syncs.
+	empty := homeTelemetry{contextUsage: -1}
+	if changed := m.applyHomeTelemetry(empty, now.Add(2*time.Second)); !changed {
+		t.Fatal("data→no-data must report a visibility change so the row is removed")
+	}
+	if m.hasHomeTelemetry() {
+		t.Fatal("after landing empty telemetry hasHomeTelemetry() must be false")
+	}
+}

--- a/tui/internal/tui/home_telemetry_context_source_test.go
+++ b/tui/internal/tui/home_telemetry_context_source_test.go
@@ -93,6 +93,10 @@ func TestHomeTelemetryContextVisibleWithoutCtrlO(t *testing.T) {
 	if tel.contextUsage < 0 {
 		t.Fatalf("context usage not found at verboseOff: gatherHomeTelemetry must read the unfiltered session cache, not the verbose-filtered m.messages (contextUsage=%v)", tel.contextUsage)
 	}
+	// hasHomeTelemetry reads the cached snapshot the async fetch populates, not
+	// gatherHomeTelemetry directly. Drive the background fetch round-trip (run the
+	// command, feed its message back) so the snapshot reflects the notification.
+	m, _ = m.Update(m.fetchHomeTelemetry())
 	if !m.hasHomeTelemetry() {
 		t.Fatal("hasHomeTelemetry() is false at verboseOff despite a context-bearing notification in the session cache — the bar would be hidden until Ctrl+O")
 	}

--- a/tui/internal/tui/home_telemetry_ui_no_io_test.go
+++ b/tui/internal/tui/home_telemetry_ui_no_io_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/anthropics/lingtai-tui/i18n"
+)
+
+// The UI render/input path must read the cached telemetry snapshot ONLY — it must
+// never re-derive telemetry from disk (sqlite sidecar / token ledger /
+// events.jsonl). This test proves that by loading a snapshot via the async fetch,
+// then DELETING the orchestrator's on-disk telemetry sources, and asserting that
+// View() still renders the row and hasHomeTelemetry() still reports true. If View
+// or hasHomeTelemetry did any disk I/O, removing the sources would blank the row.
+func TestHomeTelemetryUIPathReadsCacheNotDisk(t *testing.T) {
+	const w, h = 100, 24
+	dir := t.TempDir()
+	orchDir := filepath.Join(dir, "orch")
+	logsDir := filepath.Join(orchDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	event := `{"type":"notification","ts":1782000000,"summary":"sync","meta":{"context":{"usage":0.73}}}` + "\n"
+	eventsPath := filepath.Join(logsDir, "events.jsonl")
+	if err := os.WriteFile(eventsPath, []byte(event), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	humanDir := filepath.Join(dir, "human")
+	if err := os.MkdirAll(humanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewMailModel(humanDir, "human@local", "~", orchDir, "TestOrch", 50, dir, "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	m, _ = m.Update(m.initialRebuild())
+	// Async fetch round-trip: this is the ONE place telemetry I/O happens.
+	m, _ = m.Update(m.fetchHomeTelemetry())
+	if !m.hasHomeTelemetry() {
+		t.Fatal("setup: telemetry snapshot should be loaded after the async fetch")
+	}
+	ctxLabel := i18n.T("mail.telemetry_context")
+	if !strings.Contains(m.View(), ctxLabel) {
+		t.Fatal("setup: telemetry row should render after the async fetch")
+	}
+
+	// Now remove every on-disk telemetry source. The whole logs tree goes, so a
+	// disk read on the UI path would find nothing.
+	if err := os.RemoveAll(logsDir); err != nil {
+		t.Fatal(err)
+	}
+	// Also remove any sqlite sidecar the ingest may have written.
+	if entries, err := os.ReadDir(orchDir); err == nil {
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".db") || strings.HasSuffix(e.Name(), ".sqlite") {
+				_ = os.Remove(filepath.Join(orchDir, e.Name()))
+			}
+		}
+	}
+
+	// The UI path reads the cached snapshot, not disk — so the row survives.
+	if !m.hasHomeTelemetry() {
+		t.Fatal("hasHomeTelemetry() went false after deleting on-disk sources — the UI path is reading disk, not the cached snapshot")
+	}
+	if !strings.Contains(m.View(), ctxLabel) {
+		t.Fatal("View() dropped the telemetry row after deleting on-disk sources — View is re-deriving telemetry from disk instead of reading the cached snapshot")
+	}
+	// syncViewportHeight likewise reads the cached predicate; it must still see the
+	// row (its visibility is unchanged) with no disk access.
+	if !m.hasHomeTelemetry() {
+		t.Fatal("syncViewportHeight's visibility predicate (hasHomeTelemetry) must be cache-backed")
+	}
+	m.lastInputLines = -1
+	_ = m.syncViewportHeight()
+}

--- a/tui/internal/tui/home_telemetry_view_test.go
+++ b/tui/internal/tui/home_telemetry_view_test.go
@@ -58,6 +58,12 @@ func newReadyMailModelWithTelemetry(t *testing.T, w, h int) MailModel {
 	// Drive the deferred initial rebuild (the normal launch path) so the
 	// notification populates the session cache. No Ctrl+O, verbose stays off.
 	m, _ = m.Update(m.initialRebuild())
+	// Home telemetry is now resolved asynchronously: gathering it does I/O off the
+	// UI path via the fetchHomeTelemetry command, and the model only shows the row
+	// once the resulting homeTelemetryMsg has landed. Drive that round-trip here
+	// (run the command, feed its message back through Update) exactly as the
+	// runtime would, so the cached snapshot is populated before we render.
+	m, _ = m.Update(m.fetchHomeTelemetry())
 	// Re-sync height now that telemetry visibility flipped on.
 	m.lastInputLines = -1
 	m.syncViewportHeight()

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -165,6 +165,16 @@ type MailModel struct {
 	sessionCache      *fs.SessionCache // append-only session log
 	initialLoading    bool             // true until the deferred initial rebuild's refresh has been applied
 	copyMode          bool             // chat-only: disables mouse capture so the terminal can select/copy visible text
+
+	// Home telemetry is resolved asynchronously off the render/input path (its
+	// I/O reaches sqlite + the token ledger + .status.json, which can stall on a
+	// locked/slow sidecar). View()/hasHomeTelemetry()/syncViewportHeight() read
+	// this cached snapshot ONLY; the fetchHomeTelemetry background command
+	// refreshes it via homeTelemetryMsg. See home_telemetry.go's async note.
+	homeTelemetry          homeTelemetry // last-known snapshot; zero value renders no row
+	homeTelemetryLoaded    bool          // true once a background fetch has completed at least once
+	homeTelemetryInFlight  bool          // true while a fetchHomeTelemetry command is running (debounce)
+	homeTelemetryLastFetch time.Time     // completion time of the last fetch, for the TTL floor
 }
 
 func NewMailModel(humanDir, humanAddr, baseDir, orchDir, orchName string, pageSize int, globalDir, lang string, insights bool, toolCallTruncate int) MailModel {
@@ -715,6 +725,13 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				m.viewport.GotoBottom()
 			}
 		}
+		// Kick off the first background telemetry fetch as soon as a refresh has
+		// landed (including the deferred initial rebuild), so the row can appear on
+		// first load without waiting a full poll tick. Debounced by the same
+		// in-flight/TTL gate, so this and the tick driver never double-fetch.
+		if cmd := m.maybeScheduleHomeTelemetry(time.Now()); cmd != nil {
+			return m, cmd
+		}
 		return m, nil
 
 	case pulseTickMsg:
@@ -724,7 +741,28 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		return m, pulseTick()
 
 	case tickMsg:
-		return m, tea.Batch(m.refreshMail, tickEvery(m.pollRate))
+		// Steady-state driver: alongside the incremental mail refresh, schedule a
+		// background telemetry fetch (debounced by in-flight + TTL). All telemetry
+		// I/O funnels through maybeScheduleHomeTelemetry — the UI path never gathers.
+		cmds = append(cmds, m.refreshMail, tickEvery(m.pollRate))
+		if cmd := m.maybeScheduleHomeTelemetry(time.Now()); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return m, tea.Batch(cmds...)
+
+	case homeTelemetryMsg:
+		// A background telemetry fetch completed. Land the snapshot; only re-sync
+		// the viewport height when the row's visibility flipped (data ⇄ no-data),
+		// so ordinary numeric updates don't thrash the layout.
+		if m.applyHomeTelemetry(msg.t, time.Now()) && m.ready {
+			atBottom := m.viewport.AtBottom()
+			m.syncViewportHeight()
+			m.viewport.SetContent(m.renderMessages(m.visibleMessages()))
+			if atBottom {
+				m.viewport.GotoBottom()
+			}
+		}
+		return m, nil
 
 	case SendMsg:
 		var text string
@@ -1618,8 +1656,16 @@ func (m MailModel) View() string {
 	// session/context data is available (graceful hide). Scalar-only — never the
 	// `_meta` block hidden by PR #440.
 	footer := sep + "\n" + inputSection + "\n"
-	if telemetry := formatHomeTelemetry(m.gatherHomeTelemetry(), m.width); telemetry != "" {
-		footer += telemetry + "\n"
+	// Read the cached telemetry snapshot ONLY — never gatherHomeTelemetry — so the
+	// render path performs no sqlite/filesystem/JSONL work. The snapshot is
+	// refreshed asynchronously by fetchHomeTelemetry (see home_telemetry.go).
+	// Gate on hasHomeTelemetry() (which carries the homeTelemetryLoaded guard) so
+	// View and syncViewportHeight share the exact same visibility predicate and can
+	// never disagree about whether the row occupies a line.
+	if m.hasHomeTelemetry() {
+		if telemetry := formatHomeTelemetry(m.homeTelemetry, m.width); telemetry != "" {
+			footer += telemetry + "\n"
+		}
 	}
 	footer += statusBar
 


### PR DESCRIPTION
## Summary
- Move home telemetry gathering off the Bubble Tea render/input hot path into an asynchronous `tea.Cmd`.
- `View()`, `hasHomeTelemetry()`, and `syncViewportHeight()` now read only the last-known cached telemetry snapshot; sqlite/token-ledger/status I/O runs in the background.
- Add in-flight + TTL gating so telemetry refreshes are debounced, plus loaded/stale behavior so first load renders without the row instead of blocking.
- Keep sqlite busy timeout and a conservative worker-local deadline as background backstops; the deadline no longer protects or blocks the UI thread.

## Validation
- `gofmt -l internal/tui/home_telemetry.go internal/tui/mail.go internal/sqlitelog/molt.go internal/tui/home_telemetry_async_test.go internal/tui/home_telemetry_ui_no_io_test.go internal/tui/home_telemetry_view_test.go internal/tui/home_telemetry_context_source_test.go internal/sqlitelog/molt_cache_test.go`
- `go vet ./internal/tui/ ./internal/sqlitelog/ ./internal/fs/`
- `go test ./internal/sqlitelog/ ./internal/fs/ ./internal/tui/ -count=1`
- `go build ./...`
- `go test ./... -count=1`

## Notes
- The mail home view hot path no longer calls `gatherHomeTelemetry()` or `SumMoltSessionTokenLedger()` directly.
- `props.go` (`/kanban` detail view) still calls `SumMoltSessionTokenLedger()` synchronously; that is off the mail render/keypress path and left as a possible follow-up.

Part of #526.