### PR TITLE
docs: add YAML prompt section definitions

### DIFF
--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -17,6 +17,11 @@ related_files:
   - tui/internal/preset/preset_allowed_revoke_test.go
   - tui/internal/preset/preset_propagate_test.go
   - tui/internal/preset/preset_agent_json_merge_test.go
+  - tui/internal/preset/covenant/section.yaml
+  - tui/internal/preset/principle/section.yaml
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/soul/section.yaml
+  - tui/internal/preset/prompt_section_definition_test.go
   - tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
   - tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
 maintenance: |
@@ -53,6 +58,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 | `ResolveRefsWithAuth(refs, keys, auth)` / `ResolveRefs(refs, keys)` | `tui/internal/preset/preset.go` | health-check: Source, Exists, HasKey (+ `CodexAuthRef`) for each preset path; credential validity requires configured `api_key_env`, Codex OAuth, or Claude Code CLI auth for `claude-agent-sdk`. For codex, when `AuthState.CodexAuthDir` is set, validity is judged per-preset against the preset's own `manifest.llm.codex_auth_path` token file (empty → legacy `codex-auth.json` fallback) so multiple Codex accounts are independent; without the dir it falls back to the global `CodexOAuthConfigured` bool |
 | `Validate()` | `tui/internal/preset/preset.go:282` | mirrors kernel-side validation; `summary` non-empty, `tier` 1..5, `llm.provider`/`model` non-empty |
 | `//go:embed` directives | `tui/internal/preset/preset.go:16-47` | covenant, principle, procedures, templates, soul, recipe_assets, skills |
+| Prompt section definitions | `tui/internal/preset/procedures/section.yaml:1`, `tui/internal/preset/prompt_section_definition_test.go:10` | Metadata-only YAML sidecars for TUI-shipped resident prompt sections. Each definition links the rendered content to this anatomy and at least one neighboring `section.yaml`; the kernel does not render these YAML files into agent prompts. |
 | `skills/lingtai-dev-guide/` | `tui/internal/preset/skills/lingtai-dev-guide/SKILL.md:1`, `tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md:1` | Bundled developer guide utility skill and its skill-stewardship nested reference, including the rule that skill authors keep routers lean and link dense content through progressive disclosure rather than encoding stale hard caps. |
 | `CopyBundle` | `tui/internal/preset/recipe_apply.go:59` | copies `.recipe/` (replace) + recipe skill library sibling (merge) + `.lingtai/` (merge) into project |
 | `RecipeNeedsApply` | `tui/internal/preset/recipe_apply.go:133` | diffs `.recipe/` vs last-applied snapshot under `.tui-asset/.recipe/` |
@@ -68,12 +74,12 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 - **Called by `tui/internal/tui/`** — all Bubble Tea screens (network home, preset editor, first-run wizard, recipe selector).
 - **Calls `tui/internal/config/`** — for `GlobalDirName` constant.
 - **Reads/writes `~/.lingtai-tui/presets/`** — `templates/` (TUI-owned, rewritten on Bootstrap) and `saved/` (user-owned). Also reads/writes per-project `.lingtai/<agent>/init.json` and `.lingtai/.tui-asset/`.
-- **Embeds prompt fragments** — covenant, principle, procedures, soul, templates, recipe_assets, skills — via `//go:embed`. These are the canonical TUI-shipped prompt text; the kernel reads them from disk after the TUI extracts them. Nested utility skills (for example `skills/swiss-knife/reference/<name>/SKILL.md`) are embedded and extracted as ordinary files under their parent router.
+- **Embeds prompt fragments and metadata** — covenant, principle, procedures, soul, templates, recipe_assets, skills — via `//go:embed`. The Markdown files are the canonical TUI-shipped prompt text; adjacent `section.yaml` files are metadata-only prompt section definitions that connect each section to this anatomy and neighboring definitions. The kernel reads only the configured Markdown paths from disk after the TUI extracts them. Nested utility skills (for example `skills/swiss-knife/reference/<name>/SKILL.md`) are embedded and extracted as ordinary files under their parent router.
 
 ## Composition
 
 - **Parent:** `tui/internal/` (no own anatomy)
-- **Subfolders:** `covenant/`, `principle/`, `procedures/`, `templates/`, `soul/`, `recipe_assets/`, `skills/` — all `//go:embed` targets. `skills/swiss-knife/` is a top-level router whose nested utility references live under `skills/swiss-knife/reference/*/SKILL.md`.
+- **Subfolders:** `covenant/`, `principle/`, `procedures/`, `templates/`, `soul/`, `recipe_assets/`, `skills/` — all `//go:embed` targets. The resident prompt section folders carry metadata-only `section.yaml` sidecars next to rendered Markdown content. `skills/swiss-knife/` is a top-level router whose nested utility references live under `skills/swiss-knife/reference/*/SKILL.md`.
 - **Siblings:** `tui/internal/migrate/ANATOMY.md` — migrations m029 (preset allowed list), m030 (preset dir split) live there
 
 ## State

--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -23,6 +23,7 @@ related_files:
   - tui/internal/preset/soul/section.yaml
   - tui/internal/preset/prompt_section_definition_test.go
   - tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+  - tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
   - tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring

--- a/tui/internal/preset/covenant/section.yaml
+++ b/tui/internal/preset/covenant/section.yaml
@@ -6,12 +6,20 @@ rendered_content:
   - en/covenant.md
   - zh/covenant.md
   - wen/covenant.md
-links:
-  anatomy:
-    - tui/internal/preset/ANATOMY.md
-  section_definitions:
-    - tui/internal/preset/principle/section.yaml
-    - tui/internal/preset/procedures/section.yaml
+related_files:
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/principle/section.yaml
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/covenant/en/covenant.md
+  - tui/internal/preset/covenant/zh/covenant.md
+  - tui/internal/preset/covenant/wen/covenant.md
+  - tui/internal/preset/procedures/procedures.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include at least one
+  ANATOMY.md file and at least one peer section.yaml so the prompt-section
+  definition graph stays connected rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field. This YAML is metadata only
+  and must not be injected into the agent system prompt.
 purpose: |
   LingTai's shared covenant: the philosophical and operational foundation that
   orients agents toward acting on need, mastering tools, learning continuously,
@@ -25,15 +33,3 @@ boundaries:
     - concrete tool procedures or command recipes
     - mutable project instructions
     - per-agent identity, pad, or private knowledge
-related_files:
-  - tui/internal/preset/covenant/en/covenant.md
-  - tui/internal/preset/covenant/zh/covenant.md
-  - tui/internal/preset/covenant/wen/covenant.md
-  - tui/internal/preset/procedures/procedures.md
-maintenance: |
-  Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt. Include
-  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
-  `section.yaml` under `links.section_definitions` so the prompt-section
-  definition graph stays crawlable rather than isolated. If you create a new
-  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/covenant/section.yaml
+++ b/tui/internal/preset/covenant/section.yaml
@@ -8,12 +8,15 @@ rendered_content:
   - wen/covenant.md
 related_files:
   - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
   - tui/internal/preset/principle/section.yaml
   - tui/internal/preset/procedures/section.yaml
   - tui/internal/preset/covenant/en/covenant.md
   - tui/internal/preset/covenant/zh/covenant.md
   - tui/internal/preset/covenant/wen/covenant.md
   - tui/internal/preset/procedures/procedures.md
+  - tui/internal/preset/skills/lingtai-recipe/SKILL.md
+  - tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include at least one
   ANATOMY.md file and at least one peer section.yaml so the prompt-section

--- a/tui/internal/preset/covenant/section.yaml
+++ b/tui/internal/preset/covenant/section.yaml
@@ -32,4 +32,8 @@ related_files:
   - tui/internal/preset/procedures/procedures.md
 maintenance: |
   Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt.
+  metadata only and must not be injected into the agent system prompt. Include
+  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
+  `section.yaml` under `links.section_definitions` so the prompt-section
+  definition graph stays crawlable rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/covenant/section.yaml
+++ b/tui/internal/preset/covenant/section.yaml
@@ -1,0 +1,35 @@
+section: covenant
+kind: resident_prompt_section
+owner: tui-preset
+metadata_only: true
+rendered_content:
+  - en/covenant.md
+  - zh/covenant.md
+  - wen/covenant.md
+links:
+  anatomy:
+    - tui/internal/preset/ANATOMY.md
+  section_definitions:
+    - tui/internal/preset/principle/section.yaml
+    - tui/internal/preset/procedures/section.yaml
+purpose: |
+  LingTai's shared covenant: the philosophical and operational foundation that
+  orients agents toward acting on need, mastering tools, learning continuously,
+  collaborating with peers, and preserving durable grain.
+boundaries:
+  owns:
+    - stable LingTai ethos and constitution
+    - high-level memory/collaboration/cultivation principles
+    - language-localized covenant text for starter agents
+  does_not_own:
+    - concrete tool procedures or command recipes
+    - mutable project instructions
+    - per-agent identity, pad, or private knowledge
+related_files:
+  - tui/internal/preset/covenant/en/covenant.md
+  - tui/internal/preset/covenant/zh/covenant.md
+  - tui/internal/preset/covenant/wen/covenant.md
+  - tui/internal/preset/procedures/procedures.md
+maintenance: |
+  Keep this definition aligned with the rendered prompt section. This YAML is
+  metadata only and must not be injected into the agent system prompt.

--- a/tui/internal/preset/principle/section.yaml
+++ b/tui/internal/preset/principle/section.yaml
@@ -1,0 +1,35 @@
+section: principle
+kind: resident_prompt_section
+owner: tui-preset
+metadata_only: true
+rendered_content:
+  - en/principle.md
+  - zh/principle.md
+  - wen/principle.md
+links:
+  anatomy:
+    - tui/internal/preset/ANATOMY.md
+  section_definitions:
+    - tui/internal/preset/covenant/section.yaml
+    - tui/internal/preset/procedures/section.yaml
+purpose: |
+  Root operating principles for channel-bound communication and the text-input /
+  text-output contract. This section establishes what counts as human input,
+  system input, diary output, and the required reply channel.
+boundaries:
+  owns:
+    - non-negotiable communication-channel semantics
+    - the diary/private-output distinction
+    - the high-level human-reply rule for TUI-created starter agents
+  does_not_own:
+    - expanded lifecycle, memory, or tool procedures
+    - project-specific standing rules
+    - detailed email/chat addon manuals
+related_files:
+  - tui/internal/preset/principle/en/principle.md
+  - tui/internal/preset/principle/zh/principle.md
+  - tui/internal/preset/principle/wen/principle.md
+  - tui/internal/preset/procedures/procedures.md
+maintenance: |
+  Keep this definition aligned with the rendered prompt section. This YAML is
+  metadata only and must not be injected into the agent system prompt.

--- a/tui/internal/preset/principle/section.yaml
+++ b/tui/internal/preset/principle/section.yaml
@@ -32,4 +32,8 @@ related_files:
   - tui/internal/preset/procedures/procedures.md
 maintenance: |
   Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt.
+  metadata only and must not be injected into the agent system prompt. Include
+  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
+  `section.yaml` under `links.section_definitions` so the prompt-section
+  definition graph stays crawlable rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/principle/section.yaml
+++ b/tui/internal/preset/principle/section.yaml
@@ -6,12 +6,20 @@ rendered_content:
   - en/principle.md
   - zh/principle.md
   - wen/principle.md
-links:
-  anatomy:
-    - tui/internal/preset/ANATOMY.md
-  section_definitions:
-    - tui/internal/preset/covenant/section.yaml
-    - tui/internal/preset/procedures/section.yaml
+related_files:
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/covenant/section.yaml
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/principle/en/principle.md
+  - tui/internal/preset/principle/zh/principle.md
+  - tui/internal/preset/principle/wen/principle.md
+  - tui/internal/preset/procedures/procedures.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include at least one
+  ANATOMY.md file and at least one peer section.yaml so the prompt-section
+  definition graph stays connected rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field. This YAML is metadata only
+  and must not be injected into the agent system prompt.
 purpose: |
   Root operating principles for channel-bound communication and the text-input /
   text-output contract. This section establishes what counts as human input,
@@ -25,15 +33,3 @@ boundaries:
     - expanded lifecycle, memory, or tool procedures
     - project-specific standing rules
     - detailed email/chat addon manuals
-related_files:
-  - tui/internal/preset/principle/en/principle.md
-  - tui/internal/preset/principle/zh/principle.md
-  - tui/internal/preset/principle/wen/principle.md
-  - tui/internal/preset/procedures/procedures.md
-maintenance: |
-  Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt. Include
-  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
-  `section.yaml` under `links.section_definitions` so the prompt-section
-  definition graph stays crawlable rather than isolated. If you create a new
-  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/principle/section.yaml
+++ b/tui/internal/preset/principle/section.yaml
@@ -8,12 +8,15 @@ rendered_content:
   - wen/principle.md
 related_files:
   - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
   - tui/internal/preset/covenant/section.yaml
   - tui/internal/preset/procedures/section.yaml
   - tui/internal/preset/principle/en/principle.md
   - tui/internal/preset/principle/zh/principle.md
   - tui/internal/preset/principle/wen/principle.md
   - tui/internal/preset/procedures/procedures.md
+  - tui/internal/preset/skills/lingtai-recipe/SKILL.md
+  - tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include at least one
   ANATOMY.md file and at least one peer section.yaml so the prompt-section

--- a/tui/internal/preset/procedures/section.yaml
+++ b/tui/internal/preset/procedures/section.yaml
@@ -29,4 +29,8 @@ related_files:
   - tui/internal/preset/skills/system-manual/SKILL.md
 maintenance: |
   Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt.
+  metadata only and must not be injected into the agent system prompt. Include
+  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
+  `section.yaml` under `links.section_definitions` so the prompt-section
+  definition graph stays crawlable rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/procedures/section.yaml
+++ b/tui/internal/preset/procedures/section.yaml
@@ -4,12 +4,19 @@ owner: tui-preset
 metadata_only: true
 rendered_content:
   - procedures.md
-links:
-  anatomy:
-    - tui/internal/preset/ANATOMY.md
-  section_definitions:
-    - tui/internal/preset/principle/section.yaml
-    - tui/internal/preset/covenant/section.yaml
+related_files:
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/principle/section.yaml
+  - tui/internal/preset/covenant/section.yaml
+  - tui/internal/preset/procedures/procedures.md
+  - tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+  - tui/internal/preset/skills/system-manual/SKILL.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include at least one
+  ANATOMY.md file and at least one peer section.yaml so the prompt-section
+  definition graph stays connected rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field. This YAML is metadata only
+  and must not be injected into the agent system prompt.
 purpose: |
   Compact action playbook for the resident system prompt: progressive-disclosure
   routing, tool-choice discipline, communication expectations, molt/store
@@ -23,14 +30,3 @@ boundaries:
     - detailed GitHub issue filing or consent policy
     - long examples, troubleshooting, or command recipes
     - private project facts or reusable skill bodies
-related_files:
-  - tui/internal/preset/procedures/procedures.md
-  - tui/internal/preset/skills/lingtai-issue-report/SKILL.md
-  - tui/internal/preset/skills/system-manual/SKILL.md
-maintenance: |
-  Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt. Include
-  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
-  `section.yaml` under `links.section_definitions` so the prompt-section
-  definition graph stays crawlable rather than isolated. If you create a new
-  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/procedures/section.yaml
+++ b/tui/internal/preset/procedures/section.yaml
@@ -6,10 +6,13 @@ rendered_content:
   - procedures.md
 related_files:
   - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
   - tui/internal/preset/principle/section.yaml
   - tui/internal/preset/covenant/section.yaml
   - tui/internal/preset/procedures/procedures.md
   - tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+  - tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+  - tui/internal/preset/skills/lingtai-tui-help/SKILL.md
   - tui/internal/preset/skills/system-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include at least one

--- a/tui/internal/preset/procedures/section.yaml
+++ b/tui/internal/preset/procedures/section.yaml
@@ -1,0 +1,32 @@
+section: procedures
+kind: resident_prompt_section
+owner: tui-preset
+metadata_only: true
+rendered_content:
+  - procedures.md
+links:
+  anatomy:
+    - tui/internal/preset/ANATOMY.md
+  section_definitions:
+    - tui/internal/preset/principle/section.yaml
+    - tui/internal/preset/covenant/section.yaml
+purpose: |
+  Compact action playbook for the resident system prompt: progressive-disclosure
+  routing, tool-choice discipline, communication expectations, molt/store
+  reminders, skill routing, and deliverable/reporting preferences.
+boundaries:
+  owns:
+    - short operational routing hooks
+    - compact checklist-level rules that must stay resident
+    - pointers to the skills/manuals that own detailed procedures
+  does_not_own:
+    - detailed GitHub issue filing or consent policy
+    - long examples, troubleshooting, or command recipes
+    - private project facts or reusable skill bodies
+related_files:
+  - tui/internal/preset/procedures/procedures.md
+  - tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+  - tui/internal/preset/skills/system-manual/SKILL.md
+maintenance: |
+  Keep this definition aligned with the rendered prompt section. This YAML is
+  metadata only and must not be injected into the agent system prompt.

--- a/tui/internal/preset/procedures/section.yaml
+++ b/tui/internal/preset/procedures/section.yaml
@@ -13,7 +13,6 @@ related_files:
   - tui/internal/preset/skills/lingtai-issue-report/SKILL.md
   - tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
   - tui/internal/preset/skills/lingtai-tui-help/SKILL.md
-  - tui/internal/preset/skills/system-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include at least one
   ANATOMY.md file and at least one peer section.yaml so the prompt-section

--- a/tui/internal/preset/prompt_section_definition_test.go
+++ b/tui/internal/preset/prompt_section_definition_test.go
@@ -79,15 +79,18 @@ func TestPromptSectionDefinitionsAreBundled(t *testing.T) {
 				t.Fatalf("read bundled %s: %v", tt.path, err)
 			}
 			body := string(data)
+			if strings.Contains(body, "\nlinks:") || strings.HasPrefix(body, "links:") {
+				t.Fatalf("%s should use anatomy-style related_files, not a links field", tt.path)
+			}
 			for _, want := range tt.want {
 				if !strings.Contains(body, want) {
 					t.Fatalf("%s missing %q\n%s", tt.path, want, body)
 				}
 			}
 			for _, want := range []string{
+				"Keep related_files as repo-relative paths to real files",
 				"must not be injected into the agent system prompt",
-				"at least one `ANATOMY.md` under `links.anatomy`",
-				"at least one peer",
+				"at least one peer section.yaml",
 				"copy this maintenance field",
 			} {
 				if !strings.Contains(body, want) {

--- a/tui/internal/preset/prompt_section_definition_test.go
+++ b/tui/internal/preset/prompt_section_definition_test.go
@@ -182,6 +182,71 @@ func TestRelatedManualsLinkBackToPromptSectionDefinitions(t *testing.T) {
 	}
 }
 
+func TestRelatedFileEntriesResolve(t *testing.T) {
+	repoRoot := filepath.Clean("../../..")
+	for _, rel := range []string{
+		"covenant/section.yaml",
+		"principle/section.yaml",
+		"procedures/section.yaml",
+		"soul/section.yaml",
+		"skills/lingtai-tui-anatomy/SKILL.md",
+		"skills/lingtai-issue-report/SKILL.md",
+		"skills/lingtai-dev-guide/SKILL.md",
+		"skills/lingtai-tui-help/SKILL.md",
+		"skills/lingtai-tutorial-guide/SKILL.md",
+		"skills/lingtai-recipe/SKILL.md",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.FromSlash(rel))
+			if err != nil {
+				t.Fatalf("read %s: %v", rel, err)
+			}
+			text := string(data)
+			if strings.HasSuffix(rel, ".md") {
+				text = yamlFrontmatter(t, rel, text)
+			}
+			for _, related := range relatedFiles(text) {
+				if _, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(related))); err != nil {
+					t.Fatalf("%s related_files entry %q does not resolve from repo root: %v", rel, related, err)
+				}
+			}
+		})
+	}
+}
+
+func yamlFrontmatter(t *testing.T, rel, text string) string {
+	t.Helper()
+	if !strings.HasPrefix(text, "---\n") {
+		t.Fatalf("%s has no YAML frontmatter", rel)
+	}
+	end := strings.Index(text[4:], "\n---\n")
+	if end < 0 {
+		t.Fatalf("%s has unclosed YAML frontmatter", rel)
+	}
+	return text[4 : 4+end]
+}
+
+func relatedFiles(yamlText string) []string {
+	var out []string
+	inRelatedFiles := false
+	for _, line := range strings.Split(yamlText, "\n") {
+		if line == "related_files:" {
+			inRelatedFiles = true
+			continue
+		}
+		if inRelatedFiles {
+			if strings.HasPrefix(line, "  - ") {
+				out = append(out, strings.TrimSpace(strings.TrimPrefix(line, "  - ")))
+				continue
+			}
+			if strings.TrimSpace(line) != "" && !strings.HasPrefix(line, " ") {
+				inRelatedFiles = false
+			}
+		}
+	}
+	return out
+}
+
 func TestBootstrapPopulatesPromptSectionDefinitions(t *testing.T) {
 	dir := t.TempDir()
 	if err := Bootstrap(dir); err != nil {

--- a/tui/internal/preset/prompt_section_definition_test.go
+++ b/tui/internal/preset/prompt_section_definition_test.go
@@ -120,6 +120,68 @@ func TestPresetAnatomyLinksPromptSectionDefinitions(t *testing.T) {
 	}
 }
 
+func TestRelatedManualsLinkBackToPromptSectionDefinitions(t *testing.T) {
+	tests := []struct {
+		path string
+		want []string
+	}{
+		{
+			path: "skills/lingtai-tui-anatomy/SKILL.md",
+			want: []string{
+				"related_files:",
+				"tui/internal/preset/ANATOMY.md",
+				"tui/internal/preset/covenant/section.yaml",
+				"tui/internal/preset/principle/section.yaml",
+				"tui/internal/preset/procedures/section.yaml",
+				"tui/internal/preset/soul/section.yaml",
+			},
+		},
+		{
+			path: "skills/lingtai-issue-report/SKILL.md",
+			want: []string{"related_files:", "tui/internal/preset/procedures/section.yaml"},
+		},
+		{
+			path: "skills/lingtai-dev-guide/SKILL.md",
+			want: []string{"related_files:", "tui/internal/preset/procedures/section.yaml"},
+		},
+		{
+			path: "skills/lingtai-tui-help/SKILL.md",
+			want: []string{"related_files:", "tui/internal/preset/procedures/section.yaml"},
+		},
+		{
+			path: "skills/lingtai-tutorial-guide/SKILL.md",
+			want: []string{
+				"related_files:",
+				"tui/internal/preset/covenant/section.yaml",
+				"tui/internal/preset/principle/section.yaml",
+			},
+		},
+		{
+			path: "skills/lingtai-recipe/SKILL.md",
+			want: []string{
+				"related_files:",
+				"tui/internal/preset/covenant/section.yaml",
+				"tui/internal/preset/principle/section.yaml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.FromSlash(tt.path))
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.path, err)
+			}
+			body := string(data)
+			for _, want := range tt.want {
+				if !strings.Contains(body, want) {
+					t.Fatalf("%s missing bidirectional related_files entry %q", tt.path, want)
+				}
+			}
+		})
+	}
+}
+
 func TestBootstrapPopulatesPromptSectionDefinitions(t *testing.T) {
 	dir := t.TempDir()
 	if err := Bootstrap(dir); err != nil {

--- a/tui/internal/preset/prompt_section_definition_test.go
+++ b/tui/internal/preset/prompt_section_definition_test.go
@@ -1,0 +1,134 @@
+package preset
+
+import (
+	"embed"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPromptSectionDefinitionsAreBundled(t *testing.T) {
+	tests := []struct {
+		name string
+		fsys embed.FS
+		path string
+		want []string
+	}{
+		{
+			name: "covenant",
+			fsys: covenantFS,
+			path: "covenant/section.yaml",
+			want: []string{
+				"section: covenant",
+				"metadata_only: true",
+				"en/covenant.md",
+				"zh/covenant.md",
+				"wen/covenant.md",
+				"tui/internal/preset/ANATOMY.md",
+				"tui/internal/preset/principle/section.yaml",
+			},
+		},
+		{
+			name: "principle",
+			fsys: principleFS,
+			path: "principle/section.yaml",
+			want: []string{
+				"section: principle",
+				"metadata_only: true",
+				"en/principle.md",
+				"zh/principle.md",
+				"wen/principle.md",
+				"tui/internal/preset/ANATOMY.md",
+				"tui/internal/preset/covenant/section.yaml",
+			},
+		},
+		{
+			name: "procedures",
+			fsys: proceduresFS,
+			path: "procedures/section.yaml",
+			want: []string{
+				"section: procedures",
+				"metadata_only: true",
+				"procedures.md",
+				"detailed GitHub issue filing or consent policy",
+				"tui/internal/preset/ANATOMY.md",
+				"tui/internal/preset/principle/section.yaml",
+			},
+		},
+		{
+			name: "soul",
+			fsys: soulFS,
+			path: "soul/section.yaml",
+			want: []string{
+				"section: soul",
+				"metadata_only: true",
+				"en/soul-flow.md",
+				"zh/soul-flow.md",
+				"wen/soul-flow.md",
+				"tui/internal/preset/ANATOMY.md",
+				"tui/internal/preset/procedures/section.yaml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.fsys.ReadFile(tt.path)
+			if err != nil {
+				t.Fatalf("read bundled %s: %v", tt.path, err)
+			}
+			body := string(data)
+			for _, want := range tt.want {
+				if !strings.Contains(body, want) {
+					t.Fatalf("%s missing %q\n%s", tt.path, want, body)
+				}
+			}
+		})
+	}
+}
+
+func TestPresetAnatomyLinksPromptSectionDefinitions(t *testing.T) {
+	data, err := os.ReadFile("ANATOMY.md")
+	if err != nil {
+		t.Fatalf("read ANATOMY.md: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"Prompt section definitions",
+		"tui/internal/preset/covenant/section.yaml",
+		"tui/internal/preset/principle/section.yaml",
+		"tui/internal/preset/procedures/section.yaml",
+		"tui/internal/preset/soul/section.yaml",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("ANATOMY.md missing %q", want)
+		}
+	}
+}
+
+func TestBootstrapPopulatesPromptSectionDefinitions(t *testing.T) {
+	dir := t.TempDir()
+	if err := Bootstrap(dir); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	for _, rel := range []string{
+		"covenant/section.yaml",
+		"principle/section.yaml",
+		"procedures/section.yaml",
+		"soul/section.yaml",
+	} {
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("expected Bootstrap to populate %s: %v", rel, err)
+		}
+		if !strings.Contains(string(data), "metadata_only: true") {
+			t.Fatalf("%s should declare metadata_only: true", rel)
+		}
+	}
+
+	if got := ProceduresPath(dir, "en"); strings.HasSuffix(got, "section.yaml") {
+		t.Fatalf("ProceduresPath should resolve rendered markdown, got metadata sidecar %q", got)
+	}
+}

--- a/tui/internal/preset/prompt_section_definition_test.go
+++ b/tui/internal/preset/prompt_section_definition_test.go
@@ -84,6 +84,16 @@ func TestPromptSectionDefinitionsAreBundled(t *testing.T) {
 					t.Fatalf("%s missing %q\n%s", tt.path, want, body)
 				}
 			}
+			for _, want := range []string{
+				"must not be injected into the agent system prompt",
+				"at least one `ANATOMY.md` under `links.anatomy`",
+				"at least one peer",
+				"copy this maintenance field",
+			} {
+				if !strings.Contains(body, want) {
+					t.Fatalf("%s missing shared maintenance rule %q\n%s", tt.path, want, body)
+				}
+			}
 		})
 	}
 }

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -9,7 +9,10 @@ description: >
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
 version: 2.6.1
-last_changed_at: "2026-07-03T08:05:00Z"
+last_changed_at: 2026-07-04T09:14:00Z
+related_files:
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/ANATOMY.md
 ---
 
 # LingTai Developer Guide

--- a/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
@@ -2,7 +2,10 @@
 name: lingtai-issue-report
 description: Protocol router for reporting bugs, stale info, missing capabilities, or design issues you spot in any LingTai skill, capability, preset, or system behavior. Enter through this router, then load the one nested reference you need — evidence-checklist (when to report, what evidence to collect, secret hygiene), report-template (the report body/title structure), or filing-flow (human consent, the gh CLI path, and the paste-ready fallback). You always assemble a structured report and ask the human for permission before filing.
 version: 1.4.0
-last_changed_at: "2026-06-02T02:43:15-07:00"
+last_changed_at: 2026-07-04T09:14:00Z
+related_files:
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/procedures/procedures.md
 ---
 
 # Reporting LingTai Issues

--- a/tui/internal/preset/skills/lingtai-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/SKILL.md
@@ -22,7 +22,10 @@ description: >
   live system (those go through the kernel's writes to the agent's
   working directory, not through a recipe round-trip).
 version: 3.2.0
-last_changed_at: "2026-06-02T00:08:39-07:00"
+last_changed_at: 2026-07-04T09:14:00Z
+related_files:
+  - tui/internal/preset/covenant/section.yaml
+  - tui/internal/preset/principle/section.yaml
 ---
 
 # lingtai-recipe: Recipes and How to Publish Them

--- a/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
@@ -50,7 +50,13 @@ description: >
       separate tree with its own anatomy. Cross-repo references are
       narrative only ("the kernel writes this file; we read it").
 version: 0.1.0
-last_changed_at: "2026-06-24T01:56:50-07:00"
+last_changed_at: 2026-07-04T09:14:00Z
+related_files:
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/covenant/section.yaml
+  - tui/internal/preset/principle/section.yaml
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/soul/section.yaml
 ---
 
 # LingTai (Go) Anatomy — the Convention

--- a/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
@@ -9,7 +9,9 @@ description: >
   matches the current UI language.
 version: 1.0.0
 tags: [tui, help, slash-commands, reference, palette, lingtai-tui]
-last_changed_at: "2026-06-09T04:21:55-07:00"
+last_changed_at: 2026-07-04T09:14:00Z
+related_files:
+  - tui/internal/preset/procedures/section.yaml
 ---
 
 # lingtai-tui help — canonical TUI reference

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
@@ -6,7 +6,10 @@ description: >
   capabilities, operations, addons, and graduation. Invoke this skill when the
   human is ready to begin or continue the tutorial.
 version: 2.0.1
-last_changed_at: "2026-06-02T00:34:40-07:00"
+last_changed_at: 2026-07-04T09:14:00Z
+related_files:
+  - tui/internal/preset/covenant/section.yaml
+  - tui/internal/preset/principle/section.yaml
 ---
 
 # Tutorial Guide — Router

--- a/tui/internal/preset/soul/section.yaml
+++ b/tui/internal/preset/soul/section.yaml
@@ -6,12 +6,20 @@ rendered_content:
   - en/soul-flow.md
   - zh/soul-flow.md
   - wen/soul-flow.md
-links:
-  anatomy:
-    - tui/internal/preset/ANATOMY.md
-  section_definitions:
-    - tui/internal/preset/procedures/section.yaml
-    - tui/internal/preset/principle/section.yaml
+related_files:
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/procedures/section.yaml
+  - tui/internal/preset/principle/section.yaml
+  - tui/internal/preset/soul/en/soul-flow.md
+  - tui/internal/preset/soul/zh/soul-flow.md
+  - tui/internal/preset/soul/wen/soul-flow.md
+  - tui/internal/preset/skills/soul-manual/SKILL.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include at least one
+  ANATOMY.md file and at least one peer section.yaml so the prompt-section
+  definition graph stays connected rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field. This YAML is metadata only
+  and must not be injected into the agent system prompt.
 purpose: |
   Localized prompt text for the optional soul-flow inner voice. This section
   frames the separate no-tool LLM session that reads the agent diary and returns
@@ -25,15 +33,3 @@ boundaries:
     - runtime opt-in mechanics or environment gates
     - soul tool action schemas
     - agent communication, lifecycle, or task procedures
-related_files:
-  - tui/internal/preset/soul/en/soul-flow.md
-  - tui/internal/preset/soul/zh/soul-flow.md
-  - tui/internal/preset/soul/wen/soul-flow.md
-  - tui/internal/preset/skills/soul-manual/SKILL.md
-maintenance: |
-  Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt. Include
-  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
-  `section.yaml` under `links.section_definitions` so the prompt-section
-  definition graph stays crawlable rather than isolated. If you create a new
-  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/soul/section.yaml
+++ b/tui/internal/preset/soul/section.yaml
@@ -1,0 +1,35 @@
+section: soul
+kind: resident_prompt_section
+owner: tui-preset
+metadata_only: true
+rendered_content:
+  - en/soul-flow.md
+  - zh/soul-flow.md
+  - wen/soul-flow.md
+links:
+  anatomy:
+    - tui/internal/preset/ANATOMY.md
+  section_definitions:
+    - tui/internal/preset/procedures/section.yaml
+    - tui/internal/preset/principle/section.yaml
+purpose: |
+  Localized prompt text for the optional soul-flow inner voice. This section
+  frames the separate no-tool LLM session that reads the agent diary and returns
+  a concise subconscious nudge.
+boundaries:
+  owns:
+    - soul-flow voice framing
+    - localized instructions for concise inner reflections
+    - constraints on what the soul voice should and should not say
+  does_not_own:
+    - runtime opt-in mechanics or environment gates
+    - soul tool action schemas
+    - agent communication, lifecycle, or task procedures
+related_files:
+  - tui/internal/preset/soul/en/soul-flow.md
+  - tui/internal/preset/soul/zh/soul-flow.md
+  - tui/internal/preset/soul/wen/soul-flow.md
+  - tui/internal/preset/skills/soul-manual/SKILL.md
+maintenance: |
+  Keep this definition aligned with the rendered prompt section. This YAML is
+  metadata only and must not be injected into the agent system prompt.

--- a/tui/internal/preset/soul/section.yaml
+++ b/tui/internal/preset/soul/section.yaml
@@ -8,6 +8,7 @@ rendered_content:
   - wen/soul-flow.md
 related_files:
   - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
   - tui/internal/preset/procedures/section.yaml
   - tui/internal/preset/principle/section.yaml
   - tui/internal/preset/soul/en/soul-flow.md

--- a/tui/internal/preset/soul/section.yaml
+++ b/tui/internal/preset/soul/section.yaml
@@ -32,4 +32,8 @@ related_files:
   - tui/internal/preset/skills/soul-manual/SKILL.md
 maintenance: |
   Keep this definition aligned with the rendered prompt section. This YAML is
-  metadata only and must not be injected into the agent system prompt.
+  metadata only and must not be injected into the agent system prompt. Include
+  at least one `ANATOMY.md` under `links.anatomy` and at least one peer
+  `section.yaml` under `links.section_definitions` so the prompt-section
+  definition graph stays crawlable rather than isolated. If you create a new
+  prompt-section YAML, copy this maintenance field.

--- a/tui/internal/preset/soul/section.yaml
+++ b/tui/internal/preset/soul/section.yaml
@@ -14,7 +14,6 @@ related_files:
   - tui/internal/preset/soul/en/soul-flow.md
   - tui/internal/preset/soul/zh/soul-flow.md
   - tui/internal/preset/soul/wen/soul-flow.md
-  - tui/internal/preset/skills/soul-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include at least one
   ANATOMY.md file and at least one peer section.yaml so the prompt-section


### PR DESCRIPTION
## Summary
- add metadata-only `section.yaml` Prompt Section Definition sidecars for TUI-shipped resident prompt sections: covenant, principle, procedures, and soul
- use the ANATOMY-style `related_files` field (not a custom `links` field) to connect every definition to `tui/internal/preset/ANATOMY.md`, at least one neighboring `section.yaml`, rendered prompt files, and relevant bundled manual/skill files
- make those manual/skill links bidirectional by adding `related_files` frontmatter back to the relevant bundled SKILL.md files
- copy the shared maintenance rule into every `section.yaml`: keep `related_files` as real repo-relative paths, include at least one anatomy and one peer YAML, never inject the YAML into prompts, and copy the rule for new prompt-section YAML files
- update the preset anatomy and add regression coverage that the YAML sidecars are embedded/populated but not resolved as rendered prompt content

## Validation
- `ruby -e 'require "yaml"; ...' tui/internal/preset/{principle,covenant,procedures,soul}/section.yaml`
- Ruby frontmatter parse for modified bundled SKILL.md files
- `rg -n '^links:' ...` returns no matches
- `git diff --check`
- `go test ./internal/preset/`

## Notes
- These YAML files are metadata only; the kernel still renders the configured Markdown prompt files.
- No central registry is introduced.
