### PR TITLE
Expand TUI network activity evidence

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -391,7 +391,7 @@
   "network_activity.label": "network",
   "network_activity.short_label": "net",
   "network_activity.status.active": "active",
-  "network_activity.status.daemon-active": "daemon-active",
+  "network_activity.status.daemon-active": "active",
   "network_activity.status.idle": "idle",
   "network_activity.status.asleep": "asleep",
   "network_activity.status.suspend": "suspend",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -386,7 +386,7 @@
   "network_activity.label": "云",
   "network_activity.short_label": "云",
   "network_activity.status.active": "醒",
-  "network_activity.status.daemon-active": "神动",
+  "network_activity.status.daemon-active": "醒",
   "network_activity.status.idle": "定",
   "network_activity.status.asleep": "眠",
   "network_activity.status.suspend": "假死",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -386,7 +386,7 @@
   "network_activity.label": "网络",
   "network_activity.short_label": "网",
   "network_activity.status.active": "活跃",
-  "network_activity.status.daemon-active": "神识活跃",
+  "network_activity.status.daemon-active": "活跃",
   "network_activity.status.idle": "待命",
   "network_activity.status.asleep": "休眠",
   "network_activity.status.suspend": "假死",

--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -92,8 +92,9 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 | **network.go** | | |
 | `BuildNetwork(baseDir)` | `tui/internal/fs/network.go:8` | full topology: nodes, avatar edges, contact edges, mail edges, stats |
 | **activity.go** | | |
-| `ComputeNetworkActivity(baseDir)` | `tui/internal/fs/activity.go:34` | lightweight non-human project activity badge: active, daemon-active, idle, asleep, suspend; only counts daemon runs for heartbeat-live parent agents |
-| `CountDaemons(agentDir)` | `tui/internal/fs/activity.go:110` | counts parseable `daemons/<run_id>/daemon.json` files for selected-agent daemon running/total displays |
+| `ComputeNetworkActivity(baseDir)` | `tui/internal/fs/activity.go:42` | lightweight non-human project activity badge: folds agent state, heartbeat liveness, `.status.json` activity evidence, and running daemons into active, daemon-active, idle, asleep, suspend |
+| `hasStatusActivity(agentDir, now)` | `tui/internal/fs/activity.go:174` | treats heartbeat-live agents as active when status-snapshot evidence is fresh: `active_turn` via mtime/started_at/last_progress_at within 600s, or `last_progress_at` within 90s |
+| `CountDaemons(agentDir)` | `tui/internal/fs/activity.go:238` | counts parseable `daemons/<run_id>/daemon.json` files; running daemons feed project daemon-active status and selected-agent running/total displays |
 | **resolve.go** | | |
 | `ParseAddress(addr)` | `tui/internal/fs/resolve.go:16` | `"localhost:/path"` or `"[ipv6]:/path"` → `(host, path, ok)` |
 | `IsRemoteAddress(addr)` | `tui/internal/fs/resolve.go:62` | true if non-localhost host prefix |

--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -22,6 +22,7 @@ const (
 const (
 	networkActiveTurnCap        = 600 * time.Second
 	networkRecentProgressWindow = 90 * time.Second
+	networkFutureTimestampGrace = 2 * time.Minute
 )
 
 // NetworkActivity is the project-level activity summary for non-human agents.
@@ -177,17 +178,19 @@ func hasStatusActivity(agentDir string, now time.Time) bool {
 		return false
 	}
 	if status.ActiveTurn != nil {
-		freshAt := mtime
+		candidates := []time.Time{mtime}
 		if status.ActiveTurn.StartedAt.OK {
-			freshAt = laterTime(freshAt, unixSeconds(status.ActiveTurn.StartedAt.Value))
+			candidates = append(candidates, unixSeconds(status.ActiveTurn.StartedAt.Value))
 		}
 		if status.Runtime.LastProgressAt.OK {
-			freshAt = laterTime(freshAt, unixSeconds(status.Runtime.LastProgressAt.Value))
+			candidates = append(candidates, unixSeconds(status.Runtime.LastProgressAt.Value))
 		}
+		freshAt := latestStatusFreshnessTime(now, candidates...)
 		return within(now, freshAt, networkActiveTurnCap)
 	}
 	if status.Runtime.LastProgressAt.OK {
-		return within(now, unixSeconds(status.Runtime.LastProgressAt.Value), networkRecentProgressWindow)
+		freshAt := latestStatusFreshnessTime(now, unixSeconds(status.Runtime.LastProgressAt.Value))
+		return within(now, freshAt, networkRecentProgressWindow)
 	}
 	return false
 }
@@ -209,11 +212,31 @@ func readNetworkStatusSnapshot(agentDir string) (networkStatusSnapshot, time.Tim
 	return status, info.ModTime(), true
 }
 
-func laterTime(a, b time.Time) time.Time {
-	if b.After(a) {
-		return b
+func latestStatusFreshnessTime(now time.Time, candidates ...time.Time) time.Time {
+	var latest time.Time
+	for _, candidate := range candidates {
+		t, ok := statusFreshnessTime(now, candidate)
+		if !ok {
+			continue
+		}
+		if t.After(latest) {
+			latest = t
+		}
 	}
-	return a
+	return latest
+}
+
+func statusFreshnessTime(now, t time.Time) (time.Time, bool) {
+	if t.IsZero() {
+		return time.Time{}, false
+	}
+	if t.After(now) {
+		if t.Sub(now) > networkFutureTimestampGrace {
+			return time.Time{}, false
+		}
+		return now, true
+	}
+	return t, true
 }
 
 func unixSeconds(v float64) time.Time {

--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -3,9 +3,12 @@ package fs
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -14,6 +17,11 @@ const (
 	NetworkStatusIdle         = "idle"
 	NetworkStatusAsleep       = "asleep"
 	NetworkStatusSuspend      = "suspend"
+)
+
+const (
+	networkActiveTurnCap        = 600 * time.Second
+	networkRecentProgressWindow = 90 * time.Second
 )
 
 // NetworkActivity is the project-level activity summary for non-human agents.
@@ -57,6 +65,7 @@ func computeNetworkActivity(nodes []AgentNode) NetworkActivity {
 	activity := NetworkActivity{Status: NetworkStatusSuspend}
 	var hasIdle bool
 	var hasAsleep bool
+	var hasNonDaemonActive bool
 
 	for _, node := range nodes {
 		if node.IsHuman {
@@ -64,11 +73,18 @@ func computeNetworkActivity(nodes []AgentNode) NetworkActivity {
 		}
 
 		state := strings.ToUpper(node.State)
+		live := node.Alive
 		if state == "ACTIVE" {
 			activity.ActiveAgents++
+			hasNonDaemonActive = true
 		}
-		if node.Alive {
+
+		if live {
 			activity.RunningDaemons += CountDaemons(node.WorkingDir).Running
+			if state != "ACTIVE" && hasStatusActivity(node.WorkingDir, time.Now()) {
+				activity.ActiveAgents++
+				hasNonDaemonActive = true
+			}
 		}
 
 		switch state {
@@ -78,7 +94,7 @@ func computeNetworkActivity(nodes []AgentNode) NetworkActivity {
 			// STUCK stays an individual agent state. At network level we fold a
 			// heartbeat-fresh STUCK agent into idle so a live but errored agent
 			// does not make the project look asleep or suspended.
-			if node.Alive {
+			if live {
 				hasIdle = true
 			}
 		case "ASLEEP":
@@ -87,7 +103,7 @@ func computeNetworkActivity(nodes []AgentNode) NetworkActivity {
 	}
 
 	switch {
-	case activity.ActiveAgents > 0:
+	case hasNonDaemonActive:
 		activity.Status = NetworkStatusActive
 	case activity.RunningDaemons > 0:
 		activity.Status = NetworkStatusDaemonActive
@@ -99,6 +115,118 @@ func computeNetworkActivity(nodes []AgentNode) NetworkActivity {
 		activity.Status = NetworkStatusSuspend
 	}
 	return activity
+}
+
+type networkStatusSnapshot struct {
+	ActiveTurn *networkActiveTurn `json:"active_turn"`
+	Runtime    struct {
+		State          string             `json:"state"`
+		LastProgressAt tolerantJSONNumber `json:"last_progress_at"`
+		NoProgressSecs tolerantJSONNumber `json:"no_progress_seconds"`
+		UptimeSeconds  tolerantJSONNumber `json:"uptime_seconds"`
+		StaminaLeft    tolerantJSONNumber `json:"stamina_left"`
+	} `json:"runtime"`
+}
+
+type networkActiveTurn struct {
+	Kind           string             `json:"kind"`
+	ID             string             `json:"id"`
+	StartedAt      tolerantJSONNumber `json:"started_at"`
+	ElapsedSeconds tolerantJSONNumber `json:"elapsed_seconds"`
+}
+
+type tolerantJSONNumber struct {
+	Value float64
+	OK    bool
+}
+
+func (n *tolerantJSONNumber) UnmarshalJSON(data []byte) error {
+	text := strings.TrimSpace(string(data))
+	if text == "" || text == "null" {
+		return nil
+	}
+	if len(text) >= 2 && text[0] == '"' && text[len(text)-1] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return nil
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return nil
+		}
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+			return nil
+		}
+		n.Value = v
+		n.OK = true
+		return nil
+	}
+	v, err := strconv.ParseFloat(text, 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return nil
+	}
+	n.Value = v
+	n.OK = true
+	return nil
+}
+
+func hasStatusActivity(agentDir string, now time.Time) bool {
+	status, mtime, ok := readNetworkStatusSnapshot(agentDir)
+	if !ok {
+		return false
+	}
+	if status.ActiveTurn != nil {
+		freshAt := mtime
+		if status.ActiveTurn.StartedAt.OK {
+			freshAt = laterTime(freshAt, unixSeconds(status.ActiveTurn.StartedAt.Value))
+		}
+		if status.Runtime.LastProgressAt.OK {
+			freshAt = laterTime(freshAt, unixSeconds(status.Runtime.LastProgressAt.Value))
+		}
+		return within(now, freshAt, networkActiveTurnCap)
+	}
+	if status.Runtime.LastProgressAt.OK {
+		return within(now, unixSeconds(status.Runtime.LastProgressAt.Value), networkRecentProgressWindow)
+	}
+	return false
+}
+
+func readNetworkStatusSnapshot(agentDir string) (networkStatusSnapshot, time.Time, bool) {
+	path := filepath.Join(agentDir, ".status.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		return networkStatusSnapshot{}, time.Time{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return networkStatusSnapshot{}, time.Time{}, false
+	}
+	var status networkStatusSnapshot
+	if err := json.Unmarshal(data, &status); err != nil {
+		return networkStatusSnapshot{}, time.Time{}, false
+	}
+	return status, info.ModTime(), true
+}
+
+func laterTime(a, b time.Time) time.Time {
+	if b.After(a) {
+		return b
+	}
+	return a
+}
+
+func unixSeconds(v float64) time.Time {
+	sec, frac := math.Modf(v)
+	return time.Unix(int64(sec), int64(frac*1e9))
+}
+
+func within(now, t time.Time, window time.Duration) bool {
+	if t.IsZero() {
+		return false
+	}
+	age := now.Sub(t)
+	return age >= 0 && age <= window
 }
 
 type daemonStateFile struct {

--- a/tui/internal/fs/activity_test.go
+++ b/tui/internal/fs/activity_test.go
@@ -246,3 +246,220 @@ func writeMalformedDaemonState(t *testing.T, agentDir, runID string) {
 		t.Fatalf("write malformed daemon: %v", err)
 	}
 }
+
+func TestComputeNetworkActivity_StatusActiveTurnEvidence(t *testing.T) {
+	cases := []struct {
+		name   string
+		status map[string]interface{}
+		mtime  time.Time
+		want   string
+		active int
+	}{
+		{
+			name: "pending active turn counts with elapsed_seconds",
+			status: map[string]interface{}{
+				"active_turn": map[string]interface{}{
+					"kind":            "pending",
+					"id":              "turn-1",
+					"started_at":      time.Now().Add(-30 * time.Second).Unix(),
+					"elapsed_seconds": 30,
+				},
+			},
+			mtime:  time.Now(),
+			want:   NetworkStatusActive,
+			active: 1,
+		},
+		{
+			name: "fresh mtime keeps old started_at active",
+			status: map[string]interface{}{
+				"active_turn": map[string]interface{}{
+					"kind":            "tool",
+					"id":              "turn-2",
+					"started_at":      time.Now().Add(-2 * networkActiveTurnCap).Unix(),
+					"elapsed_seconds": 1200,
+				},
+			},
+			mtime:  time.Now(),
+			want:   NetworkStatusActive,
+			active: 1,
+		},
+		{
+			name: "old mtime and old active_turn age out at cap",
+			status: map[string]interface{}{
+				"active_turn": map[string]interface{}{
+					"kind":            "tool",
+					"id":              "turn-3",
+					"started_at":      time.Now().Add(-2 * networkActiveTurnCap).Unix(),
+					"elapsed_seconds": 1200,
+				},
+			},
+			mtime:  time.Now().Add(-2 * networkActiveTurnCap),
+			want:   NetworkStatusIdle,
+			active: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			agentDir := writeActivityAgent(t, base, "alice", "IDLE", true)
+			writeStatus(t, agentDir, tc.status, tc.mtime)
+
+			activity, err := ComputeNetworkActivity(base)
+			if err != nil {
+				t.Fatalf("compute activity: %v", err)
+			}
+			if activity.Status != tc.want {
+				t.Fatalf("status = %q, want %q", activity.Status, tc.want)
+			}
+			if activity.ActiveAgents != tc.active {
+				t.Fatalf("active agents = %d, want %d", activity.ActiveAgents, tc.active)
+			}
+		})
+	}
+}
+
+func TestComputeNetworkActivity_StatusRuntimeLastProgressWindow(t *testing.T) {
+	cases := []struct {
+		name  string
+		last  interface{}
+		mtime time.Time
+		want  string
+	}{
+		{
+			name:  "fresh standalone last_progress_at counts briefly",
+			last:  time.Now().Add(-30 * time.Second).Unix(),
+			mtime: time.Now().Add(-2 * networkRecentProgressWindow),
+			want:  NetworkStatusActive,
+		},
+		{
+			name:  "standalone last_progress_at does not use active turn cap or mtime",
+			last:  time.Now().Add(-2 * networkRecentProgressWindow).Unix(),
+			mtime: time.Now(),
+			want:  NetworkStatusIdle,
+		},
+		{
+			name:  "scrubbed empty string ignored",
+			last:  "",
+			mtime: time.Now(),
+			want:  NetworkStatusIdle,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			agentDir := writeActivityAgent(t, base, "alice", "IDLE", true)
+			writeStatus(t, agentDir, map[string]interface{}{
+				"active_turn": nil,
+				"runtime": map[string]interface{}{
+					"last_progress_at":    tc.last,
+					"no_progress_seconds": "",
+					"state":               "IDLE",
+				},
+			}, tc.mtime)
+
+			activity, err := ComputeNetworkActivity(base)
+			if err != nil {
+				t.Fatalf("compute activity: %v", err)
+			}
+			if activity.Status != tc.want {
+				t.Fatalf("status = %q, want %q", activity.Status, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeNetworkActivity_StatusEvidenceRequiresFreshHeartbeat(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "IDLE", false)
+	writeStatus(t, agentDir, map[string]interface{}{
+		"active_turn": map[string]interface{}{
+			"kind":            "tool",
+			"id":              "turn-1",
+			"started_at":      time.Now().Unix(),
+			"elapsed_seconds": 1,
+		},
+	}, time.Now())
+
+	activity, err := ComputeNetworkActivity(base)
+	if err != nil {
+		t.Fatalf("compute activity: %v", err)
+	}
+	if activity.Status != NetworkStatusSuspend {
+		t.Fatalf("status = %q, want %q", activity.Status, NetworkStatusSuspend)
+	}
+}
+
+func TestComputeNetworkActivity_MalformedStatusFallsBackSafely(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "IDLE", true)
+	path := filepath.Join(agentDir, ".status.json")
+	if err := os.WriteFile(path, []byte(`{"active_turn":`), 0o644); err != nil {
+		t.Fatalf("write malformed status: %v", err)
+	}
+
+	activity, err := ComputeNetworkActivity(base)
+	if err != nil {
+		t.Fatalf("compute activity: %v", err)
+	}
+	if activity.Status != NetworkStatusIdle {
+		t.Fatalf("status = %q, want %q", activity.Status, NetworkStatusIdle)
+	}
+}
+
+func TestBuildNetwork_ActivityMatchesComputeNetworkActivityForStatusEvidence(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "IDLE", true)
+	writeStatus(t, agentDir, map[string]interface{}{
+		"active_turn": map[string]interface{}{
+			"kind":            "pending",
+			"id":              "turn-1",
+			"started_at":      time.Now().Unix(),
+			"elapsed_seconds": 0,
+		},
+	}, time.Now())
+
+	activity, err := ComputeNetworkActivity(base)
+	if err != nil {
+		t.Fatalf("compute activity: %v", err)
+	}
+	net, err := BuildNetwork(base)
+	if err != nil {
+		t.Fatalf("build network: %v", err)
+	}
+	if net.Activity != activity {
+		t.Fatalf("BuildNetwork activity = %+v, ComputeNetworkActivity = %+v", net.Activity, activity)
+	}
+}
+
+func TestComputeNetworkActivity_DaemonActiveOnlyWhenSoleSignal(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "IDLE", true)
+	writeDaemonState(t, agentDir, "run-1", map[string]interface{}{"state": "running"})
+	writeStatus(t, agentDir, map[string]interface{}{
+		"runtime": map[string]interface{}{
+			"last_progress_at": time.Now().Unix(),
+		},
+	}, time.Now())
+
+	activity, err := ComputeNetworkActivity(base)
+	if err != nil {
+		t.Fatalf("compute activity: %v", err)
+	}
+	if activity.Status != NetworkStatusActive {
+		t.Fatalf("status = %q, want %q", activity.Status, NetworkStatusActive)
+	}
+	if activity.RunningDaemons != 1 {
+		t.Fatalf("running daemons = %d, want 1", activity.RunningDaemons)
+	}
+}
+
+func writeStatus(t *testing.T, agentDir string, status map[string]interface{}, mtime time.Time) {
+	t.Helper()
+	path := filepath.Join(agentDir, ".status.json")
+	writeJSON(t, path, status)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes status: %v", err)
+	}
+}

--- a/tui/internal/fs/activity_test.go
+++ b/tui/internal/fs/activity_test.go
@@ -370,6 +370,85 @@ func TestComputeNetworkActivity_StatusRuntimeLastProgressWindow(t *testing.T) {
 	}
 }
 
+func TestHasStatusActivity_FutureTimestampFreshness(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	cases := []struct {
+		name   string
+		status map[string]interface{}
+		mtime  time.Time
+		want   bool
+	}{
+		{
+			name: "standalone modest future last_progress_at clamps to now",
+			status: map[string]interface{}{
+				"runtime": map[string]interface{}{
+					"last_progress_at": now.Add(30 * time.Second).Unix(),
+				},
+			},
+			mtime: now.Add(-2 * networkRecentProgressWindow),
+			want:  true,
+		},
+		{
+			name: "standalone far future last_progress_at ignored",
+			status: map[string]interface{}{
+				"runtime": map[string]interface{}{
+					"last_progress_at": now.Add(24 * time.Hour).Unix(),
+				},
+			},
+			mtime: now,
+			want:  false,
+		},
+		{
+			name: "active turn modest future started_at clamps to now",
+			status: map[string]interface{}{
+				"active_turn": map[string]interface{}{
+					"kind":       "tool",
+					"id":         "turn-1",
+					"started_at": now.Add(30 * time.Second).Unix(),
+				},
+			},
+			mtime: now.Add(-2 * networkActiveTurnCap),
+			want:  true,
+		},
+		{
+			name: "active turn far future started_at does not hide fresh mtime",
+			status: map[string]interface{}{
+				"active_turn": map[string]interface{}{
+					"kind":       "tool",
+					"id":         "turn-2",
+					"started_at": now.Add(24 * time.Hour).Unix(),
+				},
+			},
+			mtime: now,
+			want:  true,
+		},
+		{
+			name: "active turn far future started_at ignored without fresh evidence",
+			status: map[string]interface{}{
+				"active_turn": map[string]interface{}{
+					"kind":       "tool",
+					"id":         "turn-3",
+					"started_at": now.Add(24 * time.Hour).Unix(),
+				},
+			},
+			mtime: now.Add(-2 * networkActiveTurnCap),
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentDir := t.TempDir()
+			writeStatus(t, agentDir, tc.status, tc.mtime)
+
+			if got := hasStatusActivity(agentDir, now); got != tc.want {
+				t.Fatalf("hasStatusActivity = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestComputeNetworkActivity_StatusEvidenceRequiresFreshHeartbeat(t *testing.T) {
 	base := t.TempDir()
 	agentDir := writeActivityAgent(t, base, "alice", "IDLE", false)

--- a/tui/internal/tui/network_activity_i18n_test.go
+++ b/tui/internal/tui/network_activity_i18n_test.go
@@ -1,0 +1,31 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/anthropics/lingtai-tui/i18n"
+	"github.com/anthropics/lingtai-tui/internal/fs"
+)
+
+func TestNetworkActivityDaemonActiveDisplaysAsActive(t *testing.T) {
+	oldLang := i18n.Lang()
+	t.Cleanup(func() { i18n.SetLang(oldLang) })
+
+	for _, lang := range []string{"en", "zh", "wen"} {
+		t.Run(lang, func(t *testing.T) {
+			i18n.SetLang(lang)
+			got := networkActivityStatusLabel(fs.NetworkStatusDaemonActive)
+			want := networkActivityStatusLabel(fs.NetworkStatusActive)
+			if got != want {
+				t.Fatalf("daemon-active label = %q, want active label %q", got, want)
+			}
+		})
+	}
+
+	gotColor := NetworkActivityColor(fs.NetworkStatusDaemonActive)
+	wantColor := NetworkActivityColor(fs.NetworkStatusActive)
+	if !reflect.DeepEqual(gotColor, wantColor) {
+		t.Fatalf("daemon-active color = %#v, want active color %#v", gotColor, wantColor)
+	}
+}

--- a/tui/internal/tui/styles.go
+++ b/tui/internal/tui/styles.go
@@ -502,7 +502,7 @@ func NetworkActivityColor(status string) color.Color {
 	case "active":
 		return ColorActive
 	case "daemon-active":
-		return ColorTool
+		return ColorActive
 	case "idle":
 		return ColorIdle
 	case "asleep":


### PR DESCRIPTION
## Summary

- expand the TUI aggregate `NetworkActivity` signal beyond lifecycle state so a live descendant with fresh status evidence (`active_turn` or recent `last_progress_at`) keeps the network active
- keep heartbeat as a liveness gate and keep `daemon-active` as a compatibility subtype that renders as the same user-visible concept as `active`
- harden status freshness against small producer clock skew by clamping near-future timestamps and ignoring far-future timestamps as invalid evidence

## Motivation

The network badge can report idle while background work is still progressing if the agent lifecycle state has already fallen back to idle but the runtime is still producing fresh status/progress evidence. The aggregate network status is the right place to answer “is something in this network still progressing?”, while per-agent lifecycle/liveness remains a separate concept.

## Behavior

For live non-human descendant agents, the TUI now treats these as aggregate network-active evidence:

- lifecycle `ACTIVE`
- fresh non-null `.status.json.active_turn`, including pending turns
- standalone numeric `runtime.last_progress_at` within the recent progress window
- running daemon evidence

Status evidence is ignored for stale/dead agents, malformed status falls back safely, and daemon-only activity keeps the existing `daemon-active` wire value while rendering as active.

Timestamp freshness now normalizes status evidence before age checks:

- timestamps up to 2 minutes in the future are treated as `now`
- farther-future timestamps are ignored as invalid evidence
- active-turn candidates are normalized independently, so one bad future value cannot hide another fresh candidate such as the status file mtime

## Non-goals

- no portal changes in this PR
- no kernel changes in this PR
- no new third user-visible status/progress concept
- no attempt to include undiscovered children beyond the TUI’s existing descendant discovery scope

## Validation

Passed on this branch after rebasing onto latest `canonical/main`:

- `go test ./internal/fs -run 'TestHasStatusActivity_FutureTimestampFreshness|TestComputeNetworkActivity|TestBuildNetworkSetsActivity|TestHasStatusActivity' -count=1`
- `go test ./internal/tui -run TestNetworkActivityDaemonActiveDisplaysAsActive -count=1`
- `go vet ./internal/fs ./internal/tui`
- `git diff --check canonical/main...HEAD`

Notes:

- `go test ./internal/fs ./internal/tui -count=1` passed before rebasing onto the latest `main`.
- After rebasing onto current `canonical/main`, the full `./internal/tui` package test fails in `TestPortalURLTimeoutKillsChild` with `fake portal never wrote its pid; cannot verify it was reaped`.
- The same `TestPortalURLTimeoutKillsChild` failure reproduces on detached current `canonical/main` (`f1277772497df01808649bc77a5244f8936ea136`), so it appears to be an existing baseline/local-environment failure rather than caused by this branch.
