### PR TITLE
fix(tui): change-aware auto-refresh for /knowledge and /skills panels

### DIFF
--- a/tui/internal/tui/auto_refresh.go
+++ b/tui/internal/tui/auto_refresh.go
@@ -39,11 +39,15 @@ func autoRefreshCtrlRMsg() tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}
 }
 
-// autoRefreshActiveView reloads only the kanban/props view. Other Ctrl+R-
-// reloadable screens (/mailbox, /system, /daemons, markdown viewers, pickers,
-// and editors) are intentionally excluded from the 1s auto-refresh loop because
+// autoRefreshActiveView reloads the kanban/props view and the knowledge/library
+// markdown viewers. Other Ctrl+R-reloadable screens (/mailbox, /system, /daemons,
+// editors) are intentionally excluded from the 1s auto-refresh loop because
 // reloading them resets or disrupts keyboard selection/scroll state. They keep
 // Ctrl+R as the explicit manual refresh path.
+//
+// The knowledge and library views use a change-aware reload (mtime check) so
+// the catalog only rebuilds when the underlying directory actually changed —
+// avoiding unnecessary scroll/selection resets on every tick.
 func (a App) autoRefreshActiveView() (App, tea.Cmd) {
 	switch a.currentView {
 	case appViewProps:
@@ -58,6 +62,16 @@ func (a App) autoRefreshActiveView() (App, tea.Cmd) {
 			a.props.syncViewportContent()
 		}
 		return a, a.props.AutoReloadCmd()
+	case appViewCodex:
+		// /knowledge: reload only when the knowledge/ directory changed on disk.
+		var cmd tea.Cmd
+		a.codex, cmd = a.codex.reloadIfChanged()
+		return a, cmd
+	case appViewLibrary:
+		// /skills: reload only when the skills directories changed on disk.
+		var cmd tea.Cmd
+		a.library, cmd = a.library.reloadIfChanged()
+		return a, cmd
 	}
 	return a, nil
 }

--- a/tui/internal/tui/auto_refresh_test.go
+++ b/tui/internal/tui/auto_refresh_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/anthropics/lingtai-tui/internal/config"
 )
@@ -123,14 +124,16 @@ func TestAutoRefreshActiveViewOnlyReloadsKanban(t *testing.T) {
 	// Interactive / markdown / picker-heavy views must not auto-refresh every
 	// second: doing so can reset scroll or selection while the human is navigating
 	// with the keyboard. They retain explicit Ctrl+R refresh only.
+	// Note: /knowledge (appViewCodex) and /skills (appViewLibrary) participate
+	// in auto-refresh via change-aware mtime checks — see
+	// TestCodexAutoRefreshReloadsOnDirectoryChange and
+	// TestLibraryAutoRefreshReloadsOnDirectoryChange below.
 	blocked := []App{
 		{currentView: appViewProjects, projects: NewProjectsModel(dir, dir), tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewDaemons, daemons: NewDaemonsModel(dir, dir), tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewDoctor, doctor: DoctorModel{orchDir: dir, globalDir: dir}, tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewMailbox, mailbox: NewMailboxModel(dir), tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewSystem, system: NewSystemModel(dir, dir), tuiConfig: config.DefaultTUIConfig()},
-		{currentView: appViewLibrary, library: NewLibraryModel(dir, dir, "en"), tuiConfig: config.DefaultTUIConfig()},
-		{currentView: appViewCodex, codex: NewCodexModel(dir, dir), tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewPresets, presetLibrary: NewPresetLibraryModel("en", dir), tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewAddon, addon: NewAddonModel(dir), tuiConfig: config.DefaultTUIConfig()},
 		{currentView: appViewNotification, notification: NewNotificationModel(dir), tuiConfig: config.DefaultTUIConfig()},
@@ -140,6 +143,109 @@ func TestAutoRefreshActiveViewOnlyReloadsKanban(t *testing.T) {
 		if _, cmd := tc.autoRefreshActiveView(); cmd != nil {
 			t.Fatalf("view %v should not participate in 1s auto-refresh; use Ctrl+R", tc.currentView)
 		}
+	}
+}
+
+// TestCodexAutoRefreshNoChangeSkipsReload verifies that /knowledge auto-refresh
+// returns nil when the knowledge/ directory hasn't changed.
+func TestCodexAutoRefreshNoChangeSkipsReload(t *testing.T) {
+	dir := t.TempDir()
+	// Create the knowledge dir so mtime is seeded by the constructor.
+	knowledgeDir := filepath.Join(dir, "knowledge")
+	if err := os.MkdirAll(knowledgeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := App{
+		currentView: appViewCodex,
+		codex:       NewCodexModel(dir, dir),
+		tuiConfig:   config.DefaultTUIConfig(),
+	}
+	_, cmd := app.autoRefreshActiveView()
+	if cmd != nil {
+		t.Fatal("/knowledge auto-refresh should return nil when directory hasn't changed")
+	}
+}
+
+// TestCodexAutoRefreshReloadsOnDirectoryChange verifies that /knowledge
+// auto-refresh triggers a reload when the knowledge/ directory is modified.
+func TestCodexAutoRefreshReloadsOnDirectoryChange(t *testing.T) {
+	dir := t.TempDir()
+	knowledgeDir := filepath.Join(dir, "knowledge")
+	if err := os.MkdirAll(knowledgeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := App{
+		currentView: appViewCodex,
+		codex:       NewCodexModel(dir, dir),
+		tuiConfig:   config.DefaultTUIConfig(),
+	}
+
+	// Simulate a knowledge entry being written (dir mtime advances).
+	if err := os.MkdirAll(filepath.Join(knowledgeDir, "test-entry"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(knowledgeDir, "test-entry", "KNOWLEDGE.md"),
+		[]byte("---\nname: test\ndescription: test\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Set lastMtime to zero to force detection (mkdir+write may happen within
+	// the same filesystem tick window).
+	app.codex.lastMtime = time.Time{}
+	app.codex.width = 80
+	app.codex.height = 24
+
+	updated, _ := app.autoRefreshActiveView()
+	// The reload happened if lastMtime advanced from the zero value.
+	if updated.codex.lastMtime.IsZero() {
+		t.Fatal("/knowledge auto-refresh should reload when directory has changed (lastMtime should be updated)")
+	}
+}
+
+// TestLibraryAutoRefreshNoChangeSkipsReload verifies that /skills auto-refresh
+// returns nil when the .library/ directory hasn't changed.
+func TestLibraryAutoRefreshNoChangeSkipsReload(t *testing.T) {
+	dir := t.TempDir()
+	libraryDir := filepath.Join(dir, ".library")
+	if err := os.MkdirAll(libraryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := App{
+		currentView: appViewLibrary,
+		library:     NewLibraryModel(dir, dir, "en"),
+		tuiConfig:   config.DefaultTUIConfig(),
+	}
+	_, cmd := app.autoRefreshActiveView()
+	if cmd != nil {
+		t.Fatal("/skills auto-refresh should return nil when directory hasn't changed")
+	}
+}
+
+// TestLibraryAutoRefreshReloadsOnDirectoryChange verifies that /skills
+// auto-refresh triggers a reload when the .library/ directory is modified.
+func TestLibraryAutoRefreshReloadsOnDirectoryChange(t *testing.T) {
+	dir := t.TempDir()
+	libraryDir := filepath.Join(dir, ".library")
+	if err := os.MkdirAll(libraryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := App{
+		currentView: appViewLibrary,
+		library:     NewLibraryModel(dir, dir, "en"),
+		tuiConfig:   config.DefaultTUIConfig(),
+	}
+
+	// Simulate a skill being added (dir mtime advances).
+	if err := os.MkdirAll(filepath.Join(libraryDir, "custom", "test-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Set lastMtime to zero to force detection.
+	app.library.lastMtime = time.Time{}
+	app.library.width = 80
+	app.library.height = 24
+
+	updated, _ := app.autoRefreshActiveView()
+	if updated.library.lastMtime.IsZero() {
+		t.Fatal("/skills auto-refresh should reload when directory has changed (lastMtime should be updated)")
 	}
 }
 

--- a/tui/internal/tui/codex.go
+++ b/tui/internal/tui/codex.go
@@ -2,8 +2,10 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -30,11 +32,15 @@ type CodexModel struct {
 	pickerIdx  int
 	agentNodes []fs.AgentNode
 
-	width  int
-	height int
-	ready  bool
+	width     int
+	height    int
+	ready     bool
 
 	pickerVP viewport.Model
+
+	// lastMtime tracks the modification time of the knowledge/ directory so
+	// that auto-refresh can skip rebuilding the catalog when nothing changed.
+	lastMtime time.Time
 }
 
 type codexLoadMsg struct {
@@ -47,11 +53,16 @@ func NewCodexModel(baseDir, selectedDir string) CodexModel {
 	entries := buildAgentCodexEntries(selectedDir)
 	inner := NewMarkdownViewer(entries, codexTitleFor(selectedDir))
 	inner.FooterHint = i18n.T("hints.props_select")
-	return CodexModel{
+	m := CodexModel{
 		baseDir:     baseDir,
 		selectedDir: selectedDir,
 		inner:       inner,
 	}
+	// Seed mtime so auto-refresh only fires on changes after construction.
+	if info, err := os.Stat(filepath.Join(selectedDir, "knowledge")); err == nil {
+		m.lastMtime = info.ModTime()
+	}
+	return m
 }
 
 func codexTitleFor(agentDir string) string {
@@ -71,8 +82,13 @@ func codexTitleFor(agentDir string) string {
 }
 
 // reloadInner rebuilds the knowledge catalog for the selected agent from disk,
-// resetting the inner markdown viewer to the top. Invoked by ctrl+r.
+// resetting the inner markdown viewer to the top. Invoked by ctrl+r and
+// auto-refresh (when the directory has changed).
 func (m CodexModel) reloadInner() (CodexModel, tea.Cmd) {
+	m.drillIn = nil // match LibraryModel.reloadCatalog: clear drill-in on reload
+	if info, err := os.Stat(filepath.Join(m.selectedDir, "knowledge")); err == nil {
+		m.lastMtime = info.ModTime()
+	}
 	entries := buildAgentCodexEntries(m.selectedDir)
 	m.inner = NewMarkdownViewer(entries, codexTitleFor(m.selectedDir))
 	m.inner.FooterHint = i18n.T("hints.props_select")
@@ -82,6 +98,26 @@ func (m CodexModel) reloadInner() (CodexModel, tea.Cmd) {
 		return m, cmd
 	}
 	return m, nil
+}
+
+// reloadIfChanged checks whether the knowledge/ directory has been modified
+// since the last reload and, if so, rebuilds the catalog. This is the
+// auto-refresh entry point: cheap (a single os.Stat) when nothing changed,
+// and only rebuilds when new/removed/updated entries are detected.
+func (m CodexModel) reloadIfChanged() (CodexModel, tea.Cmd) {
+	// Skip when the user is interacting (picker open or drilling into an entry).
+	if m.pickerOpen || m.drillIn != nil {
+		return m, nil
+	}
+	info, err := os.Stat(filepath.Join(m.selectedDir, "knowledge"))
+	if err != nil {
+		return m, nil
+	}
+	if !info.ModTime().After(m.lastMtime) {
+		return m, nil
+	}
+	m.lastMtime = info.ModTime()
+	return m.reloadInner()
 }
 
 func (m CodexModel) loadAgents() tea.Msg {

--- a/tui/internal/tui/library.go
+++ b/tui/internal/tui/library.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -659,6 +660,10 @@ type LibraryModel struct {
 	// Picker scrolling viewport (used only while picker is open so very large
 	// networks don't overflow the screen).
 	pickerVP viewport.Model
+
+	// lastMtime tracks the modification time of the .library/ directory so
+	// that auto-refresh can skip rebuilding the catalog when nothing changed.
+	lastMtime time.Time
 }
 
 // libraryLoadMsg carries the discovered agent list for the picker.
@@ -674,12 +679,17 @@ func NewLibraryModel(baseDir, selectedDir, lang string) LibraryModel {
 	entries := buildAgentLibraryCatalog(selectedDir, lang)
 	inner := NewMarkdownViewer(entries, libraryTitleFor(selectedDir))
 	inner.FooterHint = i18n.T("hints.skills_catalog")
-	return LibraryModel{
+	m := LibraryModel{
 		baseDir:     baseDir,
 		selectedDir: selectedDir,
 		lang:        lang,
 		inner:       inner,
 	}
+	// Seed mtime so auto-refresh only fires on changes after construction.
+	if info, err := os.Stat(filepath.Join(selectedDir, ".library")); err == nil {
+		m.lastMtime = info.ModTime()
+	}
+	return m
 }
 
 // libraryTitleFor returns the viewer title annotated with the current agent's
@@ -727,12 +737,33 @@ func (m LibraryModel) reloadCatalog() (LibraryModel, tea.Cmd) {
 	m.inner = NewMarkdownViewer(entries, libraryTitleFor(m.selectedDir))
 	m.inner.FooterHint = i18n.T("hints.skills_catalog")
 	m.drillIn = nil
+	if info, err := os.Stat(filepath.Join(m.selectedDir, ".library")); err == nil {
+		m.lastMtime = info.ModTime()
+	}
 	if m.width > 0 && m.height > 0 {
 		var cmd tea.Cmd
 		m.inner, cmd = m.inner.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
 		return m, cmd
 	}
 	return m, nil
+}
+
+// reloadIfChanged checks whether the .library/ directory has been modified
+// since the last reload and, if so, rebuilds the catalog. This is the
+// auto-refresh entry point: cheap (a single os.Stat) when nothing changed,
+// and only rebuilds when new/removed/updated skills are detected.
+func (m LibraryModel) reloadIfChanged() (LibraryModel, tea.Cmd) {
+	if m.pickerOpen || m.drillIn != nil {
+		return m, nil
+	}
+	info, err := os.Stat(filepath.Join(m.selectedDir, ".library"))
+	if err != nil {
+		return m, nil
+	}
+	if !info.ModTime().After(m.lastMtime) {
+		return m, nil
+	}
+	return m.reloadCatalog()
 }
 
 const (


### PR DESCRIPTION
## Problem

Fixes #546

The `/knowledge` and `/skills` panels were deliberately excluded from the 1-second auto-refresh loop because rebuilding their catalogs resets scroll position and selection state. This meant that when an agent wrote new knowledge entries or skills during runtime, the TUI panel would not show them until the user manually pressed Ctrl+R or re-entered the view — even after an agent `refresh`.

## Solution

Add **change-aware auto-refresh**: check the directory's mtime via a single `os.Stat` before deciding whether to rebuild. The catalog only reloads when the underlying directory actually changed on disk, so:
- Normal 1s ticks are cheap (one stat call, no rebuild)
- Scroll position and selection are preserved when nothing changed
- New/modified entries appear within ~1 second of the filesystem change

## Changes

| File | Change |
|------|--------|
| `codex.go` | Add `lastMtime` field, `reloadIfChanged()` method, seed mtime in constructor. Also fix `reloadInner()` to clear `drillIn` (matching `LibraryModel.reloadCatalog` behavior — this was a secondary bug where stale drill-in persisted after Ctrl+R). |
| `library.go` | Mirror the same `lastMtime` + `reloadIfChanged()` pattern for the `/skills` panel. |
| `auto_refresh.go` | Add `appViewCodex` and `appViewLibrary` cases that call `reloadIfChanged()`. |
| `auto_refresh_test.go` | Remove codex/library from blocked list, add 4 new tests for change-aware refresh behavior. |

## Testing

```
=== RUN   TestAutoRefreshActiveViewOnlyReloadsKanban
--- PASS
=== RUN   TestCodexAutoRefreshNoChangeSkipsReload
--- PASS
=== RUN   TestCodexAutoRefreshReloadsOnDirectoryChange
--- PASS
=== RUN   TestLibraryAutoRefreshNoChangeSkipsReload
--- PASS
=== RUN   TestLibraryAutoRefreshReloadsOnDirectoryChange
--- PASS
```

All existing TUI tests continue to pass.