### PR TITLE
fix(setup): label Codex OAuth accounts

### DIFF
--- a/tui/internal/tui/codex_auth_store.go
+++ b/tui/internal/tui/codex_auth_store.go
@@ -79,13 +79,13 @@ func readCodexTokenFile(path string) (CodexTokens, bool) {
 		return CodexTokens{}, false
 	}
 	var tokens CodexTokens
-	if json.Unmarshal(data, &tokens) != nil || tokens.RefreshToken == "" {
+	if json.Unmarshal(data, &tokens) != nil {
 		return CodexTokens{}, false
 	}
 	if strings.TrimSpace(tokens.Email) == "" {
 		tokens.Email = extractEmailFromJWT(tokens.AccessToken)
 	}
-	return tokens, true
+	return tokens, strings.TrimSpace(tokens.RefreshToken) != ""
 }
 
 // codexAuthPathValid reports whether the token file at the given absolute path

--- a/tui/internal/tui/codex_auth_store.go
+++ b/tui/internal/tui/codex_auth_store.go
@@ -82,6 +82,9 @@ func readCodexTokenFile(path string) (CodexTokens, bool) {
 	if json.Unmarshal(data, &tokens) != nil || tokens.RefreshToken == "" {
 		return CodexTokens{}, false
 	}
+	if strings.TrimSpace(tokens.Email) == "" {
+		tokens.Email = extractEmailFromJWT(tokens.AccessToken)
+	}
 	return tokens, true
 }
 

--- a/tui/internal/tui/codex_auth_store_test.go
+++ b/tui/internal/tui/codex_auth_store_test.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,6 +24,22 @@ func writeStubCodexToken(t *testing.T, path, email string) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("write token: %v", err)
 	}
+}
+
+func fakeCodexAccessTokenWithEmail(t *testing.T, email string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := map[string]interface{}{
+		"sub": "u-1",
+		"https://api.openai.com/profile": map[string]string{
+			"email": email,
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return fmt.Sprintf("%s.%s.sig", header, base64.RawURLEncoding.EncodeToString(payloadJSON))
 }
 
 // TestResolveCodexAuthPath_LegacyFallback verifies an empty ref resolves to the
@@ -62,6 +80,31 @@ func TestCodexAuthPathValid(t *testing.T) {
 	os.WriteFile(bad, []byte(`{"access_token":"x"}`), 0o600) // no refresh_token
 	if codexAuthPathValid(bad) {
 		t.Error("a file without a refresh_token should be invalid")
+	}
+}
+
+func TestReadCodexTokenFileDerivesEmailFromAccessToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tok := CodexTokens{
+		AccessToken:  fakeCodexAccessTokenWithEmail(t, "alice@example.com"),
+		RefreshToken: "stub-refresh",
+		ExpiresAt:    9999999999,
+	}
+	data, _ := json.Marshal(tok)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	got, ok := readCodexTokenFile(path)
+	if !ok {
+		t.Fatal("token file should parse as valid")
+	}
+	if got.Email != "alice@example.com" {
+		t.Fatalf("expected email derived from access_token, got %q", got.Email)
 	}
 }
 

--- a/tui/internal/tui/codex_auth_store_test.go
+++ b/tui/internal/tui/codex_auth_store_test.go
@@ -108,6 +108,30 @@ func TestReadCodexTokenFileDerivesEmailFromAccessToken(t *testing.T) {
 	}
 }
 
+func TestReadCodexTokenFileKeepsEmailForInvalidRefresh(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tok := CodexTokens{
+		AccessToken: fakeCodexAccessTokenWithEmail(t, "invalid@example.com"),
+		ExpiresAt:   9999999999,
+	}
+	data, _ := json.Marshal(tok)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	got, ok := readCodexTokenFile(path)
+	if ok {
+		t.Fatal("token file without refresh_token should remain invalid")
+	}
+	if got.Email != "invalid@example.com" {
+		t.Fatalf("invalid token file should still keep derived email for display; got %q", got.Email)
+	}
+}
+
 // TestListCodexAccounts_LegacyAndPerAccount verifies enumeration surfaces the
 // legacy file (as a legacy account with empty ref) plus per-account files.
 func TestListCodexAccounts_LegacyAndPerAccount(t *testing.T) {

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -210,6 +210,7 @@ type FirstRunModel struct {
 	codexAuth      struct {
 		valid bool
 		email string // "" if JWT didn't carry one but tokens are valid
+		label string // non-secret display label: email, per-account slug, or localized default
 	}
 	// claudeCodeAuthValid is true when the local Claude Code CLI exists
 	// and reports an authenticated session. The TUI only detects this
@@ -2320,11 +2321,7 @@ func (m FirstRunModel) View() string {
 			if m.setupMode {
 				if m.codexAuth.valid {
 					okStyle := lipgloss.NewStyle().Foreground(ColorActive)
-					if m.codexAuth.email != "" {
-						row += "  " + okStyle.Render("✓ "+m.codexAuth.email)
-					} else {
-						row += "  " + okStyle.Render("✓ "+i18n.T("preset.codex_credential_authed_badge"))
-					}
+					row += "  " + okStyle.Render("✓ "+m.codexAuthDisplayLabel())
 				}
 				if m.cursor == visibleCount {
 					row += "  " + StyleFaint.Render(i18n.T("preset.codex_credential_setup_hint"))
@@ -2334,11 +2331,7 @@ func (m FirstRunModel) View() string {
 				// Login-only row: just confirm the authed state and
 				// point the user at 新建预设 for actual preset creation.
 				okStyle := lipgloss.NewStyle().Foreground(ColorActive)
-				if m.codexAuth.email != "" {
-					row += "  " + okStyle.Render("✓ "+m.codexAuth.email)
-				} else {
-					row += "  " + okStyle.Render("✓ "+i18n.T("preset.codex_credential_authed_badge"))
-				}
+				row += "  " + okStyle.Render("✓ "+m.codexAuthDisplayLabel())
 				// When the cursor parks on this row, surface the relogin
 				// affordance — quiet otherwise.
 				if m.cursor == visibleCount {
@@ -3966,6 +3959,14 @@ func (m FirstRunModel) codexPresetAuthValid(p preset.Preset) bool {
 	return codexAuthPathValid(resolveCodexAuthPath(m.globalDir, ref))
 }
 
+func (m FirstRunModel) codexAuthDisplayLabel() string {
+	label := strings.TrimSpace(m.codexAuth.label)
+	if label != "" {
+		return label
+	}
+	return codexAccountName(codexAccount{Email: m.codexAuth.email, Legacy: true})
+}
+
 func (m *FirstRunModel) refreshCodexAuth() {
 	// codexAuth.valid reflects whether ANY Codex account is configured, so
 	// the inline credential row shows an authed state once the user has at
@@ -3974,27 +3975,25 @@ func (m *FirstRunModel) refreshCodexAuth() {
 	if !ok {
 		// No legacy account; fall back to any per-account file so the row
 		// still reflects "Codex is set up" when only newer accounts exist.
-		if hasAnyCodexAccount(m.globalDir) {
-			m.codexAuth.valid = true
-			m.codexAuth.email = ""
-			for _, a := range listCodexAccounts(m.globalDir) {
-				if a.Valid && a.Email != "" {
-					m.codexAuth.email = a.Email
-					break
-				}
-			}
-			return
-		}
 		m.codexAuth.valid = false
 		m.codexAuth.email = ""
+		m.codexAuth.label = ""
+		for _, a := range listCodexAccounts(m.globalDir) {
+			if !a.Valid {
+				continue
+			}
+			m.codexAuth.valid = true
+			m.codexAuth.email = a.Email
+			m.codexAuth.label = codexAccountName(a)
+			if a.Email != "" {
+				break
+			}
+		}
 		return
 	}
 	m.codexAuth.valid = true
-	if tokens.Email != "" {
-		m.codexAuth.email = tokens.Email
-	} else {
-		m.codexAuth.email = ""
-	}
+	m.codexAuth.email = tokens.Email
+	m.codexAuth.label = codexAccountName(codexAccount{Email: tokens.Email, Legacy: true})
 }
 
 // refreshClaudeCodeAuth checks whether Claude Code is installed and logged in.

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -343,6 +343,34 @@ func TestPickPreset_OAuthDoneWritesOnMatchingEpoch(t *testing.T) {
 	}
 }
 
+func TestPickPreset_CodexAuthRowShowsAccountLabel(t *testing.T) {
+	i18n.SetLang("en")
+	globalDir := t.TempDir()
+	workPath := filepath.Join(codexAuthDir(globalDir), "work-bob.json")
+	writeCodexAccountFile(t, workPath, "")
+
+	m := FirstRunModel{
+		step:      stepPickPreset,
+		setupMode: true,
+		globalDir: globalDir,
+		cursor:    0,
+	}
+	m.refreshCodexAuth()
+	if !m.codexAuth.valid {
+		t.Fatal("per-account Codex auth should make /setup codex auth row valid")
+	}
+	if m.codexAuth.label != "work-bob" {
+		t.Fatalf("expected per-account slug label, got %q", m.codexAuth.label)
+	}
+	view := m.View()
+	if !strings.Contains(view, "work-bob") {
+		t.Fatalf("/setup codex auth row should show account label; view=%s", view)
+	}
+	if strings.Contains(view, i18n.T("preset.codex_credential_authed_badge")) {
+		t.Fatalf("/setup codex auth row should not fall back to generic logged-in badge; view=%s", view)
+	}
+}
+
 // TestPickPreset_DelCancelsInFlightLogin verifies that pressing Del
 // while codexLoggingIn invokes the stored cancel and bumps the epoch,
 // so any late callback is dropped.

--- a/tui/internal/tui/login.go
+++ b/tui/internal/tui/login.go
@@ -156,28 +156,32 @@ func NewSetupCredentialsModel(orchDir, globalDir string) LoginModel {
 // Helpers
 // ---------------------------------------------------------------------------
 
-// codexAccountDisplay returns the credential-row display string for a Codex
-// account: the fixed "OAuth" tag followed by a recognizable, non-secret account
-// name so multiple accounts can be told apart at a glance. The name prefers the
+// codexAccountName returns a recognizable, non-secret account name so
+// multiple Codex accounts can be told apart at a glance. The name prefers the
 // account email; falls back to the per-account file slug; and, for the legacy
 // single-account file with no stored email, uses the localized default-account
-// label (matching PresetEditorModel.codexBoundAccountLabel). It never renders a
-// bare "OAuth", and never exposes token material — only the email/slug already
-// derived for display. Kept in login.go (not codex_auth_store.go) so the store
-// helper stays free of the i18n dependency.
-func codexAccountDisplay(acct codexAccount) string {
-	name := acct.Email
-	if name == "" {
-		if acct.Legacy {
-			name = i18n.T("codex.account_default")
-		} else {
-			// codexAccount.Label() derives the file slug for a per-account file
-			// (its own fallback for the legacy case is a plain-English "default",
-			// which we deliberately override above with the localized label).
-			name = acct.Label()
-		}
+// label (matching PresetEditorModel.codexBoundAccountLabel). It never exposes
+// token material — only the email/slug already derived for display. Kept in
+// login.go (not codex_auth_store.go) so the store helper stays free of the i18n
+// dependency.
+func codexAccountName(acct codexAccount) string {
+	name := strings.TrimSpace(acct.Email)
+	if name != "" {
+		return name
 	}
-	return "OAuth — " + name
+	if acct.Legacy {
+		return i18n.T("codex.account_default")
+	}
+	// codexAccount.Label() derives the file slug for a per-account file
+	// (its own fallback for the legacy case is a plain-English "default",
+	// which we deliberately override above with the localized label).
+	return acct.Label()
+}
+
+// codexAccountDisplay returns the credential-row display string for a Codex
+// account: the fixed "OAuth" tag followed by the shared account name.
+func codexAccountDisplay(acct codexAccount) string {
+	return "OAuth — " + codexAccountName(acct)
 }
 
 // providerBaseURL returns the default API base URL for known providers.

--- a/tui/internal/tui/login.go
+++ b/tui/internal/tui/login.go
@@ -156,6 +156,30 @@ func NewSetupCredentialsModel(orchDir, globalDir string) LoginModel {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// codexAccountDisplay returns the credential-row display string for a Codex
+// account: the fixed "OAuth" tag followed by a recognizable, non-secret account
+// name so multiple accounts can be told apart at a glance. The name prefers the
+// account email; falls back to the per-account file slug; and, for the legacy
+// single-account file with no stored email, uses the localized default-account
+// label (matching PresetEditorModel.codexBoundAccountLabel). It never renders a
+// bare "OAuth", and never exposes token material — only the email/slug already
+// derived for display. Kept in login.go (not codex_auth_store.go) so the store
+// helper stays free of the i18n dependency.
+func codexAccountDisplay(acct codexAccount) string {
+	name := acct.Email
+	if name == "" {
+		if acct.Legacy {
+			name = i18n.T("codex.account_default")
+		} else {
+			// codexAccount.Label() derives the file slug for a per-account file
+			// (its own fallback for the legacy case is a plain-English "default",
+			// which we deliberately override above with the localized label).
+			name = acct.Label()
+		}
+	}
+	return "OAuth — " + name
+}
+
 // providerBaseURL returns the default API base URL for known providers.
 func providerBaseURL(provider string) string {
 	switch provider {
@@ -191,15 +215,9 @@ func NewLoginModel(orchDir, globalDir string) LoginModel {
 	// Each becomes its own entry so multiple ChatGPT accounts coexist.
 	for _, acct := range listCodexAccounts(globalDir) {
 		tok, _ := readCodexTokenFile(acct.Path)
-		display := "OAuth"
-		if acct.Email != "" {
-			display = "OAuth — " + acct.Email
-		} else if !acct.Legacy {
-			display = "OAuth — " + acct.Label()
-		}
 		m.entries = append(m.entries, loginEntry{
 			Provider:    "codex",
-			Display:     display,
+			Display:     codexAccountDisplay(acct),
 			Status:      loginChecking,
 			IsOAuth:     true,
 			BaseURL:     "https://chatgpt.com/backend-api",
@@ -410,12 +428,17 @@ func (m LoginModel) Update(msg tea.Msg) (LoginModel, tea.Cmd) {
 			return m, nil
 		}
 
-		// Update the matching account entry by path, or add a new one.
+		// Update the matching account entry by path, or add a new one. Build the
+		// display name through the shared helper so a re-auth/add keeps the same
+		// recognizable label the constructor renders (email → file slug →
+		// localized default) instead of collapsing to a bare "OAuth" when the
+		// fresh tokens carry no email.
 		isLegacy := target == legacy
-		display := "OAuth"
-		if msg.Tokens.Email != "" {
-			display = "OAuth — " + msg.Tokens.Email
-		}
+		display := codexAccountDisplay(codexAccount{
+			Path:   target,
+			Email:  msg.Tokens.Email,
+			Legacy: isLegacy,
+		})
 		found := false
 		for idx := range m.entries {
 			if m.entries[idx].Provider == "codex" && m.entries[idx].CodexPath == target {

--- a/tui/internal/tui/login_account_name_test.go
+++ b/tui/internal/tui/login_account_name_test.go
@@ -1,0 +1,201 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/lingtai-tui/i18n"
+)
+
+// writeCodexAccountFile writes a stub token bundle to path (creating parent
+// dirs). email may be "" to simulate a bundle whose id_token carried no email
+// (older logins / a JWT without the profile claim). No real secret is used.
+func writeCodexAccountFile(t *testing.T, path, email string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir for %q: %v", path, err)
+	}
+	tok := CodexTokens{
+		AccessToken:  "stub-access",
+		RefreshToken: "stub-refresh",
+		ExpiresAt:    9999999999,
+		Email:        email,
+	}
+	data, _ := json.Marshal(tok)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+// TestCodexAccountDisplay_LabelPerCase pins the display label helper directly:
+// email wins, then the per-account file slug, then the localized default-account
+// label for the legacy file with no email. Every case is prefixed "OAuth — " so
+// the row always shows a recognizable name, never a bare "OAuth".
+func TestCodexAccountDisplay_LabelPerCase(t *testing.T) {
+	defaultLabel := i18n.T("codex.account_default")
+
+	cases := []struct {
+		name string
+		acct codexAccount
+		want string
+	}{
+		{
+			name: "email present",
+			acct: codexAccount{Email: "alice@example.com"},
+			want: "OAuth — alice@example.com",
+		},
+		{
+			name: "per-account file, no email -> slug",
+			acct: codexAccount{Path: "/x/codex-auth/work-bob.json", Email: ""},
+			want: "OAuth — work-bob",
+		},
+		{
+			name: "legacy, no email -> localized default label",
+			acct: codexAccount{Legacy: true, Email: ""},
+			want: "OAuth — " + defaultLabel,
+		},
+		{
+			name: "legacy with email prefers email",
+			acct: codexAccount{Legacy: true, Email: "primary@example.com"},
+			want: "OAuth — primary@example.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexAccountDisplay(tc.acct); got != tc.want {
+				t.Fatalf("codexAccountDisplay = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoginModel_MultiAccountRowsShowRecognizableNames is the acceptance test
+// for Jason's report: with several Codex accounts, EACH row must carry a
+// recognizable account name. This seeds three accounts — a legacy file with no
+// email (the previously-bare "OAuth" row), a per-account file with an email, and
+// a per-account file with no email (slug only) — and asserts all three names
+// appear in the rendered credentials view, and that no row renders a bare
+// "OAuth" with nothing after it.
+func TestLoginModel_MultiAccountRowsShowRecognizableNames(t *testing.T) {
+	_, globalDir := withTempCodexHome(t)
+
+	// Legacy file, no email — used to render as a bare "OAuth".
+	writeCodexAccountFile(t, legacyCodexAuthPath(globalDir), "")
+	// Per-account file with an email.
+	writeCodexAccountFile(t, filepath.Join(codexAuthDir(globalDir), "alice.json"), "alice@example.com")
+	// Per-account file without an email — recognizable via its slug.
+	writeCodexAccountFile(t, filepath.Join(codexAuthDir(globalDir), "work-bob.json"), "")
+
+	m := NewLoginModel("", globalDir)
+	if len(m.entries) != 3 {
+		t.Fatalf("expected 3 codex entries; got %d: %#v", len(m.entries), m.entries)
+	}
+
+	defaultLabel := i18n.T("codex.account_default")
+	for _, e := range m.entries {
+		if e.Provider != "codex" {
+			t.Fatalf("unexpected non-codex entry: %#v", e)
+		}
+		// No row may be a bare "OAuth" with no distinguishing suffix.
+		if strings.TrimSpace(e.Display) == "OAuth" {
+			t.Fatalf("codex row has no recognizable name (bare OAuth): %#v", e)
+		}
+	}
+
+	m.width = 100
+	view := m.View()
+	for _, want := range []string{"alice@example.com", "work-bob", defaultLabel} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("credentials view missing recognizable name %q; view=%q", want, view)
+		}
+	}
+}
+
+// TestLoginModel_LegacyNoEmailRowNotBareOAuth isolates the legacy-only case: a
+// single legacy account with no email must still show the localized default
+// label rather than a bare "OAuth", so a user who later adds a second account
+// can tell which is which.
+func TestLoginModel_LegacyNoEmailRowNotBareOAuth(t *testing.T) {
+	_, globalDir := withTempCodexHome(t)
+	writeCodexAccountFile(t, legacyCodexAuthPath(globalDir), "")
+
+	m := NewLoginModel("", globalDir)
+	if len(m.entries) != 1 || !m.entries[0].CodexLegacy {
+		t.Fatalf("expected one legacy codex entry; got %#v", m.entries)
+	}
+	want := "OAuth — " + i18n.T("codex.account_default")
+	if m.entries[0].Display != want {
+		t.Fatalf("legacy no-email display = %q, want %q", m.entries[0].Display, want)
+	}
+}
+
+// TestLoginModel_OAuthDonePreservesRecognizableName verifies the re-auth/add
+// completion path (CodexOAuthDoneMsg) also lands a recognizable name on the
+// row. When the fresh tokens carry no email and the target is a per-account
+// file, the row must show the file slug — not fall back to a bare "OAuth".
+func TestLoginModel_OAuthDonePreservesRecognizableName(t *testing.T) {
+	_, globalDir := withTempCodexHome(t)
+	// Pre-existing legacy account so the "add another" completion writes a new
+	// per-account file (its slug derives from the email, but tokens here have
+	// none, so the derived path uses the "codex" fallback slug).
+	writeCodexAccountFile(t, legacyCodexAuthPath(globalDir), "primary@example.com")
+
+	m := NewLoginModel("", globalDir)
+	// Re-auth an EXISTING per-account file with a known slug so we can assert on
+	// it deterministically.
+	target := filepath.Join(codexAuthDir(globalDir), "teammate.json")
+	writeCodexAccountFile(t, target, "teammate@example.com")
+	m = NewLoginModel("", globalDir)
+	m.codexLoginTargetPath = target
+	m.codexLogging = true
+	m.codexLoginEpoch = 5
+
+	// Fresh tokens with NO email (simulating a JWT that lacked the profile claim).
+	m, _ = m.Update(CodexOAuthDoneMsg{
+		Epoch:  5,
+		Tokens: &CodexTokens{AccessToken: "a", RefreshToken: "r", Email: ""},
+	})
+
+	var got *loginEntry
+	for i := range m.entries {
+		if m.entries[i].CodexPath == target {
+			got = &m.entries[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("re-auth target row not found; entries=%#v", m.entries)
+	}
+	if got.Display != "OAuth — teammate" {
+		t.Fatalf("re-auth row display = %q, want %q", got.Display, "OAuth — teammate")
+	}
+}
+
+// TestLoginModel_OAuthDoneLegacyNoEmailShowsDefault verifies the seed-first-
+// account completion path: the very first login writes the legacy file, and if
+// the tokens carry no email the row shows the localized default label, not a
+// bare "OAuth".
+func TestLoginModel_OAuthDoneLegacyNoEmailShowsDefault(t *testing.T) {
+	_, globalDir := withTempCodexHome(t)
+	m := NewLoginModel("", globalDir)
+	if len(m.entries) != 0 {
+		t.Fatalf("precondition: expected no entries; got %#v", m.entries)
+	}
+	m.codexLoginTargetPath = ""
+	m.codexLogging = true
+	m.codexLoginEpoch = 1
+	m, _ = m.Update(CodexOAuthDoneMsg{
+		Epoch:  1,
+		Tokens: &CodexTokens{AccessToken: "a", RefreshToken: "r", Email: ""},
+	})
+	if len(m.entries) != 1 {
+		t.Fatalf("expected one seeded legacy entry; got %#v", m.entries)
+	}
+	want := "OAuth — " + i18n.T("codex.account_default")
+	if m.entries[0].Display != want {
+		t.Fatalf("seeded legacy no-email display = %q, want %q", m.entries[0].Display, want)
+	}
+}

--- a/tui/internal/tui/oauth.go
+++ b/tui/internal/tui/oauth.go
@@ -585,6 +585,9 @@ func exchangeCodeForTokens(tokenURL, code, verifier, redirectURI string) (*Codex
 	}
 
 	email := extractEmailFromJWT(raw.IDToken)
+	if email == "" {
+		email = extractEmailFromJWT(raw.AccessToken)
+	}
 
 	return &CodexTokens{
 		AccessToken:  raw.AccessToken,
@@ -685,6 +688,8 @@ func refreshCodexTokens(refreshToken string, existing CodexTokens) (*CodexTokens
 	}
 	merged.ExpiresAt = time.Now().Unix() + raw.ExpiresIn
 	if email := extractEmailFromJWT(raw.IDToken); email != "" {
+		merged.Email = email
+	} else if email := extractEmailFromJWT(raw.AccessToken); email != "" {
 		merged.Email = email
 	}
 	return &merged, nil


### PR DESCRIPTION
## Summary
- show recognizable, non-secret labels for Codex OAuth accounts anywhere setup renders Codex auth state
- `/setup credentials`: account rows show `OAuth — <name>` using persisted/derived account email → per-account token-file slug → localized default-account label
- `/setup codex auth`: the inline Codex auth row now also shows the account label instead of a generic `logged in` badge
- existing token files with empty stored `email` now derive the email from the access-token profile claim at read time, so current accounts can display real account names without re-auth
- keep Codex Pool active/weight/not-in-pool/corrupt-pool behavior unchanged

## Tests
- `cd tui && go test ./internal/tui/ ./internal/preset/ ./i18n/`
- `cd tui && go vet ./...`
- `cd tui && go test ./...`
- `cd tui && go build ./...`
- `git diff --check`

## Local rebuild
- rebuilt local binary from this PR branch with `cd tui && make dev`
- `/opt/homebrew/bin/lingtai-tui --version` → `lingtai-tui dev`
- `/opt/homebrew/bin/lingtai --version` → `lingtai-tui dev`

## Notes
- no new i18n keys; reuses existing `codex.account_default`
- tests use synthetic token fixtures only; no real OAuth token material is read or exposed in tests/logs