### PR TITLE
fix: skip brew update when TUI is already at latest version

### DIFF
--- a/tui/internal/config/tui_updater.go
+++ b/tui/internal/config/tui_updater.go
@@ -135,7 +135,8 @@ func RunManualTUIUpdate(globalDir string, opts ManualTUIUpdateOptions) TUIUpdate
 			case releaseNewer(current, release.TagName):
 				result.add(DoctorWarn, "TUI update available: %s -> %s", current, release.TagName)
 			default:
-				result.add(DoctorOK, "Latest release is not newer than current TUI version; running updater anyway")
+				result.add(DoctorOK, "TUI is already at the latest version (%s)", current)
+				return result
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Skip `brew update && brew upgrade` when the installed TUI is already at the latest version. Previously, `/update-tui` unconditionally ran the updater even after detecting no newer release, causing unnecessary network calls and failures on `brew` lock conflicts.

## Root cause

`RunManualTUIUpdate()` in `tui/internal/config/tui_updater.go` performed a version comparison but did not return early in the "already latest" case — the message literally said "running updater anyway."

## Fix

Add `return result` after the "TUI is already at the latest version" message in the `default` case of the version comparison switch (line 137-139). The result is returned with `Healthy: true`, `Updated: false`, `Err: nil` — correct values for a no-op.

### Before

```go
default:
    result.add(DoctorOK, "Latest release is not newer than current TUI version; running updater anyway")
    // ← falls through to RunTUIUpdate() unconditionally
```

### After

```go
default:
    result.add(DoctorOK, "TUI is already at the latest version (%s)", current)
    return result
```

## Validation

- [x] `git diff --check` — no whitespace errors
- [ ] Existing tests pass (unable to run Go tests locally due to network issues; CI will verify)

## Notes

- Closes #552
- No secrets or sensitive information in this PR
