### PR TITLE
Add Ctrl+End chat tail jump

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -153,6 +153,7 @@
   "mail.no_messages": "No messages yet. Waiting for mail...",
   "mail.initial_loading": "loading...",
   "mail.load_more": "▲ %d older — ctrl+u to load",
+  "mail.jump_bottom_hint": "Jump to bottom: Ctrl+End",
   "mail.collapse": "▼ ctrl+d to collapse to recent",
   "mail.placeholder": "Type a message...",
   "mail.refreshed": "Agent restarted.",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -153,6 +153,7 @@
   "mail.no_messages": "暂无书信，候邮中...",
   "mail.initial_loading": "载中...",
   "mail.load_more": "▲ 尚有 %d 旧书 — ctrl+u 载之",
+  "mail.jump_bottom_hint": "至末：Ctrl+End",
   "mail.collapse": "▼ ctrl+d 收至近书",
   "mail.placeholder": "书...",
   "mail.refreshed": "器灵已重启。",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -153,6 +153,7 @@
   "mail.no_messages": "暂无消息，等待邮件...",
   "mail.initial_loading": "加载中...",
   "mail.load_more": "▲ 还有 %d 条旧消息 — ctrl+u 加载",
+  "mail.jump_bottom_hint": "跳到底部：Ctrl+End",
   "mail.collapse": "▼ ctrl+d 收起到最新",
   "mail.placeholder": "输入消息...",
   "mail.refreshed": "Agent 已重启。",

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -387,6 +387,21 @@ func (m *MailModel) visibleMessages() []ChatMessage {
 	return m.messages[len(m.messages)-limit:]
 }
 
+func (m MailModel) chatTailRemainingLines() int {
+	if !m.ready || m.viewport.Height() <= 0 {
+		return 0
+	}
+	remaining := m.viewport.TotalLineCount() - m.viewport.Height() - m.viewport.YOffset()
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (m MailModel) showChatTailHint() bool {
+	return m.chatTailRemainingLines() > m.viewport.Height()
+}
+
 func (m MailModel) refreshMail() tea.Msg {
 	// Refresh human location (no-op if cache is <1h old)
 	go fs.UpdateHumanLocation(m.humanDir)
@@ -947,9 +962,12 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 
 		case "ctrl+end":
 			if m.ready {
+				// Ctrl+End is the chat-tail jump even while the compose textarea
+				// keeps focus; do not forward it to textarea cursor handling.
 				m.viewport.GotoBottom()
 				return m, nil
 			}
+			return m, nil
 
 		case "esc":
 			// Dismiss all visible insights
@@ -1376,6 +1394,51 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 	return b.String()
 }
 
+func (m MailModel) viewportWithChatTailHint() string {
+	view := m.viewport.View()
+	if !m.showChatTailHint() {
+		return view
+	}
+
+	text := i18n.T("mail.jump_bottom_hint")
+	maxHintWidth := m.width - 4
+	if maxHintWidth < 10 {
+		return view
+	}
+	if lipgloss.Width(text) > maxHintWidth {
+		text = ansi.Truncate(text, maxHintWidth, "…")
+	}
+	hint := StyleFaint.Render(" " + text + " ")
+	hintWidth := lipgloss.Width(hint)
+	if hintWidth <= 0 || hintWidth > m.width {
+		return view
+	}
+
+	lines := strings.Split(view, "\n")
+	if len(lines) == 0 {
+		return view
+	}
+
+	// Overlay into the viewport's already-padded output. This makes the hint
+	// non-focus and non-layout-affecting: no scroll, history, or input state
+	// changes are needed just to render it.
+	row := len(lines) - 1
+	start := m.width - hintWidth - 2
+	if start < 0 {
+		start = 0
+	}
+	prefix := ansi.Cut(lines[row], 0, start)
+	if pad := start - lipgloss.Width(prefix); pad > 0 {
+		prefix += strings.Repeat(" ", pad)
+	}
+	suffix := m.width - lipgloss.Width(prefix) - hintWidth
+	if suffix < 0 {
+		suffix = 0
+	}
+	lines[row] = prefix + hint + strings.Repeat(" ", suffix)
+	return strings.Join(lines, "\n")
+}
+
 // humanName returns the human's display name. Prefers nickname from .agent.json,
 // falls back to i18n "mail.you".
 func (m MailModel) humanName() string {
@@ -1694,5 +1757,5 @@ func (m MailModel) View() string {
 	}
 
 	// Viewport fills the middle
-	return header + "\n" + topBanner + PaintViewportBG(m.viewport.View(), m.width) + "\n" + bottomBanner + footer
+	return header + "\n" + topBanner + PaintViewportBG(m.viewportWithChatTailHint(), m.width) + "\n" + bottomBanner + footer
 }

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -1408,7 +1408,7 @@ func (m MailModel) viewportWithChatTailHint() string {
 	if lipgloss.Width(text) > maxHintWidth {
 		text = ansi.Truncate(text, maxHintWidth, "…")
 	}
-	hint := StyleFaint.Render(" " + text + " ")
+	hint := chatTailHintStyle().Render(" " + text + " ")
 	hintWidth := lipgloss.Width(hint)
 	if hintWidth <= 0 || hintWidth > m.width {
 		return view
@@ -1437,6 +1437,10 @@ func (m MailModel) viewportWithChatTailHint() string {
 	}
 	lines[row] = prefix + hint + strings.Repeat(" ", suffix)
 	return strings.Join(lines, "\n")
+}
+
+func chatTailHintStyle() lipgloss.Style {
+	return StyleSubtle
 }
 
 // humanName returns the human's display name. Prefers nickname from .agent.json,

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -1408,7 +1408,7 @@ func (m MailModel) viewportWithChatTailHint() string {
 	if lipgloss.Width(text) > maxHintWidth {
 		text = ansi.Truncate(text, maxHintWidth, "…")
 	}
-	hint := chatTailHintStyle().Render(" " + text + " ")
+	hint := chatTailHintStyle().Render(text)
 	hintWidth := lipgloss.Width(hint)
 	if hintWidth <= 0 || hintWidth > m.width {
 		return view
@@ -1423,19 +1423,11 @@ func (m MailModel) viewportWithChatTailHint() string {
 	// non-focus and non-layout-affecting: no scroll, history, or input state
 	// changes are needed just to render it.
 	row := len(lines) - 1
-	start := m.width - hintWidth - 2
-	if start < 0 {
-		start = 0
-	}
-	prefix := ansi.Cut(lines[row], 0, start)
-	if pad := start - lipgloss.Width(prefix); pad > 0 {
-		prefix += strings.Repeat(" ", pad)
-	}
-	suffix := m.width - lipgloss.Width(prefix) - hintWidth
+	suffix := m.width - hintWidth
 	if suffix < 0 {
 		suffix = 0
 	}
-	lines[row] = prefix + hint + strings.Repeat(" ", suffix)
+	lines[row] = hint + strings.Repeat(" ", suffix)
 	return strings.Join(lines, "\n")
 }
 

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -945,6 +945,12 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 			m.viewport, cmd = m.viewport.Update(msg)
 			return m, cmd
 
+		case "ctrl+end":
+			if m.ready {
+				m.viewport.GotoBottom()
+				return m, nil
+			}
+
 		case "esc":
 			// Dismiss all visible insights
 			changed := false

--- a/tui/internal/tui/mail_ctrl_end_test.go
+++ b/tui/internal/tui/mail_ctrl_end_test.go
@@ -64,6 +64,26 @@ func hasChatTailHint(m MailModel) bool {
 	return strings.Contains(m.View(), i18n.T("mail.jump_bottom_hint"))
 }
 
+func TestMailChatTailHintStyleReadableOnDarkBackground(t *testing.T) {
+	prevTheme := ActiveTheme()
+	SetTheme(ThemeInkDark())
+	t.Cleanup(func() {
+		SetTheme(prevTheme)
+	})
+
+	got := colorToHex(chatTailHintStyle().GetForeground())
+	want := colorToHex(ColorTextDim)
+	if got != want {
+		t.Fatalf("chat-tail hint foreground = %s, want readable secondary text %s", got, want)
+	}
+	if got == colorToHex(ColorTextFaint) {
+		t.Fatalf("chat-tail hint foreground must not use faintest text color %s on dark backgrounds", got)
+	}
+	if chatTailHintStyle().GetFaint() {
+		t.Fatal("chat-tail hint style must not rely on ANSI faint rendering for dark-background readability")
+	}
+}
+
 func TestMailCtrlEndKeyRepresentation(t *testing.T) {
 	ctrlEndKey(t)
 }

--- a/tui/internal/tui/mail_ctrl_end_test.go
+++ b/tui/internal/tui/mail_ctrl_end_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/anthropics/lingtai-tui/i18n"
 )
@@ -170,6 +171,28 @@ func TestMailChatTailHintVisibility(t *testing.T) {
 			t.Fatalf("chat-tail hint should be visible when more than one page from bottom")
 		}
 	})
+}
+
+func TestMailChatTailHintAnchoredBottomLeft(t *testing.T) {
+	m := newSizedMailModel(t)
+	m.initialLoading = false
+	setMailViewportLineCount(t, &m, m.viewport.Height()*3)
+	m.viewport.SetYOffset(mailViewportBottomOffset(m) - m.viewport.Height() - 1)
+
+	view := ansi.Strip(m.viewportWithChatTailHint())
+	lines := strings.Split(view, "\n")
+	if len(lines) == 0 {
+		t.Fatalf("viewport render should have at least one row")
+	}
+
+	text := i18n.T("mail.jump_bottom_hint")
+	lastRow := lines[len(lines)-1]
+	if idx := strings.Index(lastRow, text); idx != 0 {
+		t.Fatalf("chat-tail hint should start at viewport column 0, got index %d in row %q", idx, lastRow)
+	}
+	if previousRows := strings.Join(lines[:len(lines)-1], "\n"); strings.Contains(previousRows, text) {
+		t.Fatalf("chat-tail hint should render on the bottom viewport row only:\n%s", view)
+	}
 }
 
 func TestMailCtrlEndHidesChatTailHint(t *testing.T) {

--- a/tui/internal/tui/mail_ctrl_end_test.go
+++ b/tui/internal/tui/mail_ctrl_end_test.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func ctrlEndKey(t *testing.T) tea.KeyPressMsg {
+	t.Helper()
+	k := tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModCtrl}
+	if got := k.String(); got != "ctrl+end" {
+		t.Fatalf("ctrl+end keypress String() = %q, want %q", got, "ctrl+end")
+	}
+	if key := k.Key(); key.Code != tea.KeyEnd || key.Mod != tea.ModCtrl {
+		t.Fatalf("ctrl+end keypress Key() = {Code:%v Mod:%v}, want {Code:%v Mod:%v}", key.Code, key.Mod, tea.KeyEnd, tea.ModCtrl)
+	}
+	return k
+}
+
+func scrollableMailModel(t *testing.T) MailModel {
+	t.Helper()
+	m := newSizedMailModel(t)
+	content := strings.TrimSuffix(strings.Repeat("message line\n", m.viewport.Height()+30), "\n")
+	m.viewport.SetContent(content)
+	m.viewport.GotoBottom()
+	if !m.viewport.AtBottom() || m.viewport.YOffset() == 0 {
+		t.Fatalf("precondition: viewport should have scrollable content at bottom, offset=%d height=%d", m.viewport.YOffset(), m.viewport.Height())
+	}
+	m.viewport.GotoTop()
+	if m.viewport.AtBottom() {
+		t.Fatalf("precondition: viewport should be away from bottom")
+	}
+	return m
+}
+
+func TestMailCtrlEndKeyRepresentation(t *testing.T) {
+	ctrlEndKey(t)
+}
+
+func TestMailCtrlEndJumpsViewportToBottom(t *testing.T) {
+	m := scrollableMailModel(t)
+	m.loadedExtra = m.pageSize
+	before := m.viewport.YOffset()
+
+	updated, cmd := m.Update(ctrlEndKey(t))
+	if cmd != nil {
+		t.Fatalf("ctrl+end should not return a command")
+	}
+	if !updated.viewport.AtBottom() {
+		t.Fatalf("ctrl+end should jump viewport to bottom, before offset=%d after offset=%d", before, updated.viewport.YOffset())
+	}
+	if updated.viewport.YOffset() <= before {
+		t.Fatalf("ctrl+end should increase viewport offset, before=%d after=%d", before, updated.viewport.YOffset())
+	}
+	if updated.loadedExtra != m.loadedExtra {
+		t.Fatalf("ctrl+end should not collapse loaded history, loadedExtra=%d want %d", updated.loadedExtra, m.loadedExtra)
+	}
+}
+
+func TestMailCtrlEndOverlayPriority(t *testing.T) {
+	t.Run("editor warning", func(t *testing.T) {
+		m := scrollableMailModel(t)
+		m.showEditorWarn = true
+
+		updated, cmd := m.Update(ctrlEndKey(t))
+		if cmd != nil {
+			t.Fatalf("ctrl+end under editor warning should not return a command")
+		}
+		if updated.viewport.AtBottom() {
+			t.Fatalf("ctrl+end should not move viewport while editor warning is active")
+		}
+		if !updated.showEditorWarn {
+			t.Fatalf("ctrl+end should leave editor warning active")
+		}
+	})
+
+	t.Run("slash palette", func(t *testing.T) {
+		m := scrollableMailModel(t)
+		m.input.SetValue("/help")
+		if !m.input.IsPaletteActive() {
+			t.Fatalf("precondition: slash palette should be active")
+		}
+
+		updated, _ := m.Update(ctrlEndKey(t))
+		if updated.viewport.AtBottom() {
+			t.Fatalf("ctrl+end should not move viewport while slash palette is active")
+		}
+		if !updated.input.IsPaletteActive() {
+			t.Fatalf("ctrl+end should leave slash palette active")
+		}
+	})
+}

--- a/tui/internal/tui/mail_ctrl_end_test.go
+++ b/tui/internal/tui/mail_ctrl_end_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/anthropics/lingtai-tui/i18n"
 )
 
 func ctrlEndKey(t *testing.T) tea.KeyPressMsg {
@@ -35,6 +37,33 @@ func scrollableMailModel(t *testing.T) MailModel {
 	return m
 }
 
+func setMailViewportLineCount(t *testing.T, m *MailModel, lineCount int) {
+	t.Helper()
+	if lineCount < 1 {
+		lineCount = 1
+	}
+	lines := make([]string, lineCount)
+	for i := range lines {
+		lines[i] = "message line"
+	}
+	m.viewport.SetContent(strings.Join(lines, "\n"))
+	if got := m.viewport.TotalLineCount(); got != lineCount {
+		t.Fatalf("viewport line count = %d, want %d", got, lineCount)
+	}
+}
+
+func mailViewportBottomOffset(m MailModel) int {
+	bottom := m.viewport.TotalLineCount() - m.viewport.Height()
+	if bottom < 0 {
+		return 0
+	}
+	return bottom
+}
+
+func hasChatTailHint(m MailModel) bool {
+	return strings.Contains(m.View(), i18n.T("mail.jump_bottom_hint"))
+}
+
 func TestMailCtrlEndKeyRepresentation(t *testing.T) {
 	ctrlEndKey(t)
 }
@@ -42,6 +71,10 @@ func TestMailCtrlEndKeyRepresentation(t *testing.T) {
 func TestMailCtrlEndJumpsViewportToBottom(t *testing.T) {
 	m := scrollableMailModel(t)
 	m.loadedExtra = m.pageSize
+	m.input.SetValue("draft")
+	if !m.input.Focused() {
+		t.Fatalf("precondition: compose textarea should be focused")
+	}
 	before := m.viewport.YOffset()
 
 	updated, cmd := m.Update(ctrlEndKey(t))
@@ -56,6 +89,87 @@ func TestMailCtrlEndJumpsViewportToBottom(t *testing.T) {
 	}
 	if updated.loadedExtra != m.loadedExtra {
 		t.Fatalf("ctrl+end should not collapse loaded history, loadedExtra=%d want %d", updated.loadedExtra, m.loadedExtra)
+	}
+	if !updated.input.Focused() || updated.input.Value() != "draft" {
+		t.Fatalf("ctrl+end should leave compose focus/value unchanged, focused=%v value=%q", updated.input.Focused(), updated.input.Value())
+	}
+}
+
+func TestMailCtrlEndNotReadyReturnsNoop(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m.input.SetValue("draft")
+
+	updated, cmd := m.Update(ctrlEndKey(t))
+	if cmd != nil {
+		t.Fatalf("ctrl+end before ready should not return a command")
+	}
+	if updated.ready {
+		t.Fatalf("ctrl+end before ready should not mark mail ready")
+	}
+	if updated.input.Value() != "draft" {
+		t.Fatalf("ctrl+end before ready should not alter input value: %q", updated.input.Value())
+	}
+}
+
+func TestMailChatTailHintVisibility(t *testing.T) {
+	t.Run("hidden at bottom", func(t *testing.T) {
+		m := newSizedMailModel(t)
+		m.initialLoading = false
+		setMailViewportLineCount(t, &m, m.viewport.Height()*3)
+		m.viewport.GotoBottom()
+
+		if hasChatTailHint(m) {
+			t.Fatalf("chat-tail hint should be hidden at bottom")
+		}
+	})
+
+	t.Run("hidden one page from bottom", func(t *testing.T) {
+		m := newSizedMailModel(t)
+		m.initialLoading = false
+		setMailViewportLineCount(t, &m, m.viewport.Height()*3)
+		m.viewport.SetYOffset(mailViewportBottomOffset(m) - m.viewport.Height())
+		if got, want := m.chatTailRemainingLines(), m.viewport.Height(); got != want {
+			t.Fatalf("remaining lines = %d, want exactly one page (%d)", got, want)
+		}
+
+		if hasChatTailHint(m) {
+			t.Fatalf("chat-tail hint should be hidden at one page from bottom")
+		}
+	})
+
+	t.Run("visible more than one page from bottom", func(t *testing.T) {
+		m := newSizedMailModel(t)
+		m.initialLoading = false
+		setMailViewportLineCount(t, &m, m.viewport.Height()*3)
+		m.viewport.SetYOffset(mailViewportBottomOffset(m) - m.viewport.Height() - 1)
+		if got, want := m.chatTailRemainingLines(), m.viewport.Height()+1; got != want {
+			t.Fatalf("remaining lines = %d, want just over one page (%d)", got, want)
+		}
+
+		if !hasChatTailHint(m) {
+			t.Fatalf("chat-tail hint should be visible when more than one page from bottom")
+		}
+	})
+}
+
+func TestMailCtrlEndHidesChatTailHint(t *testing.T) {
+	m := newSizedMailModel(t)
+	m.initialLoading = false
+	setMailViewportLineCount(t, &m, m.viewport.Height()*3)
+	m.viewport.SetYOffset(mailViewportBottomOffset(m) - m.viewport.Height() - 1)
+	if !hasChatTailHint(m) {
+		t.Fatalf("precondition: chat-tail hint should be visible before ctrl+end")
+	}
+
+	updated, cmd := m.Update(ctrlEndKey(t))
+	if cmd != nil {
+		t.Fatalf("ctrl+end should not return a command")
+	}
+	if !updated.viewport.AtBottom() {
+		t.Fatalf("ctrl+end should jump to bottom")
+	}
+	if hasChatTailHint(updated) {
+		t.Fatalf("chat-tail hint should hide after ctrl+end jumps to bottom")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a mail/chat viewport shortcut and discoverability hint for returning to the latest loaded chat content:

- `Ctrl+End` jumps the mail chat viewport to the bottom when the viewport is ready.
- A localized `Jump to bottom: Ctrl+End` hint appears only when the chat viewport is more than one viewport page away from the bottom.
- The hint is anchored at the bottom-left of the chat viewport, remains render-only, and does not change history loading, input focus/value, or scroll state except when the user presses `Ctrl+End`.
- The hint uses the existing subtle text color rather than the faintest text color so it remains readable on the default dark background.

## Behavior

- Overlay and palette states keep priority: editor warnings and the slash palette continue to receive/own key handling before the chat-tail shortcut.
- `Ctrl+End` intentionally takes precedence over the textarea's default cursor-end behavior while preserving compose focus/value; textarea alternatives such as `Alt+>` remain available.
- If the mail viewport is not ready, `Ctrl+End` is an explicit no-op.
- The hint appears only when the remaining scroll distance is greater than one viewport page, and disappears at/near the bottom or after `Ctrl+End` jumps to the tail.
- No new key aliases are added.

## Non-goals

- No automatic scrolling.
- No change to older-history loading/collapse behavior.
- No new mode or persistent UI state.
- No changes to live runtime configuration.

## Validation

- `go test ./internal/tui -run 'TestMail(CtrlEnd|ChatTailHint)' -count=1`
- `go vet ./internal/tui`
- `git diff --check canonical/main...HEAD`
- Local render smoke using `MailModel.View()` at an 80x24 frame verified the hint is visible when more than one page from the bottom, hidden after a simulated `Ctrl+End`, and hidden exactly one page from the bottom.
- Dark-theme contrast check: the hint now uses `ColorTextDim` (`#8a8680`) instead of the faintest text color (`#4a4845`) on the default dark background (`#161718`), avoiding the ANSI faint attribute while keeping the hint visually secondary.
