### PR TITLE
fix(update): skip TUI updater when already latest

### DIFF
--- a/tui/internal/config/tui_updater.go
+++ b/tui/internal/config/tui_updater.go
@@ -135,7 +135,10 @@ func RunManualTUIUpdate(globalDir string, opts ManualTUIUpdateOptions) TUIUpdate
 			case releaseNewer(current, release.TagName):
 				result.add(DoctorWarn, "TUI update available: %s -> %s", current, release.TagName)
 			default:
-				result.add(DoctorOK, "Latest release is not newer than current TUI version; running updater anyway")
+				// Already at (or ahead of) the latest release: skip the updater
+				// entirely so we don't run Homebrew for a no-op upgrade.
+				result.add(DoctorOK, "TUI is already at the latest version (%s)", release.TagName)
+				return result
 			}
 		}
 	}

--- a/tui/internal/config/tui_updater_test.go
+++ b/tui/internal/config/tui_updater_test.go
@@ -217,6 +217,42 @@ func TestManualTUIUpdateHomebrewRoutesThroughUpdater(t *testing.T) {
 	}
 }
 
+func TestManualTUIUpdateSkipsWhenAlreadyLatest(t *testing.T) {
+	runner := &fakeRunner{}
+	report := RunManualTUIUpdate(t.TempDir(), ManualTUIUpdateOptions{
+		CurrentTUIVersion: "v0.8.1",
+		HTTPClient:        testVersionClient(t, "0.9.7", "v0.8.1"),
+		Runner:            runner,
+		LookPath: func(name string) (string, error) {
+			if name == "brew" {
+				return "/opt/homebrew/bin/brew", nil
+			}
+			return "", errors.New("not found")
+		},
+		Executable: func() (string, error) { return "/opt/homebrew/bin/__lingtai_doctor_test_lingtai_tui__", nil },
+		LookupEnv:  func(string) (string, bool) { return "", false },
+	})
+
+	if !report.Healthy {
+		t.Fatalf("already-latest result should be healthy: %+v", report)
+	}
+	if report.Updated {
+		t.Fatalf("already-latest result should not report an update: %+v", report)
+	}
+	if report.Err != nil {
+		t.Fatalf("already-latest result should have no error: %v", report.Err)
+	}
+	if !containsLine(report.Lines, "TUI is already at the latest version (v0.8.1)") {
+		t.Fatalf("expected already-latest line: %+v", report.Lines)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("already-latest update must not run any commands, got %#v", runner.calls)
+	}
+	if containsCall(runner.calls, "brew") {
+		t.Fatalf("already-latest update must not run brew, got %#v", runner.calls)
+	}
+}
+
 func TestManualTUIUpdateSourceInstallSucceeds(t *testing.T) {
 	globalDir := t.TempDir()
 	prefix := t.TempDir()


### PR DESCRIPTION
## Summary
- Skip the manual TUI updater when the current TUI version is already at the latest GitHub release.
- Replace the old "running updater anyway" fallthrough with an early healthy no-op result.
- Add regression coverage proving the already-latest path runs no Homebrew/fake runner commands.

Fixes #552.

## Validation
- `cd tui && go test ./internal/config`
- `cd tui && go test ./internal/config -run 'ManualTUIUpdate|TUIUpdater' -v`
- `cd tui && go test ./...`
- `cd tui && go build ./...`
- `git diff --check`
