### PR TITLE
fix: abort clean when agents fail to suspend within deadline (#562)

### DIFF
--- a/tui/clean_test.go
+++ b/tui/clean_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeHeartbeat(t *testing.T, dir string, ts time.Time) {
+	t.Helper()
+	content := fmt.Sprintf("%.6f", float64(ts.UnixNano())/1e9)
+	if err := os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAliveDirs_FreshAndStaleHeartbeats(t *testing.T) {
+	fresh := t.TempDir()
+	stale := t.TempDir()
+	missing := t.TempDir()
+	garbage := t.TempDir()
+
+	writeHeartbeat(t, fresh, time.Now())
+	writeHeartbeat(t, stale, time.Now().Add(-60*time.Second))
+	if err := os.WriteFile(filepath.Join(garbage, ".agent.heartbeat"), []byte("not-a-number"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := aliveDirs([]string{fresh, stale, missing, garbage}, 3.0)
+	if len(got) != 1 || got[0] != fresh {
+		t.Fatalf("aliveDirs = %v, want only %q", got, fresh)
+	}
+}
+
+func TestWaitForSuspend_ReturnsEmptyWhenAgentsDie(t *testing.T) {
+	dir := t.TempDir()
+	writeHeartbeat(t, dir, time.Now())
+
+	// With a 0.5s threshold and no refresher, the heartbeat goes stale
+	// mid-wait; waitForSuspend should return before the full 5s timeout.
+	start := time.Now()
+	survivors := waitForSuspend([]string{dir}, 5*time.Second, 0.5)
+	elapsed := time.Since(start)
+
+	if len(survivors) != 0 {
+		t.Fatalf("survivors = %v, want none", survivors)
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("waitForSuspend took %v, expected early return before timeout", elapsed)
+	}
+}
+
+func TestWaitForSuspend_ReturnsSurvivorsOnTimeout(t *testing.T) {
+	dir := t.TempDir()
+	writeHeartbeat(t, dir, time.Now())
+
+	// Keep the heartbeat fresh for the duration of the wait, simulating an
+	// agent that never suspends. Under the old code this state fell through
+	// to os.RemoveAll and created a phantom.
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				// Write via rename so a concurrent poll never reads a
+				// truncated file. (Not writeHeartbeat: t.Fatal must not
+				// run off the test goroutine.)
+				content := fmt.Sprintf("%.6f", float64(time.Now().UnixNano())/1e9)
+				tmp := filepath.Join(dir, ".agent.heartbeat.tmp")
+				os.WriteFile(tmp, []byte(content), 0o644)
+				os.Rename(tmp, filepath.Join(dir, ".agent.heartbeat"))
+			}
+		}
+	}()
+
+	survivors := waitForSuspend([]string{dir}, 1*time.Second, 3.0)
+	close(stop)
+	<-done
+
+	if len(survivors) != 1 || survivors[0] != dir {
+		t.Fatalf("survivors = %v, want [%q]", survivors, dir)
+	}
+}
+
+func TestWaitForSuspend_NoDirs(t *testing.T) {
+	start := time.Now()
+	survivors := waitForSuspend(nil, 5*time.Second, 3.0)
+	if len(survivors) != 0 {
+		t.Fatalf("survivors = %v, want none", survivors)
+	}
+	if time.Since(start) >= 1*time.Second {
+		t.Fatalf("waitForSuspend with no dirs should return immediately")
+	}
+}

--- a/tui/main.go
+++ b/tui/main.go
@@ -624,7 +624,7 @@ func printHelp() {
 	fmt.Println("       lingtai-tui purge [dir]")
 	fmt.Println("       lingtai-tui list [--detailed|-d] [--admin] [dir]")
 	fmt.Println("       lingtai-tui suspend [dir]")
-	fmt.Println("       lingtai-tui clean")
+	fmt.Println("       lingtai-tui clean [--force]")
 	fmt.Println("       lingtai-tui postman [--port N] [dir ...]")
 	fmt.Println("       lingtai-tui bootstrap")
 	fmt.Println("       lingtai-tui presets [--saved-only] [--templates-only]")
@@ -640,6 +640,7 @@ func printHelp() {
 	fmt.Println("               Marks main agents; --detailed adds names/state/path; --admin adds admin flags.")
 	fmt.Println("  suspend      Gracefully suspend agents via signal files (all, or those in <dir>)")
 	fmt.Println("  clean        Suspend agents in current directory, then remove .lingtai/")
+	fmt.Println("               Aborts if agents survive the 10s deadline unless --force is given.")
 	fmt.Println("  postman      Start the mail relay daemon (UDP, port 7777 by default)")
 	fmt.Println("  bootstrap       Re-extract embedded skills to ~/.lingtai-tui/utilities/")
 	fmt.Println("  presets      List available presets as JSON (for agent consumption)")
@@ -819,7 +820,40 @@ func showWelcome(globalDir string) {
 	os.WriteFile(sentinel, []byte(time.Now().Format(time.RFC3339)+"\n"), 0o644)
 }
 
+// aliveDirs returns the subset of dirs whose agent heartbeats are fresher
+// than threshold seconds.
+func aliveDirs(dirs []string, threshold float64) []string {
+	var out []string
+	for _, d := range dirs {
+		if fs.IsAlive(d, threshold) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// waitForSuspend polls the given agent dirs until their heartbeats go stale
+// or the timeout elapses. Returns the dirs still alive at the end (empty
+// slice = clean shutdown).
+func waitForSuspend(dirs []string, timeout time.Duration, threshold float64) []string {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(aliveDirs(dirs, threshold)) == 0 {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return aliveDirs(dirs, threshold)
+}
+
 func cleanMain() {
+	force := false
+	for _, a := range os.Args[2:] {
+		if a == "--force" || a == "-f" {
+			force = true
+		}
+	}
+
 	projectDir, _ := os.Getwd()
 	projectDir, _ = filepath.Abs(projectDir)
 	lingtaiDir := filepath.Join(projectDir, ".lingtai")
@@ -868,19 +902,22 @@ func cleanMain() {
 	// Wait for all to die (poll, max 10s)
 	if len(alive) > 0 {
 		fmt.Printf("Suspending %d agent(s)...\n", len(alive))
-		deadline := time.Now().Add(10 * time.Second)
-		for time.Now().Before(deadline) {
-			allDead := true
-			for _, dir := range alive {
-				if fs.IsAlive(dir, 3.0) {
-					allDead = false
-					break
-				}
+		survivors := waitForSuspend(alive, 10*time.Second, 3.0)
+		if len(survivors) > 0 && !force {
+			fmt.Fprintf(os.Stderr, "%d agent(s) did not suspend within 10s:\n", len(survivors))
+			for _, dir := range survivors {
+				fmt.Fprintf(os.Stderr, "  %s\n", dir)
 			}
-			if allDead {
-				break
-			}
-			time.Sleep(250 * time.Millisecond)
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Not removing .lingtai/ — deleting it now would orphan these processes (phantoms).")
+			fmt.Fprintln(os.Stderr, "Options:")
+			fmt.Fprintln(os.Stderr, "  1. Wait a moment and re-run: lingtai-tui clean")
+			fmt.Fprintf(os.Stderr, "  2. Force-kill the processes: lingtai-tui purge %s\n", projectDir)
+			fmt.Fprintln(os.Stderr, "  3. Delete anyway (creates phantoms): lingtai-tui clean --force")
+			os.Exit(1)
+		}
+		if len(survivors) > 0 {
+			fmt.Fprintf(os.Stderr, "warning: removing .lingtai/ with %d agent(s) still alive (--force); run 'lingtai-tui purge' afterwards to kill them\n", len(survivors))
 		}
 	}
 


### PR DESCRIPTION
## Summary

`lingtai-tui clean` signaled agents to suspend, polled heartbeats for up to 10s, and then deleted `.lingtai/` unconditionally — even when the deadline expired with agents still heartbeating, silently orphaning them as the exact phantom processes the TUI's own welcome text warns about.

This PR:

- Extracts the poll loop into two testable helpers in `tui/main.go`: `aliveDirs(dirs, threshold)` and `waitForSuspend(dirs, timeout, threshold)`. The latter re-checks liveness **after** the deadline and returns the surviving dirs — the check the old code was missing.
- Gates `os.RemoveAll(lingtaiDir)` on that result: if agents survive the 10s deadline, `clean` lists them, refuses to delete, exits 1, and tells the user to re-run `clean`, run `lingtai-tui purge <dir>`, or pass `--force`.
- Adds a `--force`/`-f` flag to `clean` that preserves the old always-delete behavior (with a loud warning) for scripted teardown or stale-heartbeat edge cases.
- Updates `printHelp` to document `clean [--force]` and the new abort behavior.

The 3.0s liveness threshold and 250ms poll interval are unchanged, as are the happy path (all agents suspend in time) and the no-agents path.

Closes #562

## Testing

New `tui/clean_test.go` (package `main`, plain temp dirs + heartbeat files):

- `TestAliveDirs_FreshAndStaleHeartbeats` — fresh vs. 60s-stale vs. missing vs. garbage heartbeat.
- `TestWaitForSuspend_ReturnsEmptyWhenAgentsDie` — heartbeat goes stale mid-wait; early return, no survivors.
- `TestWaitForSuspend_ReturnsSurvivorsOnTimeout` — a goroutine keeps the heartbeat fresh (atomic rename writes); the dir is reported as a survivor. This is the regression test: under the old code this state fell through to deletion.
- `TestWaitForSuspend_NoDirs` — empty input returns immediately.

Ran `go build ./...`, `go vet ./...`, and `go test ./...` in `tui/` — all pass (new tests run 5x with `-count=5` to check for flakes).

## Caveats

- `clean` can now exit 1 without deleting; scripts relying on unconditional deletion must pass `--force` (they already had to pipe `y` into the confirm prompt, so fully non-interactive use is rare).
- A crash that leaves a <3s-old heartbeat can cause a false "survivor" abort; re-running `clean` a few seconds later or `--force` covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
