### PR TITLE
fix(tui): show api call group separators

### DIFF
--- a/tui/internal/tui/apriori_summary_render_test.go
+++ b/tui/internal/tui/apriori_summary_render_test.go
@@ -234,7 +234,7 @@ func TestShouldShow_AprioriSummaryFollowsToolVerbosity(t *testing.T) {
 }
 
 // The summary shares the raw result's api_call_id, so it must NOT introduce a
-// blank separator between the raw result and its summary.
+// separator between the raw result and its summary.
 func TestRenderMessages_SummaryStaysGroupedWithItsToolResult(t *testing.T) {
 	m := MailModel{width: 100}
 	out := m.renderMessages([]ChatMessage{
@@ -243,7 +243,7 @@ func TestRenderMessages_SummaryStaysGroupedWithItsToolResult(t *testing.T) {
 			Kind: "apriori_generated", ToolName: "bash", Text: "ok summary", SummaryChars: 10,
 		}},
 	})
-	if strings.Contains(out, "\n\n") {
-		t.Fatalf("summary sharing the tool_result api_call_id must stay grouped (no blank separator):\n%q", out)
+	if strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("summary sharing the tool_result api_call_id must stay grouped (no separator):\n%q", out)
 	}
 }

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -1083,7 +1083,7 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 	// llm_response carrier that holds the scalars arrives at the TOP of the
 	// group in stream order (llm_call → llm_response → tool_call/tool_result),
 	// so we stash it and flush a single faint footer line once the group ends:
-	// before the blank separator that precedes the next group, when a
+	// before the visual separator that precedes the next group, when a
 	// non-grouped entry breaks the run, or at end of stream.
 	tokenFooterStyle := lipgloss.NewStyle().Foreground(ColorTextDim).Faint(true)
 	var pendingUsage *fs.TokenUsage
@@ -1136,12 +1136,12 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 			switch msg.Type {
 			case "thinking", "diary", "text_input", "text_output":
 				if apiCallGroupSeparatorBefore(prevVisibleApiGroup, msg) {
-					b.WriteString("\n")
+					b.WriteString(renderApiCallGroupSeparator(m.width) + "\n")
 				}
 				evStyle = thinkingStyle
 			default:
 				if apiCallGroupSeparatorBefore(prevVisibleApiGroup, msg) {
-					b.WriteString("\n")
+					b.WriteString(renderApiCallGroupSeparator(m.width) + "\n")
 				}
 				evStyle = toolStyle
 				// Tool lines get a leading timestamp. Ctrl+O level 1 shows only
@@ -1193,7 +1193,7 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 				wrapWidth = 20
 			}
 			if apiCallGroupSeparatorBefore(prevVisibleApiGroup, msg) {
-				b.WriteString("\n")
+				b.WriteString(renderApiCallGroupSeparator(m.width) + "\n")
 			}
 			for _, line := range renderAprioriSummaryBlock(msg.Summary, wrapWidth, m.verbose != verboseExtended) {
 				b.WriteString(line + "\n")

--- a/tui/internal/tui/toolcall_display.go
+++ b/tui/internal/tui/toolcall_display.go
@@ -88,9 +88,9 @@ func compactToolCallSummary(body string) string {
 	return string(runes[:toolCallSummaryPreviewLimit]) + "…"
 }
 
-// toolGroupSeparatorBefore reports whether a blank separator line should be
-// rendered before the current tool entry to visually group tool calls/results
-// by the LLM API response that produced them.
+// toolGroupSeparatorBefore reports whether a separator line should be rendered
+// before the current tool entry to visually group tool calls/results by the LLM
+// API response that produced them.
 func toolGroupSeparatorBefore(prev *ChatMessage, cur ChatMessage) bool {
 	if prev == nil || !isToolMessageType(prev.Type) || !isToolMessageType(cur.Type) {
 		return false
@@ -115,7 +115,7 @@ func isApiGroupedVerboseMessageType(t string) bool {
 	}
 }
 
-// apiCallGroupSeparatorBefore reports whether a blank separator line should be
+// apiCallGroupSeparatorBefore reports whether a separator line should be
 // rendered before cur in the ctrl+o verbose stream. Thinking/diary/text/tool
 // entries that share an api_call_id came from the same LLM API round-trip and
 // stay visually grouped; a non-empty api_call_id change starts a new group.
@@ -129,6 +129,14 @@ func apiCallGroupSeparatorBefore(prev *ChatMessage, cur ChatMessage) bool {
 		return prev.ApiCallID != cur.ApiCallID
 	}
 	return toolGroupSeparatorBefore(prev, cur)
+}
+
+func renderApiCallGroupSeparator(width int) string {
+	separatorWidth := width - 4
+	if separatorWidth < 8 {
+		separatorWidth = 8
+	}
+	return StyleFaint.Render("  " + strings.Repeat("┈", separatorWidth))
 }
 
 // renderAprioriSummaryBlock renders the model-visible `summary=true` (a-priori)
@@ -215,7 +223,7 @@ func isTextOutputMessageType(t string) bool {
 	return t == "text_output"
 }
 
-// textOutputGroupSeparatorBefore reports whether a blank separator line should
+// textOutputGroupSeparatorBefore reports whether a separator line should
 // be rendered before the current text_output entry to mirror tool-call grouping
 // by the LLM API response that produced the assistant text.
 func textOutputGroupSeparatorBefore(prev *ChatMessage, cur ChatMessage) bool {

--- a/tui/internal/tui/toolcall_display_test.go
+++ b/tui/internal/tui/toolcall_display_test.go
@@ -192,7 +192,7 @@ func TestTruncateToolBody_DeterministicByRune(t *testing.T) {
 	}
 }
 
-func TestRenderMessages_InsertsBlankLineBetweenApiCallGroups(t *testing.T) {
+func TestRenderMessages_InsertsVisualSeparatorBetweenApiCallGroups(t *testing.T) {
 	m := MailModel{width: 100}
 	out := m.renderMessages([]ChatMessage{
 		{Type: "tool_call", Body: "read({})", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:26Z"},
@@ -202,8 +202,8 @@ func TestRenderMessages_InsertsBlankLineBetweenApiCallGroups(t *testing.T) {
 	if !strings.Contains(out, "read → ok") || !strings.Contains(out, "bash({})") {
 		t.Fatalf("rendered output missing tool bodies: %q", out)
 	}
-	if !strings.Contains(out, "read → ok") || !strings.Contains(out, "\n\n") {
-		t.Fatalf("expected a blank separator line between api groups, got %q", out)
+	if !strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("expected a visual separator line between api groups, got %q", out)
 	}
 }
 
@@ -214,8 +214,8 @@ func TestRenderMessages_DoesNotSeparateSameApiCallGroup(t *testing.T) {
 		{Type: "tool_result", Body: "read → ok", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:27Z"},
 		{Type: "tool_call", Body: "bash({})", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:28Z"},
 	})
-	if strings.Contains(out, "\n\n") {
-		t.Fatalf("same api_call_id should render as one group without blank separator: %q", out)
+	if strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("same api_call_id should render as one group without separator: %q", out)
 	}
 }
 
@@ -259,7 +259,7 @@ func TestTextOutputGroupSeparatorBefore_NonTextBoundariesNoSeparator(t *testing.
 	}
 }
 
-func TestRenderMessages_InsertsBlankLineBetweenTextOutputApiCallGroups(t *testing.T) {
+func TestRenderMessages_InsertsVisualSeparatorBetweenTextOutputApiCallGroups(t *testing.T) {
 	m := MailModel{width: 100}
 	out := m.renderMessages([]ChatMessage{
 		{Type: "text_output", Body: "first answer", ApiCallID: "api_one"},
@@ -268,8 +268,8 @@ func TestRenderMessages_InsertsBlankLineBetweenTextOutputApiCallGroups(t *testin
 	if !strings.Contains(out, "first answer") || !strings.Contains(out, "second answer") {
 		t.Fatalf("rendered output missing text_output bodies: %q", out)
 	}
-	if !strings.Contains(out, "\n\n") {
-		t.Fatalf("expected a blank separator line between text_output api groups, got %q", out)
+	if !strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("expected a visual separator line between text_output api groups, got %q", out)
 	}
 }
 
@@ -279,8 +279,8 @@ func TestRenderMessages_DoesNotSeparateSameTextOutputApiCallGroup(t *testing.T) 
 		{Type: "text_output", Body: "first chunk", ApiCallID: "api_one"},
 		{Type: "text_output", Body: "second chunk", ApiCallID: "api_one"},
 	})
-	if strings.Contains(out, "\n\n") {
-		t.Fatalf("same text_output api_call_id should render as one group without blank separator: %q", out)
+	if strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("same text_output api_call_id should render as one group without separator: %q", out)
 	}
 }
 
@@ -319,7 +319,7 @@ func TestBuildMessagesAssignsApiCallIDToTextOutput(t *testing.T) {
 	}
 }
 
-func TestRenderMessages_InsertsBlankLineBetweenDiaryApiCallGroups(t *testing.T) {
+func TestRenderMessages_InsertsVisualSeparatorBetweenDiaryApiCallGroups(t *testing.T) {
 	m := MailModel{width: 100}
 	out := m.renderMessages([]ChatMessage{
 		{Type: "diary", Body: "first diary", ApiCallID: "api_one"},
@@ -328,8 +328,8 @@ func TestRenderMessages_InsertsBlankLineBetweenDiaryApiCallGroups(t *testing.T) 
 	if !strings.Contains(out, "first diary") || !strings.Contains(out, "second diary") {
 		t.Fatalf("rendered output missing diary bodies: %q", out)
 	}
-	if !strings.Contains(out, "\n\n") {
-		t.Fatalf("expected a blank separator line between diary api groups, got %q", out)
+	if !strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("expected a visual separator line between diary api groups, got %q", out)
 	}
 }
 
@@ -341,7 +341,7 @@ func TestRenderMessages_KeepsMixedVerboseEntriesInSameApiCallGroup(t *testing.T)
 		{Type: "tool_call", Body: "read({})", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:26Z"},
 		{Type: "tool_result", Body: "read ok", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:27Z"},
 	})
-	if strings.Contains(out, "\n\n") {
+	if strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
 		t.Fatalf("mixed verbose entries from the same api_call_id should stay grouped, got %q", out)
 	}
 }
@@ -356,8 +356,8 @@ func TestRenderMessages_SeparatesMixedVerboseApiCallGroups(t *testing.T) {
 	if !strings.Contains(out, "first diary") || !strings.Contains(out, "second diary") {
 		t.Fatalf("rendered output missing mixed verbose bodies: %q", out)
 	}
-	if !strings.Contains(out, "\n\n") {
-		t.Fatalf("expected a blank separator line before the new api group, got %q", out)
+	if !strings.Contains(out, "┈") || strings.Contains(out, "\n\n") {
+		t.Fatalf("expected a visual separator line before the new api group, got %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the blank API-call group gap in the TUI replay with a faint dotted visual separator
- keep same-`api_call_id` verbose/tool entries grouped without a separator
- update focused render tests to assert separator presence/absence for tool calls, text output, diary, mixed groups, and apriori summaries

## Scope / taste check
- Checked with the local `lingtai-taste` skill before implementation.
- This stays in the TUI rendering/presentation layer only: no runtime/API/log/persistence/config/settings changes.
- Claude Code was unavailable due a session limit, so implementation was delegated to Codex CLI and then independently reviewed/validated.

## Validation
- `GOCACHE=/tmp/lingtai-go-build-cache go test ./internal/tui -run 'ApiCall|Separator|RenderMessages' -count=1`
- `GOCACHE=/tmp/lingtai-go-build-cache go test ./internal/tui -count=1`
- `GOCACHE=/tmp/lingtai-go-build-cache go build ./...`
- `GOCACHE=/tmp/lingtai-go-build-cache go test ./... -count=1`
- `git diff --check`
