### PR TITLE
test(tui): avoid opening browser in OAuth flow tests

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1702,7 +1702,9 @@ func isWSL() bool {
 	return strings.Contains(s, "microsoft") || strings.Contains(s, "wsl")
 }
 
-func openBrowser(url string) {
+var openBrowser = openBrowserReal
+
+func openBrowserReal(url string) {
 	if url == "" {
 		return
 	}

--- a/tui/internal/tui/oauth_test.go
+++ b/tui/internal/tui/oauth_test.go
@@ -320,12 +320,24 @@ func drainSession(t *testing.T, session *codexOAuthSession, timeout time.Duratio
 	}
 }
 
+func suppressBrowserOpenForTest(t *testing.T) chan string {
+	t.Helper()
+	old := openBrowser
+	opened := make(chan string, 8)
+	openBrowser = func(url string) {
+		opened <- url
+	}
+	t.Cleanup(func() { openBrowser = old })
+	return opened
+}
+
 // TestStartOAuthFlow_Cancellable verifies that cancelling the supplied
 // context tears down the listener and emits an ErrCodexAuthCancelled
 // message with the caller's epoch echoed back. This is the load-bearing
 // guarantee for the Del-cancel UX in FirstRunModel and LoginModel.
 func TestStartOAuthFlow_Cancellable(t *testing.T) {
 	const epoch uint64 = 42
+	suppressBrowserOpenForTest(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	session := startOAuthFlow(ctx, epoch, false)
 
@@ -366,6 +378,7 @@ func TestStartOAuthFlow_Cancellable(t *testing.T) {
 // completes the legacy working flow without requiring terminal paste-back.
 func TestStartOAuthFlow_LoopbackCallbackCompletesLegacyBrowserFlow(t *testing.T) {
 	const epoch uint64 = 99
+	opened := suppressBrowserOpenForTest(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -386,6 +399,14 @@ func TestStartOAuthFlow_LoopbackCallbackCompletesLegacyBrowserFlow(t *testing.T)
 	state := authURL.Query().Get("state")
 	if state == "" {
 		t.Fatal("AuthURL did not include state")
+	}
+	select {
+	case got := <-opened:
+		if got != urlMsg.AuthURL {
+			t.Fatalf("browser opener URL = %q, want %q", got, urlMsg.AuthURL)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for browser opener call")
 	}
 
 	resp, err := http.Get(urlMsg.RedirectURI + "?code=browser-code&state=" + url.QueryEscape(state))
@@ -422,6 +443,7 @@ func TestStartOAuthFlow_LoopbackCallbackCompletesLegacyBrowserFlow(t *testing.T)
 // carries the caller's epoch. That's the invariant the handler relies on
 // to gate token-writes (Epoch must match m.codexLoginEpoch).
 func TestStartOAuthFlow_EpochEchoed(t *testing.T) {
+	suppressBrowserOpenForTest(t)
 	l1, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", defaultPort))
 	if err != nil {
 		t.Skipf("cannot bind :%d to force listen-failure: %v", defaultPort, err)


### PR DESCRIPTION
## Summary
- keep production `openBrowser` behavior unchanged, but route it through an injectable `openBrowser` variable
- replace real browser opening in `TestStartOAuthFlow*` with a fake/no-op opener
- assert the loopback OAuth test still attempts to open the generated `AuthURL` without invoking the OS browser

## Scope
This is a test-hermeticity PR only. It does not change Codex OAuth label behavior (#576) and does not change production login/re-auth semantics.

## Validation
- `cd tui && go test ./internal/tui -run 'TestStartOAuthFlow'`
- `cd tui && go test ./...`
- `cd tui && make build`
- `git diff --check`
- post-validation process check: no Codex.app / `codex exec` / `/usr/bin/open` / `/bin/open` processes matched

Local explainer: `reports/oauth-test-no-browser-20260707.html` (not committed).
