### PR TITLE
fix(tui): bound the /kanban detail recent-event sqlite reads

### DIFF
--- a/tui/internal/sqlitelog/molt.go
+++ b/tui/internal/sqlitelog/molt.go
@@ -11,27 +11,44 @@ import (
 	"time"
 )
 
-// moltSessionWindowQueryTimeout is a WORKER-LOCAL BACKSTOP that bounds how long
-// the molt-session-window sqlite3 subprocess may run before it is killed. It is
-// NOT the mechanism that protects the UI thread: home telemetry is gathered on a
-// background tea.Cmd (tui: fetchHomeTelemetry), never on the render (View) or
-// keypress (syncViewportHeight) path, so the UI never waits on this query. This
-// deadline exists only so a pathological sidecar — e.g. the kernel wedged holding
-// the write lock indefinitely — cannot pin a background worker forever; on expiry
-// the query degrades to the last cached window (see moltWindowCache). It is
-// deliberately CONSERVATIVE (1s, far above a normal write's brief lock) precisely
-// because it no longer sits on a latency-sensitive path: a tight deadline here
-// would only cause spurious stale reads with no UI-responsiveness benefit.
+// moltSessionWindowQueryTimeout bounds how long any sqlite3 read subprocess in
+// this file may run before it is killed. It guards two paths with the same 1s
+// ceiling:
+//
+//   - The molt-session-window query (queryMoltWindowLive), gathered on a
+//     background tea.Cmd (tui: fetchHomeTelemetry), never on the render (View) or
+//     keypress (syncViewportHeight) path. There it is a LOOSE WORKER-LOCAL
+//     BACKSTOP: the UI never waits on it, so the deadline exists only so a
+//     pathological sidecar — e.g. the kernel wedged holding the write lock
+//     indefinitely — cannot pin a background worker forever; on expiry the query
+//     degrades to the last cached window (see moltWindowCache).
+//   - The recent-event detail query (queryRecentEventTimes), which the /kanban
+//     Ctrl+D detail layer refreshes SYNCHRONOUSLY ON THE UI THREAD every
+//     auto-refresh tick (tui: autoRefreshActiveView -> PropsModel.loadDetail).
+//     There this deadline is a HARD CEILING / FAIL-SAFE against a slow or locked
+//     external-volume database pinning the Bubble Tea Update loop (issue #526).
+//
+// 1s is deliberately CONSERVATIVE — far above a normal write's brief lock. On the
+// background path a tighter deadline would only cause spurious stale reads with no
+// UI benefit; on the UI path it is intentionally a last-resort ceiling, not the
+// primary defense, because tripping it sends the caller into the JSONL fallback,
+// which is itself expensive on external volumes (fs.tailEventTimes still reads the
+// on-disk events.jsonl tail). The busy_timeout below, not this deadline, is what
+// absorbs ordinary lock contention on both paths.
 const moltSessionWindowQueryTimeout = 1 * time.Second
 
 // moltSessionWindowBusyTimeoutMS is the sqlite busy_timeout (milliseconds) applied
-// to the molt-session-window read. A concurrent kernel writer briefly holds the
-// database lock; without busy_timeout the read fails instantly with SQLITE_BUSY,
-// which the caller (fs.SumMoltSessionTokenLedger) treats as "no sqlite result"
-// and falls back to an expensive full events.jsonl parse. A short busy_timeout
-// lets the read wait out a normal write and still return promptly, well within
-// moltSessionWindowQueryTimeout. This too runs on the background worker, not the
-// UI thread.
+// to both sqlite reads in this file (queryMoltWindowLive and queryRecentEventTimes).
+// It is the PRIMARY defense against ordinary lock contention on both the background
+// session-window path and the UI-thread /kanban detail path. A concurrent kernel
+// writer briefly holds the database lock; without busy_timeout the read fails
+// instantly with SQLITE_BUSY, and the caller degrades — fs.SumMoltSessionTokenLedger
+// treats it as "no sqlite result" and reparses events.jsonl; fs.RecentRebuildTimes /
+// fs.RecentRefreshCompleteTimes fall back to the events.jsonl tail — both of which
+// are extra work, and costly on external volumes. 150ms covers common write-lock
+// contention so the read waits the writer out and returns fresh data, while still
+// finishing well within moltSessionWindowQueryTimeout, which stays a rarely-hit
+// ceiling rather than the normal-case path.
 const moltSessionWindowBusyTimeoutMS = 150
 
 // moltSessionWindowCacheTTL is the minimum interval between two live sqlite
@@ -253,6 +270,20 @@ func QueryRecentRefreshCompleteTimes(agentDir string, limit int) ([]time.Time, e
 // queryRecentEventTimes runs a targeted, LIMIT-bounded query for the newest
 // timestamps of a single event type. eventType is a fixed internal constant
 // (never user input), so it is interpolated directly into the SQL.
+//
+// Unlike QueryMoltSessionWindows, this query has callers on the UI thread: the
+// /kanban Ctrl+D detail layer reloads RecentRebuildTimes/RecentRefreshCompleteTimes
+// synchronously inside the 1s auto-refresh tick (tui: autoRefreshActiveView ->
+// PropsModel.loadDetail). A concurrent kernel writer briefly holds the sqlite
+// write lock, and on a slow/external-volume live database that write — plus the
+// read itself — can take seconds. Without bounds this subprocess would block the
+// Bubble Tea Update loop for that whole time, delaying keypress/render handling
+// (issue #526). So the read is bounded exactly like queryMoltWindowLive: a
+// worker-local context deadline (moltSessionWindowQueryTimeout) kills a pinned
+// subprocess, and a short sqlite busy_timeout (moltSessionWindowBusyTimeoutMS)
+// lets it wait out a normal write instead of returning early. Both bounds simply
+// surface as a descriptive error here; the fs-layer callers already degrade to
+// the events.jsonl tail (fs.RecentRebuildTimes) or draw nothing.
 func queryRecentEventTimes(agentDir, eventType string, limit int) ([]time.Time, error) {
 	if limit <= 0 {
 		limit = 10
@@ -266,9 +297,23 @@ func queryRecentEventTimes(agentDir, eventType string, limit int) ([]time.Time, 
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), moltSessionWindowQueryTimeout)
+	defer cancel()
+
+	// The `.timeout` dot-command sets sqlite's busy_timeout for the session so the
+	// read waits out a concurrent kernel writer instead of failing instantly with
+	// SQLITE_BUSY. It runs via -cmd (before the SELECT) rather than as an inline
+	// PRAGMA so its value is not emitted as a result row that would corrupt parsing.
 	sql := fmt.Sprintf(`SELECT ts FROM events WHERE type='%s' ORDER BY ts DESC LIMIT %d`, eventType, limit)
-	out, err := exec.Command(bin, "-separator", "\x1f", db, sql).Output()
+	out, err := exec.CommandContext(ctx, bin,
+		"-separator", "\x1f",
+		"-cmd", fmt.Sprintf(".timeout %d", moltSessionWindowBusyTimeoutMS),
+		db, sql,
+	).Output()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("sqlite3 %s query timed out after %s", eventType, moltSessionWindowQueryTimeout)
+		}
 		if ee, ok := err.(*exec.ExitError); ok {
 			if msg := strings.TrimSpace(string(ee.Stderr)); msg != "" {
 				return nil, fmt.Errorf("sqlite3: %s", msg)

--- a/tui/internal/sqlitelog/molt_recent_bounded_test.go
+++ b/tui/internal/sqlitelog/molt_recent_bounded_test.go
@@ -1,0 +1,67 @@
+package sqlitelog
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestQueryRecentEventTimesDeadlineBounded is the issue #526 regression guard for
+// the /kanban Ctrl+D detail path. RecentRebuildTimes / RecentRefreshCompleteTimes
+// reload via queryRecentEventTimes synchronously on the Bubble Tea Update thread
+// every auto-refresh tick (tui: autoRefreshActiveView -> PropsModel.loadDetail).
+// A slow or lock-contended sqlite3 subprocess on an external volume must NOT pin
+// that loop indefinitely: the read runs under a worker-local context deadline
+// (moltSessionWindowQueryTimeout), so a hung subprocess is killed and the caller
+// degrades to the bounded events.jsonl tail instead of stalling input/render.
+//
+// The test shadows the sqlite3 binary on PATH with a stub that hangs forever,
+// then asserts queryRecentEventTimes returns an error promptly — bounded by the
+// deadline, not the (infinite) subprocess. Before the fix (a plain exec.Command
+// with no context) this call would never return.
+func TestQueryRecentEventTimesDeadlineBounded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hanging-stub shim is POSIX shell only")
+	}
+	// Build a real sidecar first (needs the real sqlite3), then shadow PATH.
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1000.0,'psyche_molt','{}');`,
+	)
+	shadowSQLite3WithHang(t)
+
+	start := time.Now()
+	_, err := QueryRecentMoltTimes(agentDir, 10)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a deadline/error from the hanging sqlite3 stub, got nil")
+	}
+	// Must return within the deadline plus a generous margin for subprocess
+	// teardown and CI jitter — the point is that it returns AT ALL, quickly,
+	// rather than hanging on the never-exiting stub.
+	maxBound := moltSessionWindowQueryTimeout + time.Second
+	if elapsed > maxBound {
+		t.Fatalf("QueryRecentMoltTimes blocked for %s on a hung sqlite3 (bound %s); "+
+			"the context deadline guard is missing (err=%v)", elapsed, maxBound, err)
+	}
+}
+
+// shadowSQLite3WithHang prepends a temp dir to PATH containing a `sqlite3`
+// executable that ignores its args and sleeps far past the query deadline, so
+// exec.LookPath("sqlite3") in findSQLite3 resolves to it. PATH is restored on
+// test cleanup.
+func shadowSQLite3WithHang(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "sqlite3")
+	// `sleep 3600` outlives moltSessionWindowQueryTimeout (1s) by a wide margin;
+	// the context deadline must fire and kill it long before then.
+	script := "#!/bin/sh\nexec sleep 3600\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prev := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
+}


### PR DESCRIPTION
## Summary

Refs #526. This is a deliberately **partial** fix: it bounds one remaining UI-thread sqlite subprocess path that can still affect the TUI, but it does **not** claim to solve every stall mode described in the issue.

The specific residual path is the `/kanban` Ctrl+D detail refresh. That detail view calls `RecentRebuildTimes` / `RecentRefreshCompleteTimes` synchronously from the Bubble Tea update loop, and those helpers eventually run the recent-event sqlite query. Before this PR, that sqlite subprocess had no context deadline and no sqlite `busy_timeout`, so a slow or locked live DB on an external volume could pin the UI thread until the subprocess returned.

This PR:

- wraps the recent-event sqlite subprocess in the existing 1s context deadline;
- adds the existing 150ms sqlite `.timeout` busy wait so ordinary write-lock contention is waited out instead of failing instantly;
- preserves the existing fs-layer JSONL fallback behavior when sqlite is unavailable, locked too long, or times out;
- updates the surrounding comments so the timeout/busy constants now honestly describe both their background session-window role and this UI-thread `/kanban` detail role;
- adds a regression test that shadows `sqlite3` with a sleeping stub and verifies the recent-event query is deadline-bounded.

Two other #526 contributors appear already covered on current `main`: Time Machine exclusion work (#538) and the async home telemetry sqlite path (#540). This PR only covers the remaining `/kanban` detail recent-event path, so #526 should stay open unless/until the reporter or maintainer confirms this was the relevant stall.

Question for the reporter/maintainer: were the observed stalls happening while the `/kanban` Ctrl+D detail panel was open or refreshing?

## Review workflow

This was run through the requested community-issue workflow:

- `lingtai-taste` decision: GOOD_PR_CANDIDATE, but partial/narrow.
- Claude Code main writer produced the candidate and failing-first test.
- Codex audit: PASS_WITH_NOTES; required the PR wording to avoid overclaiming “nonblocking” and keep #526 open.
- GLM review: PASS_WITH_NOTES; required updating stale comments on the shared timeout/busy constants.
- Claude Code applied the reviewer-required comment cleanup and amended the commit.
- Kimi final re-review: PASS_WITH_NOTES; no blockers, only PR-body framing notes (partial, keep open, ask reporter about Ctrl+D detail path).

## Validation

Final validation after reviewer cleanup:

```bash
git diff --check origin/main...HEAD
cd tui
go vet ./internal/sqlitelog/
go test ./internal/sqlitelog ./internal/fs ./internal/tui -count=1
```

Results:

```text
go vet ./internal/sqlitelog/   # no output
go test ./internal/sqlitelog ./internal/fs ./internal/tui -count=1
ok  	github.com/anthropics/lingtai-tui/internal/sqlitelog	1.801s
ok  	github.com/anthropics/lingtai-tui/internal/fs	0.942s
ok  	github.com/anthropics/lingtai-tui/internal/tui	6.176s
```

Claude Code also previously ran the full `go test ./... -count=1` and `go vet ./...` before the comment-only cleanup.
