### PR TITLE
fix: make codex account fallback filenames clearer

### DIFF
--- a/tui/internal/tui/codex_auth_store.go
+++ b/tui/internal/tui/codex_auth_store.go
@@ -168,11 +168,14 @@ func codexAccountSlug(email, fallback string) string {
 
 // newCodexAuthPath returns a fresh, non-colliding absolute path under
 // codexAuthDir for a new account with the given email. The slug derives from
-// the email; numeric suffixes break collisions with existing files. The
-// directory is NOT created here — the caller creates it at write time.
+// the email's local part (sam@example.com → sam.json); when the tokens carry
+// no email the file is named codex-account.json so the path reads as an
+// account file rather than the ambiguous codex-auth/codex.json. Numeric
+// suffixes break collisions with existing files (sam-2.json). The directory
+// is NOT created here — the caller creates it at write time.
 func newCodexAuthPath(globalDir, email string) string {
 	dir := codexAuthDir(globalDir)
-	slug := codexAccountSlug(email, "codex")
+	slug := codexAccountSlug(email, "codex-account")
 	candidate := filepath.Join(dir, slug+".json")
 	if _, err := os.Stat(candidate); os.IsNotExist(err) {
 		return candidate

--- a/tui/internal/tui/codex_auth_store_test.go
+++ b/tui/internal/tui/codex_auth_store_test.go
@@ -172,6 +172,23 @@ func TestNewCodexAuthPath_NoCollision(t *testing.T) {
 	}
 }
 
+// TestNewCodexAuthPath_MissingEmailFallback verifies that a new account whose
+// tokens carry no email gets the readable "codex-account" slug (not the bare
+// "codex" that used to land as the confusing codex-auth/codex.json), with the
+// same numeric-suffix collision handling as email-derived slugs.
+func TestNewCodexAuthPath_MissingEmailFallback(t *testing.T) {
+	dir := t.TempDir()
+	first := newCodexAuthPath(dir, "")
+	if filepath.Base(first) != "codex-account.json" {
+		t.Fatalf("no-email account should be codex-account.json; got %q", filepath.Base(first))
+	}
+	writeStubCodexToken(t, first, "")
+	second := newCodexAuthPath(dir, "")
+	if filepath.Base(second) != "codex-account-2.json" {
+		t.Fatalf("collision should yield codex-account-2.json; got %q", filepath.Base(second))
+	}
+}
+
 // TestCodexAuthRefForPath_HomeShortened verifies a per-account path maps back to
 // a "~/"-prefixed ref and the legacy file maps to the implicit empty ref.
 func TestCodexAuthRefForPath_LegacyMapsToEmpty(t *testing.T) {

--- a/tui/internal/tui/login_account_name_test.go
+++ b/tui/internal/tui/login_account_name_test.go
@@ -140,7 +140,7 @@ func TestLoginModel_OAuthDonePreservesRecognizableName(t *testing.T) {
 	_, globalDir := withTempCodexHome(t)
 	// Pre-existing legacy account so the "add another" completion writes a new
 	// per-account file (its slug derives from the email, but tokens here have
-	// none, so the derived path uses the "codex" fallback slug).
+	// none, so the derived path uses the "codex-account" fallback slug).
 	writeCodexAccountFile(t, legacyCodexAuthPath(globalDir), "primary@example.com")
 
 	m := NewLoginModel("", globalDir)


### PR DESCRIPTION
## Summary
- use `codex-account.json` / `codex-account-2.json` for future added Codex accounts whose OAuth tokens do not carry an email
- keep email-derived filenames (`sam@example.com` -> `sam.json`) and numeric collision suffixes unchanged
- keep legacy `codex-auth.json` fallback/selection behavior unchanged; no existing token files are migrated or renamed
- add a focused regression test and update a stale test comment

## Why
`/setup` can display the account email later from token contents, but when the add-account flow has no email at path-selection time the old fallback wrote the ambiguous `codex-auth/codex.json`. The new fallback keeps no-email account paths recognizable without changing account binding semantics.

## Validation
- `git diff --check`
- `cd tui && go test ./internal/tui -run 'Codex|LoginModel|NewCodexAuthPath|AccountName|Pool'`
- `cd tui && go test ./internal/tui`

## Notes
- This intentionally does not rename existing `codex-auth/codex.json` files.
- Local implementation report (not committed): `reports/codex-account-naming-daemon-report.md`.