### PR TITLE
feat(tui): abbreviate pasted content in input area

### DIFF
--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -142,6 +142,7 @@ type MailModel struct {
 	pendingMessage    string           // full text from editor, sent on Enter
 	pasteContent      string           // actual content of abbreviated paste (sent on Enter)
 	pasteDisplay      string           // abbreviated display form of paste (for change detection)
+	pasteExpanded     bool            // whether abbreviated paste is currently expanded in input
 	globalDir         string           // ~/.lingtai-tui/
 	wasActive         bool             // true if previous refresh was ACTIVE
 	quoteIdx          int              // which quote to show (advances on each ACTIVE transition)
@@ -677,6 +678,7 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		}
 		m.pasteContent = ""
 		m.pasteDisplay = ""
+		m.pasteExpanded = false
 		if text == "" {
 			return m, nil
 		}
@@ -736,6 +738,29 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				return m, nil
 			}
 			return m, nil
+		}
+
+		// Toggle paste expand/collapse before palette routing, because
+		// expanded paste content may start with "/" and activate the palette.
+		if msg.String() == "ctrl+e" && m.pasteContent != "" && m.pasteDisplay != "" {
+			text := m.input.Value()
+			if !m.pasteExpanded {
+				if idx := strings.Index(text, m.pasteDisplay); idx >= 0 {
+					m.input.SetValue(text[:idx] + m.pasteContent + text[idx+len(m.pasteDisplay):])
+					m.pasteExpanded = true
+					m.AddSystemMessage("Paste expanded")
+					m.syncViewportHeight()
+					return m, nil
+				}
+			} else {
+				if idx := strings.Index(text, m.pasteContent); idx >= 0 {
+					m.input.SetValue(text[:idx] + m.pasteDisplay + text[idx+len(m.pasteContent):])
+					m.pasteExpanded = false
+					m.AddSystemMessage("Paste collapsed")
+					m.syncViewportHeight()
+					return m, nil
+				}
+			}
 		}
 
 		// If palette is active, route to palette
@@ -885,8 +910,17 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		m.maybeShowEditorHint()
 		// Abbreviate the pasted segment for cleaner display, preserving text
 		// the user may have typed before the paste.
+		// If the previous paste was expanded, collapse it back first so the
+		// new paste doesn't mix with the old expanded content.
+		if m.pasteExpanded && m.pasteContent != "" && m.pasteDisplay != "" {
+			text := m.input.Value()
+			if idx := strings.Index(text, m.pasteContent); idx >= 0 {
+				m.input.SetValue(text[:idx] + m.pasteDisplay + text[idx+len(m.pasteContent):])
+			}
+		}
 		m.pasteContent = ""
 		m.pasteDisplay = ""
+		m.pasteExpanded = false
 		if abbreviated, ok := abbrevPasteContent(pasteContent); ok {
 			m.pasteContent = pasteContent
 			m.pasteDisplay = abbreviated

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -140,6 +140,8 @@ type MailModel struct {
 	lastPaletteLines  int
 	lastBannerLines   int
 	pendingMessage    string           // full text from editor, sent on Enter
+	pasteContent      string           // actual content of abbreviated paste (sent on Enter)
+	pasteDisplay      string           // abbreviated display form of paste (for change detection)
 	globalDir         string           // ~/.lingtai-tui/
 	wasActive         bool             // true if previous refresh was ACTIVE
 	quoteIdx          int              // which quote to show (advances on each ACTIVE transition)
@@ -665,7 +667,16 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 			m.pendingMessage = ""
 		} else {
 			text = m.input.Value()
+			// If the input still holds a paste abbreviation, expand it back to
+			// the actual content before sending.
+			if m.pasteContent != "" && m.pasteDisplay != "" {
+				if idx := strings.Index(text, m.pasteDisplay); idx >= 0 {
+					text = text[:idx] + m.pasteContent + text[idx+len(m.pasteDisplay):]
+				}
+			}
 		}
+		m.pasteContent = ""
+		m.pasteDisplay = ""
 		if text == "" {
 			return m, nil
 		}
@@ -864,12 +875,30 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 
 	// Forward all other messages (including textarea paste and cursor blink) to input.
 	var cmd tea.Cmd
-	m.input, cmd = m.input.Update(msg)
-	if _, ok := msg.(tea.PasteMsg); ok {
+	if pasteMsg, ok := msg.(tea.PasteMsg); ok {
+		pasteContent := pasteMsg.Content
+		// Forward full content so viewport/editor-hint logic sees the real size.
+		m.input, cmd = m.input.Update(msg)
 		if m.syncViewportHeight() && m.viewport.AtBottom() {
 			m.viewport.GotoBottom()
 		}
 		m.maybeShowEditorHint()
+		// Abbreviate the pasted segment for cleaner display, preserving text
+		// the user may have typed before the paste.
+		m.pasteContent = ""
+		m.pasteDisplay = ""
+		if abbreviated, ok := abbrevPasteContent(pasteContent); ok {
+			m.pasteContent = pasteContent
+			m.pasteDisplay = abbreviated
+			postPasteValue := m.input.Value()
+			if strings.HasSuffix(postPasteValue, pasteContent) {
+				m.input.SetValue(postPasteValue[:len(postPasteValue)-len(pasteContent)] + abbreviated)
+			} else {
+				m.input.SetValue(abbreviated)
+			}
+		}
+	} else {
+		m.input, cmd = m.input.Update(msg)
 	}
 	if cmd != nil {
 		cmds = append(cmds, cmd)
@@ -1164,6 +1193,57 @@ func (m *MailModel) maybeShowEditorHint() {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// imagePasteExts is the set of image file extensions recognized for paste abbreviation.
+var imagePasteExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+	".webp": true, ".bmp": true, ".tiff": true, ".tif": true,
+	".heic": true, ".heif": true, ".svg": true,
+}
+
+// abbrevPasteContent checks if pasted content should be abbreviated for display.
+// It returns (abbreviated, true) when the content is image paths or long multi-line
+// text, or ("", false) when the content should be shown as-is.
+func abbrevPasteContent(content string) (string, bool) {
+	if content == "" {
+		return "", false
+	}
+	lines := strings.Split(content, "\n")
+	// Drop a single trailing empty element from a trailing newline.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return "", false
+	}
+	// Check whether every non-empty line looks like an image file path.
+	allImages := true
+	imgCount := 0
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(line))
+		if !imagePasteExts[ext] {
+			allImages = false
+			break
+		}
+		imgCount++
+	}
+	if allImages && imgCount > 0 {
+		var b strings.Builder
+		for i := 0; i < imgCount; i++ {
+			fmt.Fprintf(&b, "[image%d]", i+1)
+		}
+		return b.String(), true
+	}
+	// Long multi-line text: summarize as "[pasted ~N lines]".
+	if len(lines) > 3 {
+		return fmt.Sprintf("[pasted ~%d lines]", len(lines)), true
+	}
+	return "", false
 }
 
 // launchEditor creates a temp file and opens $EDITOR (default: vim).

--- a/tui/internal/tui/paste_abbreviation_test.go
+++ b/tui/internal/tui/paste_abbreviation_test.go
@@ -223,3 +223,111 @@ func TestPasteAbbreviationWithSurroundingText(t *testing.T) {
 		t.Errorf("expanded text = %q, want %q", text, want)
 	}
 }
+
+// ctrlEPress constructs a KeyPressMsg for ctrl+e.
+func ctrlEPress() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl}
+}
+
+func TestPasteExpandCollapseToggle(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content := "/path/to/img1.png\n/path/to/img2.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	// After paste, input shows abbreviated form
+	if m.input.Value() != "[image1][image2]" {
+		t.Fatalf("after paste: input = %q, want %q", m.input.Value(), "[image1][image2]")
+	}
+	if m.pasteExpanded {
+		t.Fatal("pasteExpanded should be false after paste")
+	}
+
+	// Press ctrl+e to expand
+	m, _ = m.Update(ctrlEPress())
+	if !m.pasteExpanded {
+		t.Fatal("pasteExpanded should be true after ctrl+e")
+	}
+	if m.input.Value() != content {
+		t.Errorf("after expand: input = %q, want %q", m.input.Value(), content)
+	}
+
+	// Press ctrl+e again to collapse
+	m, _ = m.Update(ctrlEPress())
+	if m.pasteExpanded {
+		t.Fatal("pasteExpanded should be false after second ctrl+e")
+	}
+	if m.input.Value() != "[image1][image2]" {
+		t.Errorf("after collapse: input = %q, want %q", m.input.Value(), "[image1][image2]")
+	}
+}
+
+func TestPasteExpandCollapseWithSurroundingText(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	m.input.SetValue("See: ")
+	content := "/path/to/img1.png\n/path/to/img2.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	wantCollapsed := "See: [image1][image2]"
+	if m.input.Value() != wantCollapsed {
+		t.Fatalf("after paste: input = %q, want %q", m.input.Value(), wantCollapsed)
+	}
+
+	// Expand
+	m, _ = m.Update(ctrlEPress())
+	wantExpanded := "See: " + content
+	if m.input.Value() != wantExpanded {
+		t.Errorf("after expand: input = %q, want %q", m.input.Value(), wantExpanded)
+	}
+
+	// Collapse
+	m, _ = m.Update(ctrlEPress())
+	if m.input.Value() != wantCollapsed {
+		t.Errorf("after collapse: input = %q, want %q", m.input.Value(), wantCollapsed)
+	}
+}
+
+func TestCtrlEPassthroughWhenNoAbbreviation(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	// Type some text (no paste abbreviation active)
+	m.input.SetValue("hello")
+	m, _ = m.Update(ctrlEPress())
+
+	// ctrl+e should pass through to textarea when no abbreviation is active.
+	// The textarea treats ctrl+e as "end of line" (no-op for single-line input),
+	// so the value should remain unchanged.
+	if m.input.Value() != "hello" {
+		t.Errorf("ctrl+e with no abbreviation: input = %q, want %q", m.input.Value(), "hello")
+	}
+}
+
+func TestPasteExpandedResetOnNewPaste(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content1 := "/path/to/img1.png\n/path/to/img2.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content1})
+
+	// Expand the first paste
+	m, _ = m.Update(ctrlEPress())
+	if !m.pasteExpanded {
+		t.Fatal("pasteExpanded should be true after ctrl+e")
+	}
+
+	// Paste something new — old expanded content collapses first,
+	// then the new paste is abbreviated and appended.
+	content2 := "/path/to/other.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content2})
+	if m.pasteExpanded {
+		t.Error("pasteExpanded should be reset to false on new paste")
+	}
+	want := "[image1][image2][image1]"
+	if m.input.Value() != want {
+		t.Errorf("after new paste: input = %q, want %q", m.input.Value(), want)
+	}
+}

--- a/tui/internal/tui/paste_abbreviation_test.go
+++ b/tui/internal/tui/paste_abbreviation_test.go
@@ -1,0 +1,225 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestAbbrevPasteContent(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		abbrev bool
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			want:   "",
+			abbrev: false,
+		},
+		{
+			name:   "single image",
+			input:  "/Users/brian/Desktop/screenshot.png",
+			want:   "[image1]",
+			abbrev: true,
+		},
+		{
+			name:   "two images",
+			input:  "/path/to/img1.png\n/path/to/img2.jpg",
+			want:   "[image1][image2]",
+			abbrev: true,
+		},
+		{
+			name:   "three images with trailing newline",
+			input:  "/a.png\n/b.jpg\n/c.gif\n",
+			want:   "[image1][image2][image3]",
+			abbrev: true,
+		},
+		{
+			name:   "short text - no abbreviation",
+			input:  "Hello, world!",
+			want:   "",
+			abbrev: false,
+		},
+		{
+			name:   "two lines - no abbreviation",
+			input:  "line 1\nline 2",
+			want:   "",
+			abbrev: false,
+		},
+		{
+			name:   "three lines - no abbreviation",
+			input:  "a\nb\nc",
+			want:   "",
+			abbrev: false,
+		},
+		{
+			name:   "four lines - abbreviate",
+			input:  "a\nb\nc\nd",
+			want:   "[pasted ~4 lines]",
+			abbrev: true,
+		},
+		{
+			name:   "twelve lines - abbreviate",
+			input:  strings.Repeat("line\n", 12),
+			want:   "[pasted ~12 lines]",
+			abbrev: true,
+		},
+		{
+			name:   "mixed image and text - no abbreviation",
+			input:  "Check this: /path/to/img.png\nAnother line",
+			want:   "",
+			abbrev: false,
+		},
+		{
+			name:   "image with spaces in path",
+			input:  "/path/to/my image.png",
+			want:   "[image1]",
+			abbrev: true,
+		},
+		{
+			name:   "various image extensions",
+			input:  "/a.png\n/b.jpeg\n/c.webp\n/d.heic",
+			want:   "[image1][image2][image3][image4]",
+			abbrev: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := abbrevPasteContent(tt.input)
+			if ok != tt.abbrev {
+				t.Errorf("abbrevPasteContent() abbrev = %v, want %v", ok, tt.abbrev)
+			}
+			if got != tt.want {
+				t.Errorf("abbrevPasteContent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPasteImagesAbbreviatedInInput(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content := "/Users/brian/Desktop/img1.png\n/Users/brian/Desktop/img2.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	// Input should show abbreviated form
+	if got := m.input.Value(); got != "[image1][image2]" {
+		t.Errorf("input value = %q, want %q", got, "[image1][image2]")
+	}
+	// Actual paste content should be stored
+	if m.pasteContent != content {
+		t.Errorf("pasteContent = %q, want %q", m.pasteContent, content)
+	}
+	if m.pasteDisplay != "[image1][image2]" {
+		t.Errorf("pasteDisplay = %q, want %q", m.pasteDisplay, "[image1][image2]")
+	}
+}
+
+func TestPasteLongTextAbbreviatedInInput(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content := strings.Repeat("some text line\n", 12)
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	if got := m.input.Value(); got != "[pasted ~12 lines]" {
+		t.Errorf("input value = %q, want %q", got, "[pasted ~12 lines]")
+	}
+	if m.pasteContent != content {
+		t.Errorf("pasteContent length = %d, want %d", len(m.pasteContent), len(content))
+	}
+}
+
+func TestPasteShortTextNoAbbreviation(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content := "Hello, world!"
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	if got := m.input.Value(); got != content {
+		t.Errorf("input value = %q, want %q", got, content)
+	}
+	if m.pasteContent != "" {
+		t.Errorf("pasteContent should be empty for short text, got %q", m.pasteContent)
+	}
+}
+
+func TestPasteContentClearedAfterSend(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content := "/path/to/img1.png\n/path/to/img2.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	if m.pasteContent == "" {
+		t.Fatal("pasteContent should be set after paste")
+	}
+
+	// Simulate send (orchestrator is empty so WriteMail is not called)
+	m, _ = m.Update(SendMsg{})
+
+	// After send, paste state should be cleared
+	if m.pasteContent != "" {
+		t.Errorf("pasteContent should be cleared after send, got %q", m.pasteContent)
+	}
+	if m.pasteDisplay != "" {
+		t.Errorf("pasteDisplay should be cleared after send, got %q", m.pasteDisplay)
+	}
+}
+
+func TestPasteAbbreviationExpandedOnSend(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	content := "/path/to/img1.png\n/path/to/img2.png"
+	m, _ = m.Update(tea.PasteMsg{Content: content})
+
+	// After paste, input shows abbreviated form
+	if m.input.Value() != "[image1][image2]" {
+		t.Fatalf("input value = %q, want %q", m.input.Value(), "[image1][image2]")
+	}
+
+	// Simulate the expansion logic from SendMsg handler
+	text := m.input.Value()
+	if m.pasteContent != "" && m.pasteDisplay != "" {
+		if idx := strings.Index(text, m.pasteDisplay); idx >= 0 {
+			text = text[:idx] + m.pasteContent + text[idx+len(m.pasteDisplay):]
+		}
+	}
+	if text != content {
+		t.Errorf("expanded text = %q, want %q", text, content)
+	}
+}
+
+func TestPasteAbbreviationWithSurroundingText(t *testing.T) {
+	m := NewMailModel("", "", "", "", "codex", 10, "", "en", false, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	// User types something, then pastes
+	m.input.SetValue("Check this: ")
+	m, _ = m.Update(tea.PasteMsg{Content: "/path/to/img.png"})
+
+	// Input should have the typed text + abbreviation
+	got := m.input.Value()
+	if got != "Check this: [image1]" {
+		t.Errorf("input value = %q, want %q", got, "Check this: [image1]")
+	}
+
+	// Simulate expansion
+	text := got
+	if m.pasteContent != "" && m.pasteDisplay != "" {
+		if idx := strings.Index(text, m.pasteDisplay); idx >= 0 {
+			text = text[:idx] + m.pasteContent + text[idx+len(m.pasteDisplay):]
+		}
+	}
+	want := "Check this: /path/to/img.png"
+	if text != want {
+		t.Errorf("expanded text = %q, want %q", text, want)
+	}
+}


### PR DESCRIPTION
## Summary
- When pasting image file paths into the TUI input, display `[image1][image2]...` instead of full paths
- When pasting long multi-line text (>3 lines), display `[pasted ~N lines]` instead of full content
- Short text (≤3 lines) is shown as-is — no change
- The original content is preserved internally and expanded back when the message is sent
- Conversation area display is unaffected (per Brian's request)

## Why
Pasting multiple image paths or a large text block clutters the input area with hard-to-read content. Abbreviation keeps the input clean while preserving the actual data sent to the agent.

## Design choices
- **Abbreviation happens in `tea.PasteMsg` handler**: full content is forwarded to the textarea first (so viewport/editor-hint height logic sees the real size), then the pasted segment is replaced with the abbreviated form
- **Expansion happens in `SendMsg` handler**: the abbreviation is replaced with the original content before `WriteMail` is called
- **Threshold: >3 lines** for text abbreviation — short pastes are shown in full
- **Image detection**: all non-empty lines must have a recognized image extension (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.tiff`, `.tif`, `.heic`, `.heif`, `.svg`)

## Validation
- `go test ./internal/tui/` — all tests pass (including new `paste_abbreviation_test.go`)
- `go vet ./internal/tui/` — clean
- Existing `TestPasteAtMaxHeightShowsEditorHint` still passes (editor hint logic unchanged)

## Notes
- Pushed via GitHub API (git push times out due to network)
- Branch: `BrianLiubr:feat/paste-abbreviation`
