### PR TITLE
Bind portal to loopback by default

### DIFF
--- a/portal/ANATOMY.md
+++ b/portal/ANATOMY.md
@@ -32,17 +32,17 @@ maintenance: |
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues; do not silently fix.
 
-The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` filesystem the TUI does and serves a network visualisation, mail UI, and topology replay over HTTP. Ships with no runtime Node dependency — the React 19 frontend is compiled in via `embed.FS`.
+The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` filesystem the TUI does and serves a network visualisation, mail UI, and topology replay over HTTP. It binds to loopback by default and ships with no runtime Node dependency — the React 19 frontend is compiled in via `embed.FS`.
 
 ## Components
 
-- **`portal/main.go:23-93`** — `main()` entry. Parses `--dir`, `--port`, `--open`, `--lang` flags (`portal/main.go:34-43`); validates `.lingtai/` exists (`portal/main.go:52-55`); runs migrations (`portal/main.go:61`); creates `.portal/` directory (`portal/main.go:67-68`); constructs the `api.Server`, starts topology recording (`portal/main.go:72`), and serves on a random port (`portal/main.go:74`). Blocks on SIGINT/SIGTERM, then calls `srv.Stop()` (`portal/main.go:87-92`).
-- **`portal/main.go:95-125`** — `openBrowser(url)` launches the OS default browser (darwin/linux/windows/WSL).
-- **`portal/main.go:127-134`** — `isWSL()` detects WSL via `/proc/version`.
+- **`portal/main.go:23-98`** — `main()` entry. Parses `--dir`, `--host`, `--port`, `--open`, `--lang` flags (`portal/main.go:34-44`); validates `.lingtai/` exists (`portal/main.go:52-55`); runs migrations (`portal/main.go:63`); creates `.portal/` directory (`portal/main.go:68-70`); constructs the `api.Server`, starts topology recording (`portal/main.go:73-74`), and serves on the requested host/port (`portal/main.go:75-82`). Blocks on SIGINT/SIGTERM, then calls `srv.Stop()` (`portal/main.go:91-97`).
+- **`portal/main.go:100-130`** — `openBrowser(url)` launches the OS default browser (darwin/linux/windows/WSL).
+- **`portal/main.go:132-139`** — `isWSL()` detects WSL via `/proc/version`.
 - **`portal/embed.go:8-9`** — `//go:embed all:web/dist` compiles the React frontend build output into `webDist embed.FS`. No runtime Node dependency.
 - **`portal/embed.go:11-17`** — `WebFS()` returns `fs.Sub(webDist, "web/dist")` so the HTTP server mounts from the `web/dist/` root.
 - **`Makefile:1-24`** — Build pipeline. `web-build` runs `npm install && npm run build` in `web/`; `go-build` depends on it and stamps `main.version` via `-ldflags`. `cross-compile` targets darwin/linux × arm64/amd64.
-- **`internal/api/`** — HTTP server, handlers, and the 680-line replay endpoint. See `portal/internal/api/ANATOMY.md`.
+- **`internal/api/`** — HTTP server, handlers, and the replay endpoint. See `portal/internal/api/ANATOMY.md`.
 - **`internal/fs/`** — Filesystem readers: agent manifests, heartbeat, mailbox, network reconstruction (`reconstruct.go`), topology types (`types.go`). Same shape as `tui/internal/fs/` but Portal-specific.
 - **`internal/migrate/`** — Migration registry sharing the `meta.json` version space with the TUI. Each migration mirrors its TUI counterpart (or is a no-op stub). See `portal/internal/migrate/migrate.go`.
 - **`web/`** — React 19 + TypeScript + Vite frontend. Source under `web/src/`; builds to `web/dist/`.
@@ -53,7 +53,7 @@ The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` 
 - **Portal → filesystem (read).** `internal/fs/` reads agent manifests, heartbeats, mailboxes, token ledgers, chat history, and `.notification/` payloads — the same files the TUI reads. All communication with running agents is filesystem-only: no sockets, no RPC.
 - **Portal → filesystem (write).** Writes `.portal/port` (bound port), `.portal/topology.jsonl` (live recording), `.portal/replay/chunks/*.json.gz` (compressed replay caches), and `.portal/reconstruct.progress` (reconstruction progress).
 - **Portal ↔ TUI integration.** The TUI launches `lingtai-portal` as a subprocess when the user opens `/viz`. The TUI reads `.portal/port` to know where to point the browser. The portal and TUI share `meta.json` version space — when one bumps `CurrentVersion`, the other must also bump. See repo-root `ANATOMY.md` Notes "Migration cross-package contract."
-- **Portal → browser.** Serves the embedded React SPA on `/` and a JSON API on `/api/*`. All endpoints set `Access-Control-Allow-Origin: *`.
+- **Portal → browser.** Serves the embedded React SPA on `/` and a same-origin JSON API on `/api/*`. The API does not emit wildcard CORS headers.
 - **Portal embeds frontend.** `embed.go` compiles `web/dist/` into the Go binary — `lingtai-portal` ships as a single file. (The dev build still requires `make web-build` to produce the dist.)
 
 ## Composition
@@ -66,15 +66,16 @@ The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` 
 
 ## State
 
-- **`.portal/port`** — Written on server start (`portal/main.go:73` → `portal/internal/api/server.go:54`). Contains the bound TCP port as an ASCII integer. Read by the TUI to know where to open the browser.
-- **`.portal/topology.jsonl`** — JSONL tape of network snapshots. Each line is `{"t": <unix_ms>, "net": <Network>}`. Appended every 3 seconds by `StartRecording` (`portal/internal/api/server.go:88-102`); also appended by the live handlers on each request.
+- **`.portal/port`** — Written on server start (`portal/main.go:75-76` → `portal/internal/api/server.go:61-62`). Contains only the bound TCP port as an ASCII integer. Read by the TUI to know where to open the browser.
+- **`.portal/topology.jsonl`** — JSONL tape of network snapshots. Each line is `{"t": <unix_ms>, "net": <Network>}`. Appended every 3 seconds by `StartRecording` (`portal/internal/api/server.go:96-110`); also appended by the live handlers on each request.
 - **`.portal/replay/chunks/`** — Compressed hourly replay chunks (`<hourMs>.json.gz`), each containing delta-encoded frames with keyframes every 100 frames. Plus `manifest.json` indexing all chunks.
-- **`.portal/reconstruct.progress`** — Temporary `"N/M"` progress file during tape reconstruction. Startup creates/deletes it in `StartRecording` (`portal/internal/api/server.go:76-85`); the shared replay writer updates it while caching reconstructed frames (`portal/internal/api/replay.go:417-446`).
+- **`.portal/reconstruct.progress`** — Temporary `"N/M"` progress file during tape reconstruction. Startup creates/deletes it in `StartRecording` (`portal/internal/api/server.go:82-93`); the shared replay writer updates it while caching reconstructed frames (`portal/internal/api/replay.go:417-446`).
 - **`meta.json`** — Migration version stamp under `.lingtai/`. Shared with the TUI; portal bumps its own `CurrentVersion` in lockstep.
 
 ## Notes
 
-- **Random port is the default.** `--port 0` (the default, `portal/main.go:40`) lets the OS pick an available port (`portal/internal/api/server.go:44-48`). The bound port is written to `.portal/port` so callers can discover it.
-- **Live recording begins at startup.** `StartRecording` (`portal/internal/api/server.go:62-106`) runs in a background goroutine. On first call it checks whether the tape needs reconstruction (`needsReconstruction`, `portal/internal/api/server.go:126-150`), rebuilds from source events if needed, then records a snapshot every 3 seconds.
-- **`needsReconstruction` detects format migration.** If `topology.jsonl` is missing, empty, or uses the pre-`direct/cc/bcc` format, the recorder triggers a full rebuild (`portal/internal/api/server.go:126-150`).
+- **Loopback host and random port are the defaults.** Empty `--host` resolves to `127.0.0.1`, and `--port 0` (the default, `portal/main.go:42`) lets the OS pick an available port (`portal/internal/api/server.go:48-60`). The bound port is written to `.portal/port` so callers can discover it.
+- **Explicit external hosts are unauthenticated.** `--host 0.0.0.0`, `--host ::`, or a named/non-loopback host is an opt-in for trusted-LAN use only. The display/open URL remains `http://localhost:<port>` for loopback and wildcard binds; explicit named/non-loopback hosts display directly.
+- **Live recording begins at startup.** `StartRecording` (`portal/internal/api/server.go:70-114`) runs in a background goroutine. On first call it checks whether the tape needs reconstruction (`needsReconstruction`, `portal/internal/api/server.go:174-200`), rebuilds from source events if needed, then records a snapshot every 3 seconds.
+- **`needsReconstruction` detects format migration.** If `topology.jsonl` is missing, empty, or uses the pre-`direct/cc/bcc` format, the recorder triggers a full rebuild (`portal/internal/api/server.go:174-200`).
 - **Dev-mode rebuild gotcha.** After ANY migration bump, rebuild both binaries: `cd tui && make build && cd ../portal && make build`. A stale portal against a migrated project fails with "data version N is newer than this binary supports."

--- a/portal/internal/api/ANATOMY.md
+++ b/portal/internal/api/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - portal/ANATOMY.md
   - portal/internal/fs/ANATOMY.md
   - portal/internal/api/server.go
+  - portal/internal/api/server_test.go
   - portal/internal/api/handlers.go
   - portal/internal/api/handlers_test.go
   - portal/internal/api/replay.go
@@ -27,22 +28,24 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 
 ### Server (`server.go`)
 
-- **`portal/internal/api/server.go:18-24`** — `Server` struct. Wraps `http.Server` with `port`, `baseDir`, `cancel`/`done` for the recording goroutine.
-- **`portal/internal/api/server.go:26-41`** — `NewServer(baseDir, staticFS)`. Registers 6 API routes (`portal/internal/api/server.go:28-33`) and mounts `staticFS` at `/` (`portal/internal/api/server.go:35`). Routes fixed before the Server is returned.
-- **`portal/internal/api/server.go:43-58`** — `Start(portFile, fixedPort)`. Listens on `0.0.0.0:0` (random port) unless `fixedPort > 0` (`portal/internal/api/server.go:44-48`). Writes bound port to `portFile` (`portal/internal/api/server.go:53-54`). Serves in a goroutine (`portal/internal/api/server.go:56`).
-- **`portal/internal/api/server.go:62-106`** — `StartRecording(baseDir)`. Background goroutine with a 3-second ticker (`portal/internal/api/server.go:70`). On first run: checks `needsReconstruction`, rebuilds tape from source via `agentfs.ReconstructTape`, writes replay caches through `writeReconstructedReplay` (`portal/internal/api/server.go:73-85`), then records `agentfs.BuildNetwork` snapshots on every tick via `AppendTopology` (`portal/internal/api/server.go:88-102`).
-- **`portal/internal/api/server.go:116-122`** — `Stop(ctx)`. Cancels the recording goroutine, waits for `s.done`, shuts down the HTTP server.
-- **`portal/internal/api/server.go:126-150`** — `needsReconstruction(path)`. Returns true if `topology.jsonl` is missing, empty, or uses the old format (lacking `direct`/`cc`/`bcc` fields on mail edges).
+- **`portal/internal/api/server.go:20-28`** — `Server` struct. Wraps `http.Server` with bound `host`/`port`, `baseDir`, `cancel`/`done` for the recording goroutine.
+- **`portal/internal/api/server.go:31-45`** — `NewServer(baseDir, staticFS)`. Registers 6 API routes (`portal/internal/api/server.go:33-38`) and mounts `staticFS` at `/` (`portal/internal/api/server.go:39`). Routes fixed before the Server is returned.
+- **`portal/internal/api/server.go:48-66`** — `Start(portFile, host, fixedPort)`. Resolves an empty host to `127.0.0.1`, listens with `net.JoinHostPort`, stores the effective host, writes only the bound port to `portFile`, and serves in a goroutine.
+- **`portal/internal/api/server.go:70-114`** — `StartRecording(baseDir)`. Background goroutine with a 3-second ticker (`portal/internal/api/server.go:78`). On first run: checks `needsReconstruction`, rebuilds tape from source via `agentfs.ReconstructTape`, writes replay caches through `writeReconstructedReplay` (`portal/internal/api/server.go:82-93`), then records `agentfs.BuildNetwork` snapshots on every tick via `AppendTopology` (`portal/internal/api/server.go:96-110`).
+- **`portal/internal/api/server.go:116-164`** — `Port`, `Host`, `URL`, and host helpers. `URL()` keeps `http://localhost:<port>` for loopback and wildcard binds, but renders explicit named/non-loopback hosts directly. `ExternalAccessWarning()` reports unauthenticated non-loopback/wildcard binds for the CLI.
+- **`portal/internal/api/server.go:166-172`** — `Stop(ctx)`. Cancels the recording goroutine, waits for `s.done`, shuts down the HTTP server.
+- **`portal/internal/api/server.go:174-200`** — `needsReconstruction(path)`. Returns true if `topology.jsonl` is missing, empty, or uses the old format (lacking `direct`/`cc`/`bcc` fields on mail edges).
 
 ### Handlers (`handlers.go`)
 
 - **`portal/internal/api/handlers.go:16`** — `TopologyMu sync.Mutex`. Global mutex guarding `topology.jsonl` writes and reads.
-- **`portal/internal/api/handlers.go:18-42`** — `NewNetworkHandler(baseDir)`. `GET /api/network` — live snapshot of the agent network via `fs.BuildNetwork`. Always returns `[]` not `null` for empty slices. Sets `Lang` on the response.
-- **`portal/internal/api/handlers.go:44-72`** — `NewTopologyHandler(baseDir)`. `GET /api/topology` — reads `topology.jsonl`, parses it into a JSON array of raw messages.
-- **`portal/internal/api/handlers.go:93-136`** — `AppendTopology(path, network)` / `AppendTopologyAt`. Writes one JSONL line `{"t":<unix_ms>,"net":<network>}`. Normalises nil slices to `[]`. Opens the file with `O_APPEND`; creates parent dirs on first write.
-- **`portal/internal/api/handlers.go:140-159`** — `NewProgressHandler(baseDir)`. `GET /api/topology/progress` — reads `reconstruct.progress` (`"N/M"` format), returns `{"current":N,"total":M}` or `{}`.
+- **`portal/internal/api/handlers.go:18-40`** — `NewNetworkHandler(baseDir)`. `GET /api/network` — live snapshot of the agent network via `fs.BuildNetwork`. Always returns `[]` not `null` for empty slices. Sets `Lang` on the response.
+- **`portal/internal/api/handlers.go:43-68`** — `NewTopologyHandler(baseDir)`. `GET /api/topology` — reads `topology.jsonl`, parses it into a JSON array of raw messages.
+- **`portal/internal/api/handlers.go:88-133`** — `AppendTopology(path, network)` / `AppendTopologyAt`. Writes one JSONL line `{"t":<unix_ms>,"net":<network>}`. Normalises nil slices to `[]`. Opens the file with `O_APPEND`; creates parent dirs on first write.
+- **`portal/internal/api/handlers.go:135-155`** — `NewProgressHandler(baseDir)`. `GET /api/topology/progress` — reads `reconstruct.progress` (`"N/M"` format), returns `{"current":N,"total":M}` or `{}`.
+- **`portal/internal/api/handlers_test.go:16-93`** — CORS regression coverage for live network, topology, and progress handlers, including success and error/fallback responses.
 
-### Replay (`replay.go`, 680 lines)
+### Replay (`replay.go`, ~675 lines)
 
 - **`portal/internal/api/replay.go:18-56`** — Wire types: `ReplayChunk` (delta-encoded hour range), `ReplayFrame` (keyframe or delta), `FrameDelta` (only-changed fields), `ChunkInfo` (manifest entry), `ReplayManifest` (tape bounds + chunk list).
 - **`portal/internal/api/replay.go:60-87`** — `deltaEncode(frames, keyframeInterval)`. Converts `[]TapeFrame` into a `ReplayChunk` with full keyframes every N frames and `FrameDelta` in between.
@@ -52,13 +55,13 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 - **`portal/internal/api/replay.go:405-489`** — `writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)`. Shared writer for already-reconstructed tapes: replaces replay chunks, writes `manifest.json` with `TapeStart = frames[0].T`, truncates `topology.jsonl` to the last reconstructed frame, and updates optional `"N/M"` progress.
 - **`portal/internal/api/replay.go:491-524`** — `writeChunkCache` / `readChunkCache`. Gzip-compressed JSON encode/decode of `ReplayChunk` to/from `<hourMs>.json.gz`.
 - **`portal/internal/api/replay.go:526-566`** — `loadChunk(replayDir, topologyPath, hourStart)`. Tries cached `.json.gz` first; falls back to scanning JSONL for that hour's frames if cache missing.
-- **`portal/internal/api/replay.go:568-593`** — `NewManifestHandler`. `GET /api/topology/manifest` — calls `buildManifest`, returns chunk index.
-- **`portal/internal/api/replay.go:595-639`** — `NewRebuildHandler`. `POST /api/topology/rebuild` — reconstructs the full tape from `fs.ReconstructTape`, then calls `writeReconstructedReplay` while holding `TopologyMu`.
-- **`portal/internal/api/replay.go:641-680`** — `NewChunkHandler`. `GET /api/topology/chunk?start=<hourMs>` — serves one delta-encoded chunk. Supports `Accept-Encoding: gzip` for transparent compression.
+- **`portal/internal/api/replay.go:568-591`** — `NewManifestHandler`. `GET /api/topology/manifest` — calls `buildManifest`, returns chunk index.
+- **`portal/internal/api/replay.go:593-635`** — `NewRebuildHandler`. `POST /api/topology/rebuild` — reconstructs the full tape from `fs.ReconstructTape`, then calls `writeReconstructedReplay` while holding `TopologyMu`.
+- **`portal/internal/api/replay.go:637-675`** — `NewChunkHandler`. `GET /api/topology/chunk?start=<hourMs>` — serves one delta-encoded chunk. Supports `Accept-Encoding: gzip` for transparent compression.
 
 ## Connections
 
-- **Called by `portal/main.go:71-74`.** `NewServer` + `srv.StartRecording` + `srv.Start` — the HTTP server is the portal's only runtime component.
+- **Called by `portal/main.go:73-88`.** `NewServer` + `srv.StartRecording` + `srv.Start` + `srv.URL` — the HTTP server is the portal's only runtime component.
 - **Calls `portal/internal/fs/`:** `BuildNetwork` (live snapshot), `ReconstructTape` (full rebuild from events + mailbox), and all types (`TapeFrame`, `Network`, `AgentNode`, `MailEdge`, etc.).
 - **Calls `portal/i18n/`:** `i18n.Lang()` for the language field on `/api/network` responses.
 - **Port file consumed by the TUI.** `main.go` writes `.portal/port` via `srv.Start`; the TUI reads it to discover the portal URL. See `tui/ANATOMY.md`.
@@ -66,7 +69,7 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 ## Composition
 
 - **Parent:** `portal/internal/`. Sibling packages: `fs/`, `migrate/`.
-- **Files:** `server.go` (~150 lines), `handlers.go` (~175 lines), `replay.go` (~680 lines), plus `*_test.go` files.
+- **Files:** `server.go` (~200 lines), `handlers.go` (~170 lines), `replay.go` (~675 lines), plus `*_test.go` files.
 - **No sub-packages.** All API logic is in this flat package.
 
 ## State
@@ -78,6 +81,8 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 
 ## Notes
 
+- **Loopback by default.** Empty host input resolves to `127.0.0.1`. Explicit `--host 0.0.0.0`, `--host ::`, or named/non-loopback hosts are allowed but treated as unauthenticated trusted-LAN exposure and warned about by the CLI.
+- **No wildcard CORS.** API handlers intentionally do not set `Access-Control-Allow-Origin: *`; same-origin browser requests from the embedded portal UI still work.
 - **TopologyMu is coarse-grained.** One global lock gates all topology I/O — both live append (3s ticker) and rebuild (POST handler). The rebuild endpoint replaces the file entirely while holding the lock.
 - **Delta encoding is the memory-replay strategy.** Instead of replaying every 3-second frame, the frontend requests hourly chunks and interpolates. Keyframes every 100 frames anchor the interpolation; deltas carry only changed fields.
 - **Old-format detection is structural.** `needsReconstruction` checks whether the most recent JSONL line's mail edges carry `direct` fields. Missing fields → rebuild. This is format migration driven by data inspection, not version stamps.

--- a/portal/internal/api/handlers.go
+++ b/portal/internal/api/handlers.go
@@ -36,7 +36,6 @@ func NewNetworkHandler(baseDir string) http.HandlerFunc {
 		}
 		network.Lang = i18n.Lang()
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		json.NewEncoder(w).Encode(network)
 	}
 }
@@ -49,7 +48,6 @@ func NewTopologyHandler(baseDir string) http.HandlerFunc {
 		data, err := os.ReadFile(topologyPath)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Write([]byte("[]"))
 			return
 		}
@@ -66,7 +64,6 @@ func NewTopologyHandler(baseDir string) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		json.NewEncoder(w).Encode(entries)
 	}
 }
@@ -142,7 +139,6 @@ func NewProgressHandler(baseDir string) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 
 		data, err := os.ReadFile(progressPath)
 		if err != nil {

--- a/portal/internal/api/handlers_test.go
+++ b/portal/internal/api/handlers_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +12,85 @@ import (
 
 	"github.com/anthropics/lingtai-portal/internal/fs"
 )
+
+func assertNoCORS(t *testing.T, rr *httptest.ResponseRecorder) {
+	t.Helper()
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want absent", got)
+	}
+}
+
+func TestHandlersDoNotSetCORSHeaders(t *testing.T) {
+	t.Run("network success", func(t *testing.T) {
+		handler := NewNetworkHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/network", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		handler := NewNetworkHandler(filepath.Join(t.TempDir(), "missing"))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/network", nil))
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("topology missing tape", func(t *testing.T) {
+		handler := NewTopologyHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("topology success", func(t *testing.T) {
+		dir := t.TempDir()
+		AppendTopologyAt(filepath.Join(dir, ".portal", "topology.jsonl"), fs.Network{}, 1000)
+		handler := NewTopologyHandler(dir)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("progress missing file", func(t *testing.T) {
+		handler := NewProgressHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/progress", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("progress success", func(t *testing.T) {
+		dir := t.TempDir()
+		progressPath := filepath.Join(dir, ".portal", "reconstruct.progress")
+		if err := os.MkdirAll(filepath.Dir(progressPath), 0o755); err != nil {
+			t.Fatalf("mkdir progress dir: %v", err)
+		}
+		if err := os.WriteFile(progressPath, []byte("2/5"), 0o644); err != nil {
+			t.Fatalf("write progress: %v", err)
+		}
+		handler := NewProgressHandler(dir)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/progress", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+}
 
 func TestAppendTopologyAt_ExplicitTimestamp(t *testing.T) {
 	dir := t.TempDir()

--- a/portal/internal/api/replay.go
+++ b/portal/internal/api/replay.go
@@ -578,7 +578,6 @@ func NewManifestHandler(baseDir string) http.HandlerFunc {
 
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Access-Control-Allow-Origin", "*")
 			json.NewEncoder(w).Encode(ReplayManifest{Chunks: []ChunkInfo{}})
 			return
 		}
@@ -587,7 +586,6 @@ func NewManifestHandler(baseDir string) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		json.NewEncoder(w).Encode(manifest)
 	}
 }
@@ -614,7 +612,6 @@ func NewRebuildHandler(baseDir string) http.HandlerFunc {
 		}
 		if len(frames) == 0 {
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Access-Control-Allow-Origin", "*")
 			json.NewEncoder(w).Encode(ReplayManifest{Chunks: []ChunkInfo{}})
 			return
 		}
@@ -633,7 +630,6 @@ func NewRebuildHandler(baseDir string) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		json.NewEncoder(w).Encode(manifest)
 	}
 }
@@ -665,7 +661,6 @@ func NewChunkHandler(baseDir string) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 
 		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 			w.Header().Set("Content-Encoding", "gzip")

--- a/portal/internal/api/replay_test.go
+++ b/portal/internal/api/replay_test.go
@@ -401,6 +401,7 @@ func TestManifestHandler(t *testing.T) {
 	if len(manifest.Chunks) == 0 {
 		t.Error("expected at least 1 chunk")
 	}
+	assertNoCORS(t, rr)
 }
 
 func TestChunkHandler(t *testing.T) {
@@ -455,4 +456,77 @@ func TestChunkHandler(t *testing.T) {
 	if len(chunk.Frames) != 2 {
 		t.Errorf("len(Frames) = %d, want 2", len(chunk.Frames))
 	}
+	assertNoCORS(t, rr)
+}
+
+func TestReplayHandlersDoNotSetCORSHeadersOnFallbackAndErrorPaths(t *testing.T) {
+	t.Run("manifest empty fallback", func(t *testing.T) {
+		handler := NewManifestHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/manifest", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("rebuild method error", func(t *testing.T) {
+		handler := NewRebuildHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/rebuild", nil))
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want 405", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("rebuild filesystem error", func(t *testing.T) {
+		handler := NewRebuildHandler(filepath.Join(t.TempDir(), "missing"))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/topology/rebuild", nil))
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("rebuild empty tape", func(t *testing.T) {
+		handler := NewRebuildHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/topology/rebuild", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("chunk missing start error", func(t *testing.T) {
+		handler := NewChunkHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/chunk", nil))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("chunk invalid start error", func(t *testing.T) {
+		handler := NewChunkHandler(t.TempDir())
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/chunk?start=nope", nil))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
+
+	t.Run("chunk filesystem error", func(t *testing.T) {
+		handler := NewChunkHandler(filepath.Join(t.TempDir(), "missing"))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/topology/chunk?start=0", nil))
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rr.Code)
+		}
+		assertNoCORS(t, rr)
+	})
 }

--- a/portal/internal/api/server.go
+++ b/portal/internal/api/server.go
@@ -10,14 +10,19 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	agentfs "github.com/anthropics/lingtai-portal/internal/fs"
 )
 
+const defaultHost = "127.0.0.1"
+
 type Server struct {
 	httpServer *http.Server
 	port       int
+	host       string
 	baseDir    string
 	cancel     context.CancelFunc
 	done       chan struct{}
@@ -40,15 +45,18 @@ func NewServer(baseDir string, staticFS fs.FS) *Server {
 	}
 }
 
-func (s *Server) Start(portFile string, fixedPort int) error {
-	addr := "0.0.0.0:0"
+func (s *Server) Start(portFile, host string, fixedPort int) error {
+	effectiveHost := EffectiveHost(host)
+	port := "0"
 	if fixedPort > 0 {
-		addr = fmt.Sprintf("0.0.0.0:%d", fixedPort)
+		port = strconv.Itoa(fixedPort)
 	}
+	addr := net.JoinHostPort(effectiveHost, port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("listen: %w", err)
 	}
+	s.host = effectiveHost
 	s.port = ln.Addr().(*net.TCPAddr).Port
 	if portFile != "" {
 		os.WriteFile(portFile, []byte(fmt.Sprintf("%d", s.port)), 0o644)
@@ -109,8 +117,52 @@ func (s *Server) Port() int {
 	return s.port
 }
 
+func (s *Server) Host() string {
+	return s.host
+}
+
 func (s *Server) URL() string {
-	return fmt.Sprintf("http://localhost:%d", s.port)
+	host := s.host
+	if host == "" || hostIsLoopback(host) || hostIsWildcard(host) {
+		host = "localhost"
+	}
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(s.port))
+}
+
+func (s *Server) ExternalAccessWarning() string {
+	if !HostRequiresWarning(s.host) {
+		return ""
+	}
+	return fmt.Sprintf("warning: --host %s exposes the unauthenticated portal API beyond loopback; use only on a trusted LAN.", s.host)
+}
+
+func EffectiveHost(host string) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	}
+	if host == "" {
+		return defaultHost
+	}
+	return host
+}
+
+func HostRequiresWarning(host string) bool {
+	host = EffectiveHost(host)
+	return !hostIsLoopback(host) || hostIsWildcard(host)
+}
+
+func hostIsLoopback(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func hostIsWildcard(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
 }
 
 func (s *Server) Stop(ctx context.Context) error {

--- a/portal/internal/api/server_test.go
+++ b/portal/internal/api/server_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestServerStartDefaultsToLoopbackAndKeepsPortFilePortOnly(t *testing.T) {
+	dir := t.TempDir()
+	portFile := filepath.Join(dir, "port")
+	srv := NewServer(dir, nil)
+	if err := srv.Start(portFile, "", 0); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer srv.Stop(context.Background())
+
+	if got := srv.Host(); got != defaultHost {
+		t.Fatalf("Host() = %q, want %q", got, defaultHost)
+	}
+	if got, want := srv.URL(), fmt.Sprintf("http://localhost:%d", srv.Port()); got != want {
+		t.Fatalf("URL() = %q, want %q", got, want)
+	}
+
+	data, err := os.ReadFile(portFile)
+	if err != nil {
+		t.Fatalf("read port file: %v", err)
+	}
+	portText := strings.TrimSpace(string(data))
+	if _, err := strconv.Atoi(portText); err != nil {
+		t.Fatalf("port file = %q, want decimal port only: %v", portText, err)
+	}
+	if portText != strconv.Itoa(srv.Port()) {
+		t.Fatalf("port file = %q, want %d", portText, srv.Port())
+	}
+	if strings.Contains(portText, ":") {
+		t.Fatalf("port file = %q, want port only without host", portText)
+	}
+}
+
+func TestServerStartWildcardHostKeepsLocalhostURL(t *testing.T) {
+	srv := NewServer(t.TempDir(), nil)
+	if err := srv.Start("", "0.0.0.0", 0); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer srv.Stop(context.Background())
+
+	if got := srv.Host(); got != "0.0.0.0" {
+		t.Fatalf("Host() = %q, want 0.0.0.0", got)
+	}
+	if got, want := srv.URL(), fmt.Sprintf("http://localhost:%d", srv.Port()); got != want {
+		t.Fatalf("URL() = %q, want %q", got, want)
+	}
+}
+
+func TestServerURLUsesExplicitNamedHosts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "dns", host: "portal.example.test", want: "http://portal.example.test:4321"},
+		{name: "ipv4", host: "192.0.2.10", want: "http://192.0.2.10:4321"},
+		{name: "ipv6", host: "2001:db8::1", want: "http://[2001:db8::1]:4321"},
+		{name: "loopback_ipv6", host: "::1", want: "http://localhost:4321"},
+		{name: "wildcard_ipv6", host: "::", want: "http://localhost:4321"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &Server{host: tc.host, port: 4321}
+			if got := srv.URL(); got != tc.want {
+				t.Fatalf("URL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHostWarningsOnlyForExternalOrWildcardBinds(t *testing.T) {
+	for _, tc := range []struct {
+		host string
+		warn bool
+	}{
+		{host: "", warn: false},
+		{host: "127.0.0.1", warn: false},
+		{host: "::1", warn: false},
+		{host: "localhost", warn: false},
+		{host: "0.0.0.0", warn: true},
+		{host: "::", warn: true},
+		{host: "192.0.2.10", warn: true},
+		{host: "portal.example.test", warn: true},
+	} {
+		t.Run(tc.host, func(t *testing.T) {
+			got := HostRequiresWarning(tc.host)
+			if got != tc.warn {
+				t.Fatalf("HostRequiresWarning(%q) = %v, want %v", tc.host, got, tc.warn)
+			}
+		})
+	}
+
+	srv := &Server{host: "0.0.0.0"}
+	warning := srv.ExternalAccessWarning()
+	if !strings.Contains(warning, "unauthenticated") || !strings.Contains(warning, "trusted LAN") {
+		t.Fatalf("warning %q should mention unauthenticated trusted-LAN exposure", warning)
+	}
+}

--- a/portal/main.go
+++ b/portal/main.go
@@ -32,11 +32,13 @@ func main() {
 	}
 
 	var dir string
+	var host string
 	var port int
 	var open bool
 	var lang string
 
 	flag.StringVar(&dir, "dir", "", "Path to project directory (default: current directory)")
+	flag.StringVar(&host, "host", "", "Host to bind (default: 127.0.0.1)")
 	flag.IntVar(&port, "port", 0, "Fixed port (default: random)")
 	flag.BoolVar(&open, "open", false, "Open browser after starting")
 	flag.StringVar(&lang, "lang", "en", "Language (en, zh, wen)")
@@ -71,9 +73,12 @@ func main() {
 	srv := api.NewServer(lingtaiDir, WebFS())
 	srv.StartRecording(lingtaiDir)
 	portFile := filepath.Join(portalDir, "port")
-	if err := srv.Start(portFile, port); err != nil {
+	if err := srv.Start(portFile, host, port); err != nil {
 		fmt.Fprintf(os.Stderr, "error starting server: %v\n", err)
 		os.Exit(1)
+	}
+	if warning := srv.ExternalAccessWarning(); warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
 	}
 
 	fmt.Printf("lingtai-portal serving %s\n", lingtaiDir)


### PR DESCRIPTION
Fixes Lingtai-AI/lingtai#561.

## Summary

- default the portal listener to loopback (`127.0.0.1`) instead of all interfaces
- add an explicit `--host` opt-in for non-loopback / wildcard binds, with a warning that the portal API remains unauthenticated and trusted-LAN only
- preserve the existing TUI handoff contract by keeping `.portal/port` as a port-only file and preserving `http://localhost:<port>` display/open URLs for loopback and wildcard binds
- remove wildcard `Access-Control-Allow-Origin: *` from portal API handlers, including replay and fallback/error paths

## Why

The portal serves agent topology/mail-derived runtime information and has no authentication. Binding to `0.0.0.0` by default exposes that API to the local network. Wildcard CORS also lets arbitrary browser origins read API responses when the portal is reachable.

This PR makes the default safe local-only behavior while keeping explicit external binding available for users who intentionally want trusted-LAN access.

## Behavior

- `lingtai-portal` now has a `--host` flag.
- Empty `--host` resolves to `127.0.0.1`.
- `api.Server.Start` listens with `net.JoinHostPort`, stores the effective host, and still writes only the bound port to `.portal/port`.
- `Server.URL()` still returns `http://localhost:<port>` for loopback and wildcard binds; explicit named/non-loopback hosts render directly, including IPv6 bracket formatting.
- Explicit wildcard/non-loopback binds print a warning about unauthenticated trusted-LAN exposure.
- Portal API handlers no longer emit wildcard CORS headers.

## Non-goals / residual risks

This intentionally stays narrow. It does **not** add authentication, a Host allowlist, Origin/CSRF enforcement, or a `--dev-cors` mode.

Residual risks remain and should not be considered solved by this PR:

- DNS rebinding still needs browser-facing hardening such as Host allowlisting plus Origin/CSRF handling.
- Browser `no-cors` POST-style risks are not eliminated by removing CORS response headers.
- `--host 0.0.0.0`, `--host ::`, or explicit non-loopback hosts remain unauthenticated and should be used only on trusted networks.

## Validation

- `go build ./...` from `portal/`
- `go vet ./...` from `portal/`
- `go test ./...` from `portal/`
- `git diff --check canonical/main...HEAD`
- grep confirmed remaining `Access-Control-Allow-Origin` references are only tests asserting absence and the anatomy note documenting no wildcard CORS

Notes:

- A fresh portal checkout needs the existing frontend embed prerequisite (`portal/web/dist`) before `go build ./...` / `go vet ./...`; I built it locally for validation and did not commit generated artifacts.
- `npm ci` reported pre-existing dependency audit findings; dependency remediation is outside this issue.

## Review

The implementation was independently reviewed by Codex, Claude Code, and GLM review daemons. All three considered it standard, simple, scope-correct, and public-PR-ready; the only feedback was non-blocking cleanup nits.