### PR TITLE
Tombstone replay edge removals

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -120,7 +120,7 @@ The repo root holds two binary trees plus shared infrastructure. Each binary is 
 
 | Package | LOC | Role |
 |---------|-----|------|
-| `portal/internal/api/` | ~1.5k | HTTP server (`server.go`), handlers (`handlers.go`), and replay endpoint (`replay.go` — 680 lines, the largest single API surface). Listens on a randomly-chosen port (or `--port`), writes the bound port to `.portal/port` so the TUI can find it. |
+| `portal/internal/api/` | ~1.5k | HTTP server (`server.go`), handlers (`handlers.go`), and replay endpoint (`replay.go` — 784 lines, the largest single API surface). Listens on a randomly-chosen port (or `--port`), writes the bound port to `.portal/port` so the TUI can find it. |
 | `portal/internal/fs/` | ~2.2k | Same shape as `tui/internal/fs/` but tailored to portal's needs: agent reading, heartbeat, mail, network/topology reconstruction (`reconstruct.go`, 326 lines), location resolution. |
 | `portal/internal/migrate/` | — | Retained m001–m039 historical source/tests and registry API; Portal production startup does not execute it or advance `.lingtai/meta.json`. See `portal/internal/migrate/ANATOMY.md`. |
 | `portal/web/` | — | React 19 + TypeScript + Vite frontend. Source under `portal/web/src/` (`App.tsx`, `Graph.tsx`, `BottomBar.tsx`, `FilterPanel.tsx`, etc.). Builds to `portal/web/dist/` then `embed.go` (`//go:embed all:web/dist`) compiles it into the Go binary. |

--- a/portal/ANATOMY.md
+++ b/portal/ANATOMY.md
@@ -42,7 +42,7 @@ The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` 
 - **`portal/embed.go:8-9`** — `//go:embed all:web/dist` compiles the React frontend build output into `webDist embed.FS`. No runtime Node dependency.
 - **`portal/embed.go:11-17`** — `WebFS()` returns `fs.Sub(webDist, "web/dist")` so the HTTP server mounts from the `web/dist/` root.
 - **`Makefile:1-24`** — Build pipeline. `web-build` runs `npm install && npm run build` in `web/`; `go-build` depends on it and stamps `main.version` via `-ldflags`. `cross-compile` targets darwin/linux × arm64/amd64.
-- **`internal/api/`** — HTTP server, handlers, and the replay endpoint. See `portal/internal/api/ANATOMY.md`.
+- **`internal/api/`** — HTTP server, handlers, and the 784-line replay endpoint. See `portal/internal/api/ANATOMY.md`.
 - **`internal/fs/`** — Filesystem readers: agent manifests, heartbeat, mailbox, network reconstruction (`reconstruct.go`), topology types (`types.go`). Same shape as `tui/internal/fs/` but Portal-specific.
 - **`internal/migrate/`** — retained m001–m039 source/tests and registry history; production Portal does not import or execute it. See `portal/internal/migrate/ANATOMY.md`.
 - **`web/`** — React 19 + TypeScript + Vite frontend. Source under `web/src/`; builds to `web/dist/`.
@@ -69,7 +69,7 @@ The `lingtai-portal` binary: a single Go binary that reads the same `.lingtai/` 
 - **`.portal/port`** — Written on server start (`portal/main.go:75-76` → `portal/internal/api/server.go:61-62`). Contains only the bound TCP port as an ASCII integer. Read by the TUI to know where to open the browser.
 - **`.portal/topology.jsonl`** — JSONL tape of network snapshots. Each line is `{"t": <unix_ms>, "net": <Network>}`. Appended every 3 seconds by `StartRecording` (`portal/internal/api/server.go:96-110`); also appended by the live handlers on each request.
 - **`.portal/replay/chunks/`** — Compressed hourly replay chunks (`<hourMs>.json.gz`), each containing delta-encoded frames with keyframes every 100 frames. Plus `manifest.json` indexing all chunks.
-- **`.portal/reconstruct.progress`** — Temporary `"N/M"` progress file during tape reconstruction. Startup creates/deletes it in `StartRecording` (`portal/internal/api/server.go:82-93`); the shared replay writer updates it while caching reconstructed frames (`portal/internal/api/replay.go:417-446`).
+- **`.portal/reconstruct.progress`** — Temporary `"N/M"` progress file during tape reconstruction. Startup creates/deletes it in `StartRecording` (`portal/internal/api/server.go:82-93`); the shared replay writer seeds it with `0/N` and then updates it as `%d/%d` while caching reconstructed frames (`portal/internal/api/replay.go:443-525`, initial write at `457`, per-batch update at `478-482`).
 - **`meta.json`** — Legacy project migration metadata may remain under `.lingtai/`; Portal production does not read, write, or advance it.
 
 ## Notes

--- a/portal/internal/api/ANATOMY.md
+++ b/portal/internal/api/ANATOMY.md
@@ -45,19 +45,20 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 - **`portal/internal/api/handlers.go:135-155`** — `NewProgressHandler(baseDir)`. `GET /api/topology/progress` — reads `reconstruct.progress` (`"N/M"` format), returns `{"current":N,"total":M}` or `{}`.
 - **`portal/internal/api/handlers_test.go:16-93`** — CORS regression coverage for live network, topology, and progress handlers, including success and error/fallback responses.
 
-### Replay (`replay.go`, ~675 lines)
+### Replay (`replay.go`, 784 lines)
 
-- **`portal/internal/api/replay.go:18-56`** — Wire types: `ReplayChunk` (delta-encoded hour range), `ReplayFrame` (keyframe or delta), `FrameDelta` (only-changed fields), `ChunkInfo` (manifest entry), `ReplayManifest` (tape bounds + chunk list).
-- **`portal/internal/api/replay.go:60-87`** — `deltaEncode(frames, keyframeInterval)`. Converts `[]TapeFrame` into a `ReplayChunk` with full keyframes every N frames and `FrameDelta` in between.
-- **`portal/internal/api/replay.go:91-178`** — `computeDelta(prev, curr)`. Field-by-field diff of two `Network` values: nodes (with `__REMOVED__` tombstones), avatar/contact/mail edges (keyed by identifier pairs), and stats. Returns nil if nothing changed.
-- **`portal/internal/api/replay.go:217-335`** — `buildManifest(topologyPath, replayDir)`. Fast path: reads cached `manifest.json`, scans only new JSONL frames after the last completed chunk, caches newly-completed hours as `.json.gz`. O(new_frames). `manifest.TapeStart` is the first real frame timestamp (preferred from the cached manifest, then `firstFrameForChunk`, then the bucket floor as last-resort) — NOT `chunks[0].Start`, which is the hour-bucket floor and would render as ~55min of empty scrubber padding.
-- **`portal/internal/api/replay.go:337-372`** — `firstFrameForChunk(info, replayDir, topologyPath)`. Returns the earliest frame timestamp in a chunk, reading `<hourMs>.json.gz` first and falling back to a JSONL scan within the chunk's hour window. Used by `buildManifest` when no cached `TapeStart` is available.
-- **`portal/internal/api/replay.go:405-489`** — `writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)`. Shared writer for already-reconstructed tapes: replaces replay chunks, writes `manifest.json` with `TapeStart = frames[0].T`, truncates `topology.jsonl` to the last reconstructed frame, and updates optional `"N/M"` progress.
-- **`portal/internal/api/replay.go:491-524`** — `writeChunkCache` / `readChunkCache`. Gzip-compressed JSON encode/decode of `ReplayChunk` to/from `<hourMs>.json.gz`.
-- **`portal/internal/api/replay.go:526-566`** — `loadChunk(replayDir, topologyPath, hourStart)`. Tries cached `.json.gz` first; falls back to scanning JSONL for that hour's frames if cache missing.
-- **`portal/internal/api/replay.go:568-591`** — `NewManifestHandler`. `GET /api/topology/manifest` — calls `buildManifest`, returns chunk index.
-- **`portal/internal/api/replay.go:593-635`** — `NewRebuildHandler`. `POST /api/topology/rebuild` — reconstructs the full tape from `fs.ReconstructTape`, then calls `writeReconstructedReplay` while holding `TopologyMu`.
-- **`portal/internal/api/replay.go:637-675`** — `NewChunkHandler`. `GET /api/topology/chunk?start=<hourMs>` — serves one delta-encoded chunk. Supports `Accept-Encoding: gzip` for transparent compression.
+- **`portal/internal/api/replay.go:19-64`** — Wire types: versioned `ReplayChunk` (delta-encoded hour range), `ReplayFrame` (keyframe or delta), `FrameDelta` (only-changed fields plus removed avatar/contact/mail key pairs), `ChunkInfo` (manifest entry), `ReplayManifest` (tape bounds + chunk list).
+- **`portal/internal/api/replay.go:68-98`** — `deltaEncode(frames, keyframeInterval)`. Converts `[]TapeFrame` into a V2 `ReplayChunk` with full keyframes every N frames and `FrameDelta` in between.
+- **`portal/internal/api/replay.go:100-215`** — `computeDelta(prev, curr)`. Field-by-field diff of two `Network` values: nodes (with `__REMOVED__` tombstones), avatar/contact/mail edge additions/changes and removals (keyed by identifier pairs), and stats. Returns nil if nothing changed.
+- **`portal/internal/api/replay.go:256-374`** — `buildManifest(topologyPath, replayDir)`. Fast path: reads cached `manifest.json`, scans only new JSONL frames after the last completed chunk, caches newly-completed hours as `.json.gz`. O(new_frames). `manifest.TapeStart` is the first real frame timestamp (preferred from the cached manifest, then `firstFrameForChunk`, then the bucket floor as last-resort) — NOT `chunks[0].Start`, which is the hour-bucket floor and would render as ~55min of empty scrubber padding.
+- **`portal/internal/api/replay.go:376-408`** — `firstFrameForChunk(info, replayDir, topologyPath)`. Returns the earliest frame timestamp in a chunk, reading `<hourMs>.json.gz` first, accepting readable stale V0 chunks for timestamp lookup, and falling back to a JSONL scan within the chunk's hour window. Used by `buildManifest` when no cached `TapeStart` is available.
+- **`portal/internal/api/replay.go:413-439`** — `scanJSONLFrom(topologyPath, fromMs)`. Streams `topology.jsonl` and returns every frame with `T >= fromMs`, skipping blank and unparseable lines. Used by `buildManifest` for the tail scan.
+- **`portal/internal/api/replay.go:443-525`** — `writeReconstructedReplay(topologyPath, replayDir, progressPath, frames)`. Shared writer for already-reconstructed tapes: replaces replay chunks, writes `manifest.json` with `TapeStart = frames[0].T`, truncates `topology.jsonl` to the last reconstructed frame, and updates optional `"N/M"` progress.
+- **`portal/internal/api/replay.go:527-567`** — `writeChunkCache` / `readChunkCache`. Gzip-compressed JSON encode/decode of `ReplayChunk` to/from `<hourMs>.json.gz`; readable missing-version chunks return a stale-format sentinel, while corrupt/unreadable chunks remain ordinary errors.
+- **`portal/internal/api/replay.go:568-678`** — `loadChunk(replayDir, topologyPath, hourStart)` plus JSONL coverage helpers (`scanJSONLChunk`, `jsonlCoversStaleChunk`). Tries cached V2 first; for stale V0 caches, reconstructs a V2 chunk from JSONL **in memory only** when JSONL covers the stale chunk, otherwise serves the readable stale chunk as compatibility fallback. `loadChunk` is a read path and never writes, replaces, or truncates a cache file — a stale V0 chunk may be the only surviving copy of that hour. Coverage is **sequence-aware**: the stale timestamp sequence must be a subsequence of the JSONL timestamps, matching relative order and every duplicate occurrence, while extra JSONL frames anywhere around it are permitted. Frame count plus endpoints is not sufficient (JSONL `[0, 6, 9]` does not cover stale `[0, 3, 6]`), and neither is distinct-timestamp set membership (JSONL `[0, 3, 6, 9]` covers neither stale `[0, 3, 3, 6]` — one occurrence of T=3 lost — nor the reordered stale `[0, 6, 3]`).
+- **`portal/internal/api/replay.go:679-704`** — `NewManifestHandler`. `GET /api/topology/manifest` — calls `buildManifest`, returns chunk index.
+- **`portal/internal/api/replay.go:705-746`** — `NewRebuildHandler`. `POST /api/topology/rebuild` — reconstructs the full tape from `fs.ReconstructTape`, then calls `writeReconstructedReplay` while holding `TopologyMu`.
+- **`portal/internal/api/replay.go:747-784`** — `NewChunkHandler`. `GET /api/topology/chunk?start=<hourMs>` — serves one delta-encoded chunk. Supports `Accept-Encoding: gzip` for transparent compression.
 
 ## Connections
 
@@ -69,15 +70,15 @@ HTTP server for `lingtai-portal`: serves the embedded React SPA on `/` and a JSO
 ## Composition
 
 - **Parent:** `portal/internal/`. Sibling packages: `fs/`, `migrate/`.
-- **Files:** `server.go` (~200 lines), `handlers.go` (~170 lines), `replay.go` (~675 lines), plus `*_test.go` files.
+- **Files:** `server.go` (~200 lines), `handlers.go` (~170 lines), `replay.go` (~784 lines), plus `*_test.go` files.
 - **No sub-packages.** All API logic is in this flat package.
 
 ## State
 
 - **`.portal/topology.jsonl`** — Always written with `TopologyMu` held. Appended by `AppendTopology` (live recording) and overwritten by `NewRebuildHandler` (reconstruction).
-- **`.portal/replay/chunks/<hourMs>.json.gz`** — Gzip-compressed delta-encoded hourly chunks. Written by `writeReconstructedReplay` for reconstructed tapes (`portal/internal/api/replay.go:454-466`) and by `buildManifest` when a new live-recorded hour completes (`portal/internal/api/replay.go:282-298`).
-- **`.portal/replay/chunks/manifest.json`** — Chunk index (`ReplayManifest`). Written by `writeReconstructedReplay` (`portal/internal/api/replay.go:480-485`) and `buildManifest` (`portal/internal/api/replay.go:329-331`).
-- **`.portal/reconstruct.progress`** — Temporary `"N/M"` file. Written by `StartRecording` / `writeReconstructedReplay` during reconstruction (`portal/internal/api/server.go:76-85`, `portal/internal/api/replay.go:417-446`) and read by `/api/topology/progress`.
+- **`.portal/replay/chunks/<hourMs>.json.gz`** — Gzip-compressed delta-encoded hourly chunks. Written by `writeReconstructedReplay` for reconstructed tapes (`portal/internal/api/replay.go:490-502`) and by `buildManifest` when a new live-recorded hour completes (`portal/internal/api/replay.go:327-332`).
+- **`.portal/replay/chunks/manifest.json`** — Chunk index (`ReplayManifest`). Written by `writeReconstructedReplay` (`portal/internal/api/replay.go:516-520`) and `buildManifest` (`portal/internal/api/replay.go:365-367`).
+- **`.portal/reconstruct.progress`** — Temporary `"N/M"` file. Written by `StartRecording` / `writeReconstructedReplay` during reconstruction (`portal/internal/api/server.go:76-85`, `portal/internal/api/replay.go:453-482`) and read by `/api/topology/progress`.
 
 ## Notes
 

--- a/portal/internal/api/replay.go
+++ b/portal/internal/api/replay.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,9 +17,13 @@ import (
 )
 
 const defaultKeyframeInterval = 100
+const chunkFormatVersion = 2
+
+var errStaleChunkFormat = errors.New("stale replay chunk format")
 
 // ReplayChunk is the wire format for a range of delta-encoded topology frames.
 type ReplayChunk struct {
+	V                int           `json:"v,omitempty"`
 	Start            int64         `json:"start"`
 	End              int64         `json:"end"`
 	KeyframeInterval int           `json:"keyframe_interval"`
@@ -34,11 +39,14 @@ type ReplayFrame struct {
 
 // FrameDelta holds only the fields that changed relative to the previous frame.
 type FrameDelta struct {
-	Nodes        []fs.AgentNode   `json:"nodes,omitempty"`
-	AvatarEdges  []fs.AvatarEdge  `json:"avatar_edges,omitempty"`
-	ContactEdges []fs.ContactEdge `json:"contact_edges,omitempty"`
-	Mail         []fs.MailEdge    `json:"mail,omitempty"`
-	Stats        *fs.NetworkStats `json:"stats,omitempty"`
+	Nodes               []fs.AgentNode   `json:"nodes,omitempty"`
+	AvatarEdges         []fs.AvatarEdge  `json:"avatar_edges,omitempty"`
+	AvatarEdgesRemoved  [][2]string      `json:"avatar_edges_removed,omitempty"`
+	ContactEdges        []fs.ContactEdge `json:"contact_edges,omitempty"`
+	ContactEdgesRemoved [][2]string      `json:"contact_edges_removed,omitempty"`
+	Mail                []fs.MailEdge    `json:"mail,omitempty"`
+	MailRemoved         [][2]string      `json:"mail_removed,omitempty"`
+	Stats               *fs.NetworkStats `json:"stats,omitempty"`
 }
 
 // ChunkInfo is a manifest entry describing one chunk.
@@ -59,6 +67,7 @@ type ReplayManifest struct {
 // every keyframeInterval frames and compact deltas in between.
 func deltaEncode(frames []fs.TapeFrame, keyframeInterval int) ReplayChunk {
 	chunk := ReplayChunk{
+		V:                chunkFormatVersion,
 		KeyframeInterval: keyframeInterval,
 	}
 	if len(frames) == 0 {
@@ -128,10 +137,19 @@ func computeDelta(prev, curr *fs.Network) *FrameDelta {
 	for _, e := range prev.AvatarEdges {
 		prevAvatars[avatarKey{e.Parent, e.Child}] = e
 	}
+	currAvatars := make(map[avatarKey]bool, len(curr.AvatarEdges))
 	for _, e := range curr.AvatarEdges {
 		k := avatarKey{e.Parent, e.Child}
+		currAvatars[k] = true
 		if pe, ok := prevAvatars[k]; !ok || pe != e {
 			delta.AvatarEdges = append(delta.AvatarEdges, e)
+			hasChange = true
+		}
+	}
+	for _, e := range prev.AvatarEdges {
+		k := avatarKey{e.Parent, e.Child}
+		if !currAvatars[k] {
+			delta.AvatarEdgesRemoved = append(delta.AvatarEdgesRemoved, [2]string{e.Parent, e.Child})
 			hasChange = true
 		}
 	}
@@ -142,10 +160,19 @@ func computeDelta(prev, curr *fs.Network) *FrameDelta {
 	for _, e := range prev.ContactEdges {
 		prevContacts[contactKey{e.Owner, e.Target}] = e
 	}
+	currContacts := make(map[contactKey]bool, len(curr.ContactEdges))
 	for _, e := range curr.ContactEdges {
 		k := contactKey{e.Owner, e.Target}
+		currContacts[k] = true
 		if pe, ok := prevContacts[k]; !ok || pe != e {
 			delta.ContactEdges = append(delta.ContactEdges, e)
+			hasChange = true
+		}
+	}
+	for _, e := range prev.ContactEdges {
+		k := contactKey{e.Owner, e.Target}
+		if !currContacts[k] {
+			delta.ContactEdgesRemoved = append(delta.ContactEdgesRemoved, [2]string{e.Owner, e.Target})
 			hasChange = true
 		}
 	}
@@ -156,10 +183,19 @@ func computeDelta(prev, curr *fs.Network) *FrameDelta {
 	for _, e := range prev.MailEdges {
 		prevMail[mailKey{e.Sender, e.Recipient}] = e
 	}
+	currMail := make(map[mailKey]bool, len(curr.MailEdges))
 	for _, e := range curr.MailEdges {
 		k := mailKey{e.Sender, e.Recipient}
+		currMail[k] = true
 		if pe, ok := prevMail[k]; !ok || pe != e {
 			delta.Mail = append(delta.Mail, e)
+			hasChange = true
+		}
+	}
+	for _, e := range prev.MailEdges {
+		k := mailKey{e.Sender, e.Recipient}
+		if !currMail[k] {
+			delta.MailRemoved = append(delta.MailRemoved, [2]string{e.Sender, e.Recipient})
 			hasChange = true
 		}
 	}
@@ -339,7 +375,7 @@ func buildManifest(topologyPath, replayDir string) (ReplayManifest, error) {
 // if no frame can be located.
 func firstFrameForChunk(info ChunkInfo, replayDir, topologyPath string) int64 {
 	cachePath := filepath.Join(replayDir, strconv.FormatInt(info.Start, 10)+".json.gz")
-	if chunk, err := readChunkCache(cachePath); err == nil && len(chunk.Frames) > 0 {
+	if chunk, err := readChunkCache(cachePath); (err == nil || errors.Is(err, errStaleChunkFormat)) && len(chunk.Frames) > 0 {
 		return chunk.Frames[0].T
 	}
 	// Fallback: scan JSONL for the first frame in this chunk's hour window.
@@ -520,18 +556,52 @@ func readChunkCache(path string) (ReplayChunk, error) {
 	if err := json.NewDecoder(gr).Decode(&chunk); err != nil {
 		return ReplayChunk{}, err
 	}
+	if chunk.V == 0 {
+		return chunk, errStaleChunkFormat
+	}
+	if chunk.V != chunkFormatVersion {
+		return ReplayChunk{}, fmt.Errorf("unsupported replay chunk format version %d", chunk.V)
+	}
 	return chunk, nil
 }
 
 func loadChunk(replayDir, topologyPath string, hourStart int64) (ReplayChunk, error) {
 	cachePath := filepath.Join(replayDir, strconv.FormatInt(hourStart, 10)+".json.gz")
-	if chunk, err := readChunkCache(cachePath); err == nil {
-		return chunk, nil
+	cachedChunk, cacheErr := readChunkCache(cachePath)
+	if cacheErr == nil {
+		return cachedChunk, nil
+	}
+	hasStaleCache := errors.Is(cacheErr, errStaleChunkFormat)
+
+	frames, err := scanJSONLChunk(topologyPath, hourStart)
+	if err != nil {
+		if hasStaleCache {
+			return cachedChunk, nil
+		}
+		return ReplayChunk{}, err
 	}
 
+	if len(frames) == 0 {
+		if hasStaleCache {
+			return cachedChunk, nil
+		}
+		return ReplayChunk{V: chunkFormatVersion, Start: hourStart, End: hourStart}, nil
+	}
+
+	if hasStaleCache && !jsonlCoversStaleChunk(frames, cachedChunk) {
+		return cachedChunk, nil
+	}
+
+	// Reconstruction is in-memory only. loadChunk is a read path, so it must
+	// never persistently mutate or replace the on-disk cache: a stale V0 chunk
+	// can be the only surviving copy of that hour's history.
+	return deltaEncode(frames, defaultKeyframeInterval), nil
+}
+
+func scanJSONLChunk(topologyPath string, hourStart int64) ([]fs.TapeFrame, error) {
 	f, err := os.Open(topologyPath)
 	if err != nil {
-		return ReplayChunk{}, err
+		return nil, err
 	}
 	defer f.Close()
 
@@ -557,12 +627,51 @@ func loadChunk(replayDir, topologyPath string, hourStart int64) (ReplayChunk, er
 		}
 		frames = append(frames, frame)
 	}
+	return frames, scanner.Err()
+}
 
-	if len(frames) == 0 {
-		return ReplayChunk{Start: hourStart, End: hourStart}, nil
+// jsonlCoversStaleChunk reports whether the JSONL frames can stand in for a
+// stale V0 chunk. The stale timestamp sequence must be a subsequence of the
+// JSONL timestamps: same relative order, every duplicate occurrence matched by
+// a distinct JSONL frame, with extra JSONL frames allowed anywhere around it.
+//
+// Weaker predicates silently drop history. Count plus endpoints accepts JSONL
+// [0, 6, 9] for stale [0, 3, 6], which omits T=3. Distinct-timestamp set
+// membership additionally accepts JSONL [0, 3, 6, 9] for stale [0, 3, 3, 6]
+// (one occurrence of T=3 lost, hidden by the extra T=9) and for the reordered
+// stale [0, 6, 3]. Only a sequence-aware check rejects all three.
+func jsonlCoversStaleChunk(frames []fs.TapeFrame, stale ReplayChunk) bool {
+	if len(stale.Frames) == 0 {
+		return len(frames) > 0
+	}
+	// Cheap necessary conditions, kept as early-outs. Each only rejects, and
+	// each rejection also fails the subsequence scan below, so they cannot
+	// change the result — a subsequence needs at least as many JSONL frames,
+	// and (JSONL being ascending) the stale head/tail must lie within range.
+	if len(frames) < len(stale.Frames) {
+		return false
+	}
+	if frames[0].T > stale.Frames[0].T {
+		return false
+	}
+	if frames[len(frames)-1].T < stale.Frames[len(stale.Frames)-1].T {
+		return false
 	}
 
-	return deltaEncode(frames, defaultKeyframeInterval), nil
+	// Greedy leftmost subsequence match: consume one JSONL frame per stale
+	// frame, in order. Greedy is optimal here — matching a stale timestamp as
+	// early as possible never rules out a later match.
+	i := 0
+	for _, sf := range stale.Frames {
+		for i < len(frames) && frames[i].T != sf.T {
+			i++
+		}
+		if i == len(frames) {
+			return false
+		}
+		i++
+	}
+	return true
 }
 
 // NewManifestHandler serves GET /api/topology/manifest.

--- a/portal/internal/api/replay_test.go
+++ b/portal/internal/api/replay_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -122,6 +123,150 @@ func TestDeltaEncode_NodeChanges(t *testing.T) {
 	}
 	if chunk.Frames[1].Delta.Nodes[0].State != "SUSPENDED" {
 		t.Errorf("delta node state = %q, want SUSPENDED", chunk.Frames[1].Delta.Nodes[0].State)
+	}
+}
+
+func TestComputeDelta_RemovedAvatarEdge(t *testing.T) {
+	prev := fs.Network{
+		Nodes:        []fs.AgentNode{{Address: "a", State: "ACTIVE"}, {Address: "b", State: "ACTIVE"}},
+		AvatarEdges:  []fs.AvatarEdge{{Parent: "a", Child: "b", ChildName: "agent-b"}},
+		ContactEdges: []fs.ContactEdge{},
+		MailEdges:    []fs.MailEdge{},
+		Stats:        fs.NetworkStats{Active: 2},
+	}
+	curr := prev
+	curr.AvatarEdges = []fs.AvatarEdge{}
+
+	delta := computeDelta(&prev, &curr)
+	if delta == nil {
+		t.Fatal("expected delta for removed avatar edge")
+	}
+	if len(delta.AvatarEdges) != 0 {
+		t.Fatalf("AvatarEdges len = %d, want 0", len(delta.AvatarEdges))
+	}
+	if len(delta.AvatarEdgesRemoved) != 1 {
+		t.Fatalf("AvatarEdgesRemoved len = %d, want 1", len(delta.AvatarEdgesRemoved))
+	}
+	if delta.AvatarEdgesRemoved[0] != [2]string{"a", "b"} {
+		t.Errorf("AvatarEdgesRemoved[0] = %#v, want [a b]", delta.AvatarEdgesRemoved[0])
+	}
+}
+
+func TestComputeDelta_RemovedContactAndMailEdgesOnly(t *testing.T) {
+	prev := fs.Network{
+		Nodes:        []fs.AgentNode{{Address: "a", State: "ACTIVE"}, {Address: "b", State: "ACTIVE"}},
+		AvatarEdges:  []fs.AvatarEdge{},
+		ContactEdges: []fs.ContactEdge{{Owner: "a", Target: "b", Name: "agent-b"}},
+		MailEdges:    []fs.MailEdge{{Sender: "a", Recipient: "b", Count: 3, Direct: 3}},
+		Stats:        fs.NetworkStats{Active: 2},
+	}
+	curr := prev
+	curr.ContactEdges = []fs.ContactEdge{}
+	curr.MailEdges = []fs.MailEdge{}
+
+	delta := computeDelta(&prev, &curr)
+	if delta == nil {
+		t.Fatal("expected non-nil removal-only delta")
+	}
+	if len(delta.ContactEdges) != 0 {
+		t.Fatalf("ContactEdges len = %d, want 0", len(delta.ContactEdges))
+	}
+	if len(delta.Mail) != 0 {
+		t.Fatalf("Mail len = %d, want 0", len(delta.Mail))
+	}
+	if len(delta.ContactEdgesRemoved) != 1 || delta.ContactEdgesRemoved[0] != [2]string{"a", "b"} {
+		t.Fatalf("ContactEdgesRemoved = %#v, want [[a b]]", delta.ContactEdgesRemoved)
+	}
+	if len(delta.MailRemoved) != 1 || delta.MailRemoved[0] != [2]string{"a", "b"} {
+		t.Fatalf("MailRemoved = %#v, want [[a b]]", delta.MailRemoved)
+	}
+	if len(delta.Nodes) != 0 || len(delta.AvatarEdgesRemoved) != 0 || delta.Stats != nil {
+		t.Fatalf("unexpected extra delta fields: %+v", delta)
+	}
+}
+
+func TestComputeDelta_NodeRemovalWithDependentEdgeRemovals(t *testing.T) {
+	prev := fs.Network{
+		Nodes:        []fs.AgentNode{{Address: "a", State: "ACTIVE"}, {Address: "b", State: "ACTIVE"}},
+		AvatarEdges:  []fs.AvatarEdge{{Parent: "a", Child: "b", ChildName: "agent-b"}},
+		ContactEdges: []fs.ContactEdge{{Owner: "a", Target: "b", Name: "agent-b"}},
+		MailEdges:    []fs.MailEdge{{Sender: "a", Recipient: "b", Count: 1, Direct: 1}},
+		Stats:        fs.NetworkStats{Active: 2},
+	}
+	curr := fs.Network{
+		Nodes:        []fs.AgentNode{{Address: "a", State: "ACTIVE"}},
+		AvatarEdges:  []fs.AvatarEdge{},
+		ContactEdges: []fs.ContactEdge{},
+		MailEdges:    []fs.MailEdge{},
+		Stats:        fs.NetworkStats{Active: 2},
+	}
+
+	delta := computeDelta(&prev, &curr)
+	if delta == nil {
+		t.Fatal("expected delta for node and edge removals")
+	}
+	foundTombstone := false
+	for _, n := range delta.Nodes {
+		if n.Address == "b" && n.State == "__REMOVED__" {
+			foundTombstone = true
+		}
+	}
+	if !foundTombstone {
+		t.Fatalf("delta.Nodes = %#v, want tombstone for b", delta.Nodes)
+	}
+	if len(delta.AvatarEdgesRemoved) != 1 || delta.AvatarEdgesRemoved[0] != [2]string{"a", "b"} {
+		t.Fatalf("AvatarEdgesRemoved = %#v, want [[a b]]", delta.AvatarEdgesRemoved)
+	}
+	if len(delta.ContactEdgesRemoved) != 1 || delta.ContactEdgesRemoved[0] != [2]string{"a", "b"} {
+		t.Fatalf("ContactEdgesRemoved = %#v, want [[a b]]", delta.ContactEdgesRemoved)
+	}
+	if len(delta.MailRemoved) != 1 || delta.MailRemoved[0] != [2]string{"a", "b"} {
+		t.Fatalf("MailRemoved = %#v, want [[a b]]", delta.MailRemoved)
+	}
+}
+
+func TestDeltaEncode_EdgeRemovalRoundTripContract(t *testing.T) {
+	net0 := replayEdgeNetwork(false)
+	net1 := replayEdgeNetwork(true)
+	net2 := replayEdgeNetwork(false)
+	frames := []fs.TapeFrame{
+		{T: 3600000, Net: net0},
+		{T: 3603000, Net: net1},
+		{T: 3606000, Net: net2},
+	}
+
+	chunk := deltaEncode(frames, 100)
+	if chunk.V != chunkFormatVersion {
+		t.Fatalf("chunk.V = %d, want %d", chunk.V, chunkFormatVersion)
+	}
+	if len(chunk.Frames[1].Delta.AvatarEdges) != 1 {
+		t.Fatalf("frame[1] AvatarEdges len = %d, want 1", len(chunk.Frames[1].Delta.AvatarEdges))
+	}
+	if len(chunk.Frames[2].Delta.AvatarEdgesRemoved) != 1 {
+		t.Fatalf("frame[2] AvatarEdgesRemoved len = %d, want 1", len(chunk.Frames[2].Delta.AvatarEdgesRemoved))
+	}
+
+	avatarEdges := map[string]fs.AvatarEdge{}
+	for _, frame := range chunk.Frames {
+		if frame.Net != nil {
+			avatarEdges = map[string]fs.AvatarEdge{}
+			for _, e := range frame.Net.AvatarEdges {
+				avatarEdges[e.Parent+"\x00"+e.Child] = e
+			}
+			continue
+		}
+		if frame.Delta == nil {
+			continue
+		}
+		for _, removed := range frame.Delta.AvatarEdgesRemoved {
+			delete(avatarEdges, removed[0]+"\x00"+removed[1])
+		}
+		for _, e := range frame.Delta.AvatarEdges {
+			avatarEdges[e.Parent+"\x00"+e.Child] = e
+		}
+	}
+	if len(avatarEdges) != 0 {
+		t.Fatalf("final avatar edge count = %d, want 0", len(avatarEdges))
 	}
 }
 
@@ -313,6 +458,237 @@ func TestLoadChunk_FromCache(t *testing.T) {
 	}
 	if len(chunk.Frames) != 3 {
 		t.Errorf("len(Frames) = %d, want 3", len(chunk.Frames))
+	}
+}
+
+func TestLoadChunk_StaleV0WithCompleteJSONLReturnsV2WithoutRewritingCache(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
+	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
+	cachePath := filepath.Join(replayDir, "3600000.json.gz")
+	if err := os.MkdirAll(replayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := staleReplayChunk([]int64{3600000, 3603000, 3606000})
+	if err := writeChunkCache(cachePath, stale); err != nil {
+		t.Fatalf("write stale cache: %v", err)
+	}
+	before := readCacheBytes(t, cachePath)
+
+	for _, frame := range []fs.TapeFrame{
+		{T: 3600000, Net: replayEdgeNetwork(false)},
+		{T: 3603000, Net: replayEdgeNetwork(true)},
+		{T: 3606000, Net: replayEdgeNetwork(false)},
+	} {
+		AppendTopologyAt(topologyPath, frame.Net, frame.T)
+	}
+
+	chunk, err := loadChunk(replayDir, topologyPath, 3600000)
+	if err != nil {
+		t.Fatalf("loadChunk: %v", err)
+	}
+	if chunk.V != chunkFormatVersion {
+		t.Fatalf("chunk.V = %d, want %d", chunk.V, chunkFormatVersion)
+	}
+	if len(chunk.Frames) != 3 {
+		t.Fatalf("len(Frames) = %d, want 3", len(chunk.Frames))
+	}
+	if chunk.Frames[2].Delta == nil || len(chunk.Frames[2].Delta.AvatarEdgesRemoved) != 1 {
+		t.Fatalf("frame[2] delta = %+v, want avatar edge removal", chunk.Frames[2].Delta)
+	}
+
+	// The reconstructed V2 chunk is an in-memory result only: a read path must
+	// never persistently mutate or replace the on-disk replay cache.
+	if after := readCacheBytes(t, cachePath); !bytes.Equal(before, after) {
+		t.Fatalf("cache bytes changed on read: %d bytes before, %d bytes after", len(before), len(after))
+	}
+	if _, err := readChunkCache(cachePath); !errors.Is(err, errStaleChunkFormat) {
+		t.Fatalf("readChunkCache error = %v, want stale format preserved on disk", err)
+	}
+}
+
+// TestLoadChunk_StaleV0WithEqualCountJSONLGapServesStale is the counterexample
+// that frame count plus endpoints cannot detect: JSONL [0, 6, 9] has the same
+// frame count as stale [0, 3, 6] and brackets its endpoints, yet is missing
+// T=3603000 entirely. Serving the JSONL reconstruction would silently drop that
+// timestamp, and persisting it would delete the only copy of that history.
+func TestLoadChunk_StaleV0WithEqualCountJSONLGapServesStale(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
+	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
+	cachePath := filepath.Join(replayDir, "3600000.json.gz")
+	if err := os.MkdirAll(replayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := staleReplayChunk([]int64{3600000, 3603000, 3606000})
+	if err := writeChunkCache(cachePath, stale); err != nil {
+		t.Fatalf("write stale cache: %v", err)
+	}
+	before := readCacheBytes(t, cachePath)
+
+	for _, ts := range []int64{3600000, 3606000, 3609000} {
+		AppendTopologyAt(topologyPath, replayEdgeNetwork(false), ts)
+	}
+
+	chunk, err := loadChunk(replayDir, topologyPath, 3600000)
+	if err != nil {
+		t.Fatalf("loadChunk: %v", err)
+	}
+	if chunk.V != 0 {
+		t.Fatalf("chunk.V = %d, want stale V0", chunk.V)
+	}
+	if len(chunk.Frames) != len(stale.Frames) {
+		t.Fatalf("len(Frames) = %d, want %d", len(chunk.Frames), len(stale.Frames))
+	}
+	if !chunkHasFrameAt(chunk, 3603000) {
+		t.Fatalf("frames = %v, want stale history retaining T=3603000", frameTimes(chunk))
+	}
+
+	if after := readCacheBytes(t, cachePath); !bytes.Equal(before, after) {
+		t.Fatalf("cache bytes changed on read: %d bytes before, %d bytes after", len(before), len(after))
+	}
+	if _, err := readChunkCache(cachePath); !errors.Is(err, errStaleChunkFormat) {
+		t.Fatalf("readChunkCache error = %v, want stale format preserved on disk", err)
+	}
+}
+
+func TestLoadChunk_StaleV0WithNoJSONLFramesServesStale(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
+	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
+	cachePath := filepath.Join(replayDir, "3600000.json.gz")
+	if err := os.MkdirAll(replayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(topologyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(topologyPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := staleReplayChunk([]int64{3600000, 3603000, 3606000})
+	if err := writeChunkCache(cachePath, stale); err != nil {
+		t.Fatalf("write stale cache: %v", err)
+	}
+
+	chunk, err := loadChunk(replayDir, topologyPath, 3600000)
+	if err != nil {
+		t.Fatalf("loadChunk: %v", err)
+	}
+	if chunk.V != 0 {
+		t.Fatalf("chunk.V = %d, want stale V0", chunk.V)
+	}
+	if len(chunk.Frames) != len(stale.Frames) {
+		t.Fatalf("len(Frames) = %d, want %d", len(chunk.Frames), len(stale.Frames))
+	}
+	if got := firstFrameForChunk(ChunkInfo{Start: 3600000}, replayDir, topologyPath); got != 3600000 {
+		t.Fatalf("firstFrameForChunk = %d, want 3600000 from stale cache", got)
+	}
+	if _, err := readChunkCache(cachePath); !errors.Is(err, errStaleChunkFormat) {
+		t.Fatalf("readChunkCache error = %v, want stale format", err)
+	}
+}
+
+func TestLoadChunk_StaleV0WithPartialJSONLServesStaleWithoutOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, ".portal", "topology.jsonl")
+	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
+	cachePath := filepath.Join(replayDir, "3600000.json.gz")
+	if err := os.MkdirAll(replayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := staleReplayChunk([]int64{3600000, 3603000, 3606000})
+	if err := writeChunkCache(cachePath, stale); err != nil {
+		t.Fatalf("write stale cache: %v", err)
+	}
+	AppendTopologyAt(topologyPath, replayEdgeNetwork(false), 3606000)
+
+	chunk, err := loadChunk(replayDir, topologyPath, 3600000)
+	if err != nil {
+		t.Fatalf("loadChunk: %v", err)
+	}
+	if chunk.V != 0 {
+		t.Fatalf("chunk.V = %d, want stale V0", chunk.V)
+	}
+	if len(chunk.Frames) != len(stale.Frames) {
+		t.Fatalf("len(Frames) = %d, want %d", len(chunk.Frames), len(stale.Frames))
+	}
+	if _, err := readChunkCache(cachePath); !errors.Is(err, errStaleChunkFormat) {
+		t.Fatalf("readChunkCache error = %v, want stale format after partial JSONL", err)
+	}
+}
+
+// TestJSONLCoversStaleChunk_SequenceAware pins the coverage predicate to
+// subsequence semantics: the stale timestamp sequence must appear in the JSONL
+// in order and with duplicate occurrences preserved, while extra JSONL frames
+// interleaved around it are legitimate. Distinct-timestamp set membership is
+// not sufficient — it accepts both duplicate loss and reordered history when
+// unrelated extra frames make the counts line up.
+func TestJSONLCoversStaleChunk_SequenceAware(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stale []int64
+		jsonl []int64
+		want  bool
+	}{
+		{
+			// Duplicate hidden by an extra frame: stale has T=3 twice, JSONL
+			// has it once, and the extra T=9 makes the counts match.
+			name:  "duplicate occurrence lost behind extra frame",
+			stale: []int64{0, 3, 3, 6},
+			jsonl: []int64{0, 3, 6, 9},
+			want:  false,
+		},
+		{
+			// Reordered history: same distinct timestamps, different order.
+			name:  "stale order not preserved by jsonl",
+			stale: []int64{0, 6, 3},
+			jsonl: []int64{0, 3, 6, 9},
+			want:  false,
+		},
+		{
+			// Legitimate growth: every stale timestamp appears in order; the
+			// interleaved and trailing extras are new frames, not losses.
+			name:  "ordered stale covered despite extra jsonl frames",
+			stale: []int64{0, 3, 6},
+			jsonl: []int64{0, 1, 3, 5, 6, 9},
+			want:  true,
+		},
+		{
+			// The originally-reported gap case must stay rejected.
+			name:  "equal count endpoint gap still rejected",
+			stale: []int64{0, 3, 6},
+			jsonl: []int64{0, 6, 9},
+			want:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsonlCoversStaleChunk(jsonlFramesAt(tc.jsonl), staleReplayChunk(tc.stale))
+			if got != tc.want {
+				t.Fatalf("jsonlCoversStaleChunk(jsonl=%v, stale=%v) = %v, want %v", tc.jsonl, tc.stale, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadChunk_CorruptCacheIsNotCompatibilityFallback(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, ".portal", "missing-topology.jsonl")
+	replayDir := filepath.Join(dir, ".portal", "replay", "chunks")
+	cachePath := filepath.Join(replayDir, "3600000.json.gz")
+	if err := os.MkdirAll(replayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath, []byte("not a gzip replay chunk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadChunk(replayDir, topologyPath, 3600000); err == nil {
+		t.Fatal("loadChunk succeeded with corrupt cache and missing JSONL, want error")
 	}
 }
 
@@ -529,4 +905,66 @@ func TestReplayHandlersDoNotSetCORSHeadersOnFallbackAndErrorPaths(t *testing.T) 
 		}
 		assertNoCORS(t, rr)
 	})
+}
+
+func replayEdgeNetwork(withAvatarEdge bool) fs.Network {
+	net := fs.Network{
+		Nodes:        []fs.AgentNode{{Address: "a", State: "ACTIVE"}, {Address: "b", State: "ACTIVE"}},
+		AvatarEdges:  []fs.AvatarEdge{},
+		ContactEdges: []fs.ContactEdge{},
+		MailEdges:    []fs.MailEdge{},
+		Stats:        fs.NetworkStats{Active: 2},
+	}
+	if withAvatarEdge {
+		net.AvatarEdges = []fs.AvatarEdge{{Parent: "a", Child: "b", ChildName: "agent-b"}}
+	}
+	return net
+}
+
+func readCacheBytes(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cache bytes: %v", err)
+	}
+	return data
+}
+
+func chunkHasFrameAt(chunk ReplayChunk, ts int64) bool {
+	for _, f := range chunk.Frames {
+		if f.T == ts {
+			return true
+		}
+	}
+	return false
+}
+
+func frameTimes(chunk ReplayChunk) []int64 {
+	times := make([]int64, 0, len(chunk.Frames))
+	for _, f := range chunk.Frames {
+		times = append(times, f.T)
+	}
+	return times
+}
+
+func jsonlFramesAt(times []int64) []fs.TapeFrame {
+	frames := make([]fs.TapeFrame, 0, len(times))
+	for _, ts := range times {
+		frames = append(frames, fs.TapeFrame{T: ts, Net: replayEdgeNetwork(false)})
+	}
+	return frames
+}
+
+func staleReplayChunk(times []int64) ReplayChunk {
+	net := replayEdgeNetwork(false)
+	chunk := ReplayChunk{
+		Start:            times[0],
+		End:              times[len(times)-1],
+		KeyframeInterval: defaultKeyframeInterval,
+		Frames:           []ReplayFrame{{T: times[0], Net: &net}},
+	}
+	for _, t := range times[1:] {
+		chunk.Frames = append(chunk.Frames, ReplayFrame{T: t})
+	}
+	return chunk
 }

--- a/portal/web/src/api.ts
+++ b/portal/web/src/api.ts
@@ -28,8 +28,11 @@ export interface ReplayManifest {
 interface FrameDelta {
   nodes?: AgentNode[];
   avatar_edges?: AvatarEdge[];
+  avatar_edges_removed?: [string, string][];
   contact_edges?: ContactEdge[];
+  contact_edges_removed?: [string, string][];
   mail?: MailEdge[];
+  mail_removed?: [string, string][];
   stats?: NetworkStats;
 }
 
@@ -40,6 +43,7 @@ interface ReplayFrame {
 }
 
 export interface ReplayChunk {
+  v?: number;
   start: number;
   end: number;
   keyframe_interval: number;
@@ -89,33 +93,42 @@ export function reconstructFrames(chunk: ReplayChunk): TapeFrame[] {
         }
 
         // Apply avatar edge changes
-        if (rf.d.avatar_edges) {
+        if (rf.d.avatar_edges || rf.d.avatar_edges_removed) {
           const avatarMap = new Map(
             net.avatar_edges.map(e => [`${e.parent}\0${e.child}`, e])
           );
-          for (const e of rf.d.avatar_edges) {
+          for (const [parent, child] of rf.d.avatar_edges_removed ?? []) {
+            avatarMap.delete(`${parent}\0${child}`);
+          }
+          for (const e of rf.d.avatar_edges ?? []) {
             avatarMap.set(`${e.parent}\0${e.child}`, e);
           }
           net.avatar_edges = Array.from(avatarMap.values());
         }
 
         // Apply contact edge changes
-        if (rf.d.contact_edges) {
+        if (rf.d.contact_edges || rf.d.contact_edges_removed) {
           const contactMap = new Map(
             net.contact_edges.map(e => [`${e.owner}\0${e.target}`, e])
           );
-          for (const e of rf.d.contact_edges) {
+          for (const [owner, target] of rf.d.contact_edges_removed ?? []) {
+            contactMap.delete(`${owner}\0${target}`);
+          }
+          for (const e of rf.d.contact_edges ?? []) {
             contactMap.set(`${e.owner}\0${e.target}`, e);
           }
           net.contact_edges = Array.from(contactMap.values());
         }
 
         // Apply mail edge changes
-        if (rf.d.mail) {
+        if (rf.d.mail || rf.d.mail_removed) {
           const mailMap = new Map(
             net.mail_edges.map(e => [`${e.sender}\0${e.recipient}`, e])
           );
-          for (const e of rf.d.mail) {
+          for (const [sender, recipient] of rf.d.mail_removed ?? []) {
+            mailMap.delete(`${sender}\0${recipient}`);
+          }
+          for (const e of rf.d.mail ?? []) {
             mailMap.set(`${e.sender}\0${e.recipient}`, e);
           }
           net.mail_edges = Array.from(mailMap.values());


### PR DESCRIPTION
Fixes Lingtai-AI/lingtai#564.

## Summary

- emit explicit replay-delta tombstones for removed avatar, contact, and mail edges
- apply removals before upserts in the Portal reconstruction path, including removal-only deltas
- version replay chunk caches as `v:2` while continuing to read legacy `v:0` chunks
- reconstruct a transient `v:2` response only when JSONL contains the stale cache's timestamp sequence in order and with duplicate multiplicity
- keep replay GET/load paths read-only: no cache rewrite, replacement, truncation, or migration during a read

## Why

Replay already represented removed nodes with `State: "__REMOVED__"`, but edge deltas had no equivalent removal path. Removed avatar/contact/mail edges could therefore remain in reconstructed frames until the next keyframe and could temporarily point at nodes that had already been removed.

The original compatibility implementation also rewrote a stale `v:0` cache from the ordinary read path when JSONL appeared to cover the hour. That was unsafe when JSONL was incomplete: a stale cache with timestamps `[0,3,6]` and a partial JSONL scan `[0,6,9]` could replace the only durable history and permanently lose the frame at T=3.

## Behavior

- `FrameDelta` carries `avatar_edges_removed`, `contact_edges_removed`, and `mail_removed` tuple lists.
- `computeDelta` emits deterministic removed-edge tuples by comparing prior and current edge keys.
- `reconstructFrames` deletes removed edges using the same composite keys as the existing upsert paths, then applies additions/changes, so a same-delta upsert wins deterministically.
- Removal-only deltas are retained and applied.
- Existing node-tombstone behavior is unchanged.
- `ReplayChunk` carries cache format version `v:2`.

## Legacy cache safety

The compatibility path is intentionally non-mutating:

- valid `v:2` chunks are served directly;
- readable legacy chunks with a missing/stale version are distinguished from corrupt cache files;
- JSONL coverage uses ordered subsequence matching, preserving duplicate multiplicity while allowing legitimate extra JSONL frames;
- when JSONL completely covers the stale timestamp sequence, the server returns a reconstructed `v:2` chunk in memory without modifying the cache file;
- when JSONL is missing, truncated, reordered, or otherwise incomplete, the readable `v:0` chunk is returned as the compatibility fallback;
- corrupt/unreadable cache files are not served as fallback.

Sequence examples covered directly:

| stale cache | JSONL scan | result |
|---|---|---|
| `[0,3,6]` | `[0,6,9]` | incomplete — serve readable V0 |
| `[0,3,3,6]` | `[0,3,6,9]` | duplicate lost — serve readable V0 |
| `[0,6,3]` | `[0,3,6,9]` | reordered — serve readable V0 |
| `[0,3,6]` | `[0,1,3,5,6,9]` | complete with extras — return transient V2 |

## Test-first repair evidence

The safety repair preserved two authentic failing stages before production changes:

1. a test-only regression proved that an ordinary load changed cache bytes and that incomplete JSONL incorrectly replaced readable V0 history;
2. after the first repair, a second test-only regression proved that distinct-timestamp set membership still accepted duplicate loss and reordered history.

The final predicate is a greedy leftmost two-pointer subsequence match: O(n+m), allocation-free, order-preserving, and multiplicity-preserving.

## Validation

Parent validation on exact head `f874240defef5689f5491f29d214efd1170fcd66`:

- `git diff --check canonical/main...HEAD`
- `cd portal/web && npm run build`
- `cd portal && go test ./...`
- `cd portal && go vet ./...`
- focused `TestJSONLCoversStaleChunk_SequenceAware` and `TestLoadChunk*` regressions
- TUI Architecture entry-link and runtime-control route tests
- exact six-path scope, gofmt, and clean-worktree checks

`npm ci` reported existing dependency advisories; no dependency file changed in this PR.

## Independent exact-head review

- Claude Code: literal `claude-opus-5`, effort `high` — **PASS**
- Codex CLI: `gpt-5.6-sol`, reasoning effort `xhigh` — **PASS**

Both reviewers independently exercised adversarial sequence cases, load-branch behavior, real frontend reconstruction, documentation citations, the six-file range, and clean before/after state at the exact final commit.

## Non-goals

- no write-path cache migration in this change
- no change to node tombstone representation
- no change to keyframe interval or recording cadence
- no dependency update or frontend test-runner infrastructure
- no topology producer changes outside replay encoding/reconstruction
