### PR TITLE
Preserve spaced agent paths in list and purge

### DIFF
--- a/tui/ANATOMY.md
+++ b/tui/ANATOMY.md
@@ -19,6 +19,9 @@ related_files:
   - tui/list_common_test.go
   - tui/list_unix.go
   - tui/list_windows.go
+  - tui/list_windows_test.go
+  - tui/purge_common.go
+  - tui/purge_common_test.go
   - tui/purge_unix.go
   - tui/purge_windows.go
   - tui/suspend_unix.go
@@ -42,14 +45,14 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 
 - **`tui/main.go:33-1138`** — single-file `package main`. The version stamp (`tui/main.go:31`, set via `-ldflags`), welcome/help text, Rust toolchain startup guidance (`tui/main.go:688-756`), and interactive entry (`tui/main.go:33-96`). After parsing subcommands, it runs global migrations, checks invariants (init.json all-or-nothing, exactly-one-orchestrator), handles upgrade prompts and first-run wizard routing, then launches Bubble Tea.
 - **`tui/main.go:35-96`** — subcommand dispatch. Each subcommand returns early; the fallthrough path starts the interactive TUI.
-- **`list_common.go` / `list_unix.go` / `list_windows.go`** — `lingtai-tui list` process discovery and decentralized contact-book-style rendering. Platform files find running `lingtai run` processes; `list_common.go` parses `--detailed` / `--admin`, reads each agent's `.agent.json` for role/name/state/admin metadata, and prints simple/detailed/admin tables without writing a central address book. Treat this command as the progressive-disclosure entry point for finding local companions or running-agent inventory before resorting to filesystem scans.
+- **`list_common.go` / `list_unix.go` / `list_windows.go`** — `lingtai-tui list` process discovery and decentralized contact-book-style rendering. Platform files call shared `processscan` discovery (`tui/list_unix.go:13-19`, `tui/list_windows.go:13-19`); `list_common.go` parses `--detailed` / `--admin`, converts processscan records into display rows (`tui/list_common.go:69-115`), reads each agent's `.agent.json` for role/name/state/admin metadata, and prints simple/detailed/admin tables without writing a central address book. Treat this command as the progressive-disclosure entry point for finding local companions or running-agent inventory before resorting to filesystem scans.
 - **`upgrade.go`** — startup TUI binary upgrade flow: after install-method routing (`tui/main.go:113-119`), Homebrew installs keep the existing prompt that detects other running TUI windows, puts affected agents to sleep, stops old TUI processes, and runs `brew upgrade` before asking the user to relaunch; source/user-local installs get a separate explicit `[y/N]` prompt that routes through the source updater backend (`install.sh --update`). Unknown installs are not mutated at startup (version-only).
 - **`tui/main.go:688-756`** — `maybePromptRustToolchain` / `markRustPromptSeen`: one-time optional Rust/Cargo startup prompt. Only prompts on an interactive TTY when the managed runtime is on the Python file-search fallback and no `cargo` is on PATH. Writes the `~/.lingtai-tui/runtime/rust-toolchain-prompted` marker on decline/install/skip — including when the probe errors or reports an unsupported runtime — so the Python probe never re-spawns on every launch.
 - **`tui/main.go:824-972`** — `cleanMain`/`cleanProject`: suspend agents in `.lingtai/` (10s timeout), then `os.RemoveAll`. Refuses to delete while any agent heartbeat is still fresh after the timeout, when agents cannot be listed, or when an agent appeared during the wait (re-discovered before deleting) — unless `--force` is given (issue #488).
 - **`tui/main.go:974-1022`** — `postmanMain`: parse `--port`, collect watch directories, call `postman.Run`.
-- **`tui/purge_unix.go:17-122`** — `purgeMain` (unix): `ps aux | grep "lingtai run"`, SIGTERM → SIGKILL survivors. Build tag `!windows`.
+- **`tui/purge_common.go:9-39` / `tui/purge_unix.go:17-75`** — `purgeMain` (unix): shared processscan-to-purge-target filtering, then SIGTERM → SIGKILL survivors. Build tag `!windows`.
 - **`purge_windows.go`** — `purgeMain` (windows): equivalent via Windows process enumeration.
-- **`tui/list_unix.go:15-141`** — `listMain` (unix): enumerate running agents with uptime, phantom detection (`.lingtai/` deleted but process still running). Build tag `!windows`.
+- **`tui/list_unix.go:13-68`** — `listMain` (unix): enumerate running agents with uptime, phantom detection (`.lingtai/` deleted but process still running). Build tag `!windows`.
 - **`list_windows.go`** — `listMain` (windows): equivalent.
 - **`tui/suspend_unix.go:14-86`** — `suspendMain` (unix): discover agents via `.agent.json`, write `.suspend` files, wait 5s. Build tag `!windows`.
 - **`suspend_windows.go`** — `suspendMain` (windows): equivalent.
@@ -103,7 +106,7 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 
 ## Notes
 
-- **Finding companions / local agent inventory:** use `lingtai-tui list --detailed [dir]` as the first stop before hand-walking `.lingtai/` trees.  `--admin` adds admin flags when the decision depends on karma/nirvana privileges.  The command surface is owned by `tui/list_common.go:43-59`, live metadata comes from `.agent.json` via `tui/list_common.go:71-98`, platform process discovery is in `tui/list_unix.go:13-80` and `tui/list_windows.go:13-80`, and the rendered simple/detailed/admin tables are built in `tui/list_common.go:222-260`.
+- **Finding companions / local agent inventory:** use `lingtai-tui list --detailed [dir]` as the first stop before hand-walking `.lingtai/` trees.  `--admin` adds admin flags when the decision depends on karma/nirvana privileges.  The command surface is owned by `tui/list_common.go:117-145`, live metadata comes from `.agent.json` via `tui/list_common.go:147-174`, platform process discovery is in `tui/list_unix.go:13-43` and `tui/list_windows.go:13-43`, and the rendered simple/detailed/admin tables are built in `tui/list_common.go:327-421`.
 - **Binary naming is `lingtai-tui`, never `lingtai`.** `lingtai` is the Python agent CLI inside the runtime venv.
 - **`main.go` is intentionally flat** — every subcommand's `*Main()` function is defined inline in `main.go` or platform-specific `*_unix.go`/`*_windows.go` files. Don't refactor subcommands into `internal/` packages; the flat `main.go` is the contract.
 - **Platform shims follow the `//go:build !windows` pattern.** Unix is the primary target; Windows files mirror the same function signatures. Every subcommand (`purge`, `list`, `suspend`) plus `countRunningAgents` and TUI-process upgrade helpers have paired platform files.

--- a/tui/ANATOMY.md
+++ b/tui/ANATOMY.md
@@ -18,11 +18,13 @@ related_files:
   - tui/list_common.go
   - tui/list_common_test.go
   - tui/list_unix.go
+  - tui/list_unix_test.go
   - tui/list_windows.go
   - tui/list_windows_test.go
   - tui/purge_common.go
   - tui/purge_common_test.go
   - tui/purge_unix.go
+  - tui/purge_unix_test.go
   - tui/purge_windows.go
   - tui/suspend_unix.go
   - tui/suspend_windows.go
@@ -45,14 +47,14 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 
 - **`tui/main.go:33-1138`** — single-file `package main`. The version stamp (`tui/main.go:31`, set via `-ldflags`), welcome/help text, Rust toolchain startup guidance (`tui/main.go:688-756`), and interactive entry (`tui/main.go:33-96`). After parsing subcommands, it runs global migrations, checks invariants (init.json all-or-nothing, exactly-one-orchestrator), handles upgrade prompts and first-run wizard routing, then launches Bubble Tea.
 - **`tui/main.go:35-96`** — subcommand dispatch. Each subcommand returns early; the fallthrough path starts the interactive TUI.
-- **`list_common.go` / `list_unix.go` / `list_windows.go`** — `lingtai-tui list` process discovery and decentralized contact-book-style rendering. Platform files call shared `processscan` discovery (`tui/list_unix.go:13-19`, `tui/list_windows.go:13-19`); `list_common.go` parses `--detailed` / `--admin`, converts processscan records into display rows (`tui/list_common.go:69-115`), reads each agent's `.agent.json` for role/name/state/admin metadata, and prints simple/detailed/admin tables without writing a central address book. Treat this command as the progressive-disclosure entry point for finding local companions or running-agent inventory before resorting to filesystem scans.
+- **`list_common.go` / `list_unix.go` / `list_windows.go`** — `lingtai-tui list` process discovery and decentralized contact-book-style rendering. Platform files call shared `processscan` discovery and fail loud with a nonzero exit when the scan command itself fails (`tui/list_unix.go:16-27`, `tui/list_windows.go:13-24`); `list_common.go` parses `--detailed` / `--admin`, converts processscan records into display rows (`tui/list_common.go:69-115`), reads each agent's `.agent.json` for role/name/state/admin metadata, and prints simple/detailed/admin tables without writing a central address book. Treat this command as the progressive-disclosure entry point for finding local companions or running-agent inventory before resorting to filesystem scans.
 - **`upgrade.go`** — startup TUI binary upgrade flow: after install-method routing (`tui/main.go:113-119`), Homebrew installs keep the existing prompt that detects other running TUI windows, puts affected agents to sleep, stops old TUI processes, and runs `brew upgrade` before asking the user to relaunch; source/user-local installs get a separate explicit `[y/N]` prompt that routes through the source updater backend (`install.sh --update`). Unknown installs are not mutated at startup (version-only).
 - **`tui/main.go:688-756`** — `maybePromptRustToolchain` / `markRustPromptSeen`: one-time optional Rust/Cargo startup prompt. Only prompts on an interactive TTY when the managed runtime is on the Python file-search fallback and no `cargo` is on PATH. Writes the `~/.lingtai-tui/runtime/rust-toolchain-prompted` marker on decline/install/skip — including when the probe errors or reports an unsupported runtime — so the Python probe never re-spawns on every launch.
 - **`tui/main.go:824-972`** — `cleanMain`/`cleanProject`: suspend agents in `.lingtai/` (10s timeout), then `os.RemoveAll`. Refuses to delete while any agent heartbeat is still fresh after the timeout, when agents cannot be listed, or when an agent appeared during the wait (re-discovered before deleting) — unless `--force` is given (issue #488).
 - **`tui/main.go:974-1022`** — `postmanMain`: parse `--port`, collect watch directories, call `postman.Run`.
-- **`tui/purge_common.go:9-39` / `tui/purge_unix.go:17-75`** — `purgeMain` (unix): shared processscan-to-purge-target filtering, then SIGTERM → SIGKILL survivors. Build tag `!windows`.
+- **`tui/purge_common.go:9-39` / `tui/purge_unix.go:17-80`** — `purgeMain` (unix): shared processscan-to-purge-target filtering, then SIGTERM → SIGKILL survivors. Build tag `!windows`.
 - **`purge_windows.go`** — `purgeMain` (windows): equivalent via Windows process enumeration.
-- **`tui/list_unix.go:13-68`** — `listMain` (unix): enumerate running agents with uptime, phantom detection (`.lingtai/` deleted but process still running). Build tag `!windows`.
+- **`tui/list_unix.go:16-124`** — `listMain` (unix): enumerate running agents with human-readable uptime derived from ps etime, phantom detection (`.lingtai/` deleted but process still running). Build tag `!windows`.
 - **`list_windows.go`** — `listMain` (windows): equivalent.
 - **`tui/suspend_unix.go:14-86`** — `suspendMain` (unix): discover agents via `.agent.json`, write `.suspend` files, wait 5s. Build tag `!windows`.
 - **`suspend_windows.go`** — `suspendMain` (windows): equivalent.
@@ -106,7 +108,7 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 
 ## Notes
 
-- **Finding companions / local agent inventory:** use `lingtai-tui list --detailed [dir]` as the first stop before hand-walking `.lingtai/` trees.  `--admin` adds admin flags when the decision depends on karma/nirvana privileges.  The command surface is owned by `tui/list_common.go:117-145`, live metadata comes from `.agent.json` via `tui/list_common.go:147-174`, platform process discovery is in `tui/list_unix.go:13-43` and `tui/list_windows.go:13-43`, and the rendered simple/detailed/admin tables are built in `tui/list_common.go:327-421`.
+- **Finding companions / local agent inventory:** use `lingtai-tui list --detailed [dir]` as the first stop before hand-walking `.lingtai/` trees.  `--admin` adds admin flags when the decision depends on karma/nirvana privileges.  The command surface is owned by `tui/list_common.go:117-145`, live metadata comes from `.agent.json` via `tui/list_common.go:147-174`, platform process discovery is in `tui/list_unix.go:16-55` and `tui/list_windows.go:13-49`, and the rendered simple/detailed/admin tables are built in `tui/list_common.go:327-421`.
 - **Binary naming is `lingtai-tui`, never `lingtai`.** `lingtai` is the Python agent CLI inside the runtime venv.
 - **`main.go` is intentionally flat** — every subcommand's `*Main()` function is defined inline in `main.go` or platform-specific `*_unix.go`/`*_windows.go` files. Don't refactor subcommands into `internal/` packages; the flat `main.go` is the contract.
 - **Platform shims follow the `//go:build !windows` pattern.** Unix is the primary target; Windows files mirror the same function signatures. Every subcommand (`purge`, `list`, `suspend`) plus `countRunningAgents` and TUI-process upgrade helpers have paired platform files.

--- a/tui/internal/process/check.go
+++ b/tui/internal/process/check.go
@@ -3,10 +3,9 @@ package process
 import "github.com/anthropics/lingtai-tui/internal/processscan"
 
 // AgentProcess is a single `lingtai run <agentDir>` process discovered by
-// scanning `ps`. The command field holds the trimmed ps line; pid is parsed
-// from the leading column. Used by FindAgentProcesses /
+// scanning the process table. Used by FindAgentProcesses /
 // TerminateAgentProcesses so callers can both detect and act on lingering
-// interpreters.
+// interpreters while preserving the full agent dir.
 type AgentProcess = processscan.AgentProcess
 
 func parsePSOutput(out, abs string) []AgentProcess {

--- a/tui/internal/processscan/ANATOMY.md
+++ b/tui/internal/processscan/ANATOMY.md
@@ -3,6 +3,12 @@ related_files:
   - tui/ANATOMY.md
   - tui/internal/migrate/ANATOMY.md
   - tui/internal/processscan/check.go
+  - tui/list_common.go
+  - tui/list_unix.go
+  - tui/list_windows.go
+  - tui/purge_common.go
+  - tui/purge_unix.go
+  - tui/purge_windows.go
   - tui/internal/process/check.go
   - tui/internal/process/check_test.go
   - tui/internal/migrate/m036_sqlite_log_backfill.go
@@ -24,18 +30,23 @@ maintenance: |
 
 | Component | File | Purpose |
 |---|---|---|
-| `AgentProcess` | `tui/internal/processscan/check.go:10` | parsed `ps` record for a matching `lingtai run <agentDir>` interpreter |
-| `ParsePSOutput` | `tui/internal/processscan/check.go:20` | unit-testable parser for `ps -eo pid=,command=` output; guards against prefix-sibling false positives |
-| `FindAgentProcesses` | `tui/internal/processscan/check.go:60` | shells out to `ps`, normalizes the requested agent dir, and parses matches |
-| `IsAgentRunning` | `tui/internal/processscan/check.go:75` | boolean convenience wrapper used by launch/migration boundaries |
+| `AgentProcess` | `tui/internal/processscan/check.go:15` | parsed process-table record with PID, optional uptime, full agent dir, and command text |
+| `ParsePSOutput` | `tui/internal/processscan/check.go:29` | unit-testable parser for `ps -eo pid=,command=` output scoped to one agent dir |
+| `ParsePSListOutput` | `tui/internal/processscan/check.go:56` | unit-testable parser for `ps -eo pid=,etime=,command=` output listing every agent process |
+| `ParseWMICOutput` | `tui/internal/processscan/check.go:81` | Windows WMIC/PowerShell list parser with the same agent-dir extraction rules |
+| `ExtractAgentDir` | `tui/internal/processscan/check.go:122` | launch-marker parser that takes the final run argument intact so spaces survive |
+| `FindAgentProcesses` | `tui/internal/processscan/check.go:255` | shells out to process listing, normalizes one requested agent dir, and parses matches |
+| `FindAllAgentProcesses` | `tui/internal/processscan/check.go:272` | shells out to process listing and returns all visible agent processes for list/purge |
+| `IsAgentRunning` | `tui/internal/processscan/check.go:320` | boolean convenience wrapper used by launch/migration boundaries |
 
 ## Composition
 
-- **Upstream callers:** `tui/internal/process/check.go` re-exports this package for existing launch/refresh callers; `tui/internal/migrate/m036_sqlite_log_backfill.go` calls it directly to skip running agents before attempting offline SQLite rebuilds.
-- **External dependency:** host `ps -eo pid=,command=`. Errors fail closed to “no match”; the kernel workdir lock remains the authoritative safety gate for SQLite rebuilds.
+- **Upstream callers:** `tui/internal/process/check.go` re-exports this package for launch/refresh callers; `tui/internal/migrate/m036_sqlite_log_backfill.go` calls it directly to skip running agents before attempting offline SQLite rebuilds; `lingtai-tui list` and `purge` consume all-process scans via `tui/list_common.go:69-115` and `tui/purge_common.go:15-39`.
+- **External dependency:** host `ps -eo pid=,command=` for one-dir checks, `ps -eo pid=,etime=,command=` for all-process list/purge, and WMIC/PowerShell on Windows. Errors fail closed to “no match”; the kernel workdir lock remains the authoritative safety gate for SQLite rebuilds.
 
 ## Invariants
 
-1. Match only exact `lingtai run <absAgentDir>` command arguments, allowing extra trailing args but rejecting prefix siblings such as `<absAgentDir>-old`.
-2. Keep this package free of imports back into TUI logic packages (`migrate`, `process`, `tui`) so it remains safe for low-level reuse.
-3. Treat `ps` detection as advisory. Callers that need correctness under races must also rely on their own hard gate (for example, the kernel offline workdir lock in SQLite rebuilds).
+1. Match supported launch forms (`python -m lingtai run`, `lingtai run`, `lingtai-agent run`) and preserve the full final agent-dir argument, including spaces.
+2. For one-dir checks, match only exact `<absAgentDir>` command arguments, allowing extra trailing args but rejecting prefix siblings such as `<absAgentDir>-old`.
+3. Keep this package free of imports back into TUI logic packages (`migrate`, `process`, `tui`) so it remains safe for low-level reuse.
+4. Treat process-table detection as advisory. Callers that need correctness under races must also rely on their own hard gate (for example, the kernel offline workdir lock in SQLite rebuilds).

--- a/tui/internal/processscan/ANATOMY.md
+++ b/tui/internal/processscan/ANATOMY.md
@@ -35,9 +35,9 @@ maintenance: |
 | `ParsePSListOutput` | `tui/internal/processscan/check.go:56` | unit-testable parser for `ps -eo pid=,etime=,command=` output listing every agent process |
 | `ParseWMICOutput` | `tui/internal/processscan/check.go:81` | Windows WMIC/PowerShell list parser with the same agent-dir extraction rules |
 | `ExtractAgentDir` | `tui/internal/processscan/check.go:122` | launch-marker parser that takes the final run argument intact so spaces survive |
-| `FindAgentProcesses` | `tui/internal/processscan/check.go:255` | shells out to process listing, normalizes one requested agent dir, and parses matches |
-| `FindAllAgentProcesses` | `tui/internal/processscan/check.go:272` | shells out to process listing and returns all visible agent processes for list/purge |
-| `IsAgentRunning` | `tui/internal/processscan/check.go:320` | boolean convenience wrapper used by launch/migration boundaries |
+| `FindAgentProcesses` | `tui/internal/processscan/check.go:262` | shells out to process listing, normalizes one requested agent dir, and parses matches |
+| `FindAllAgentProcesses` | `tui/internal/processscan/check.go:279` | shells out to process listing and returns all visible agent processes for list/purge |
+| `IsAgentRunning` | `tui/internal/processscan/check.go:327` | boolean convenience wrapper used by launch/migration boundaries |
 
 ## Composition
 
@@ -47,6 +47,6 @@ maintenance: |
 ## Invariants
 
 1. Match supported launch forms (`python -m lingtai run`, `lingtai run`, `lingtai-agent run`) and preserve the full final agent-dir argument, including spaces.
-2. For one-dir checks, match only exact `<absAgentDir>` command arguments, allowing extra trailing args but rejecting prefix siblings such as `<absAgentDir>-old`.
+2. For one-dir checks, match only exact `<absAgentDir>` command arguments. Extra trailing args are accepted only when the boundary is unambiguous (quoted dir or no-space dir); unquoted dirs with spaces must be exact so prefix siblings such as `<absAgentDir> beta` do not match.
 3. Keep this package free of imports back into TUI logic packages (`migrate`, `process`, `tui`) so it remains safe for low-level reuse.
 4. Treat process-table detection as advisory. Callers that need correctness under races must also rely on their own hard gate (for example, the kernel offline workdir lock in SQLite rebuilds).

--- a/tui/internal/processscan/ANATOMY.md
+++ b/tui/internal/processscan/ANATOMY.md
@@ -36,13 +36,13 @@ maintenance: |
 | `ParseWMICOutput` | `tui/internal/processscan/check.go:81` | Windows WMIC/PowerShell list parser with the same agent-dir extraction rules |
 | `ExtractAgentDir` | `tui/internal/processscan/check.go:122` | launch-marker parser that takes the final run argument intact so spaces survive |
 | `FindAgentProcesses` | `tui/internal/processscan/check.go:262` | shells out to process listing, normalizes one requested agent dir, and parses matches |
-| `FindAllAgentProcesses` | `tui/internal/processscan/check.go:279` | shells out to process listing and returns all visible agent processes for list/purge |
-| `IsAgentRunning` | `tui/internal/processscan/check.go:327` | boolean convenience wrapper used by launch/migration boundaries |
+| `FindAllAgentProcesses` | `tui/internal/processscan/check.go:281` | shells out to process listing and returns all visible agent processes for list/purge, or the scan-command error |
+| `IsAgentRunning` | `tui/internal/processscan/check.go:333` | boolean convenience wrapper used by launch/migration boundaries |
 
 ## Composition
 
 - **Upstream callers:** `tui/internal/process/check.go` re-exports this package for launch/refresh callers; `tui/internal/migrate/m036_sqlite_log_backfill.go` calls it directly to skip running agents before attempting offline SQLite rebuilds; `lingtai-tui list` and `purge` consume all-process scans via `tui/list_common.go:69-115` and `tui/purge_common.go:15-39`.
-- **External dependency:** host `ps -eo pid=,command=` for one-dir checks, `ps -eo pid=,etime=,command=` for all-process list/purge, and WMIC/PowerShell on Windows. Errors fail closed to “no match”; the kernel workdir lock remains the authoritative safety gate for SQLite rebuilds.
+- **External dependency:** host `ps -eo pid=,command=` for one-dir checks, `ps -eo pid=,etime=,command=` for all-process list/purge, and WMIC/PowerShell on Windows. One-dir check errors fail closed to “no match” (advisory boundary); all-process scan errors are returned from `FindAllAgentProcesses` so `list`/`purge` fail loud instead of reporting an empty process table. The kernel workdir lock remains the authoritative safety gate for SQLite rebuilds.
 
 ## Invariants
 

--- a/tui/internal/processscan/check.go
+++ b/tui/internal/processscan/check.go
@@ -275,16 +275,22 @@ func FindAgentProcesses(agentDir string) []AgentProcess {
 }
 
 // FindAllAgentProcesses returns every visible LingTai agent process. On Unix it
-// uses `etime` as a display-only uptime string.
-func FindAllAgentProcesses() []AgentProcess {
+// uses `etime` as a display-only uptime string. A process-scan command failure
+// is returned as an error, never as an empty result, so callers can tell
+// "nothing running" apart from "scan failed".
+func FindAllAgentProcesses() ([]AgentProcess, error) {
 	if runtime.GOOS == "windows" {
-		return findAgentProcessesWindows("")
+		out, err := windowsAgentProcessOutput()
+		if err != nil {
+			return nil, err
+		}
+		return ParseWMICOutput(string(out), ""), nil
 	}
 	out, err := exec.Command("ps", "-eo", "pid=,etime=,command=").Output()
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return ParsePSListOutput(string(out))
+	return ParsePSListOutput(string(out)), nil
 }
 
 func findAgentProcessesWindows(abs string) []AgentProcess {

--- a/tui/internal/processscan/check.go
+++ b/tui/internal/processscan/check.go
@@ -6,15 +6,17 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // AgentProcess is a single `lingtai run <agentDir>` process discovered by
-// scanning `ps`. The command field holds the trimmed ps line; pid is parsed
-// from the leading column. Used by FindAgentProcesses so callers can both
-// detect and act on lingering interpreters.
+// scanning the process table. AgentDir is parsed from the final run argument
+// so paths containing spaces remain intact.
 type AgentProcess struct {
-	PID     int
-	Command string
+	PID      int
+	Uptime   string
+	AgentDir string
+	Command  string
 }
 
 // ParsePSOutput extracts AgentProcess records from `ps -eo pid=,command=`
@@ -27,27 +29,51 @@ type AgentProcess struct {
 func ParsePSOutput(out, abs string) []AgentProcess {
 	var results []AgentProcess
 	for _, line := range strings.Split(out, "\n") {
-		if !strings.Contains(line, "lingtai run") {
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		if !commandMatchesAgentDir(trimmed, abs) {
-			continue
-		}
-		// Split off the leading pid column. ps emits "  1234 python ..." so
-		// Fields collapses leading whitespace; we take the first token.
-		fields := strings.Fields(trimmed)
-		if len(fields) < 2 {
+		fields, command, ok := splitLeadingFields(line, 1)
+		if !ok {
 			continue
 		}
 		pid, err := strconv.Atoi(fields[0])
 		if err != nil {
 			continue
 		}
-		results = append(results, AgentProcess{PID: pid, Command: trimmed})
+		agentDir, ok := agentDirForCommand(command, abs)
+		if !ok {
+			continue
+		}
+		results = append(results, AgentProcess{
+			PID:      pid,
+			AgentDir: agentDir,
+			Command:  strings.TrimSpace(command),
+		})
+	}
+	return results
+}
+
+// ParsePSListOutput extracts all LingTai agent processes from
+// `ps -eo pid=,etime=,command=` output. The command column may contain spaces,
+// so only the leading pid and etime fields are split.
+func ParsePSListOutput(out string) []AgentProcess {
+	var results []AgentProcess
+	for _, line := range strings.Split(out, "\n") {
+		fields, command, ok := splitLeadingFields(line, 2)
+		if !ok {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		agentDir, ok := ExtractAgentDir(command)
+		if !ok {
+			continue
+		}
+		results = append(results, AgentProcess{
+			PID:      pid,
+			Uptime:   fields[1],
+			AgentDir: agentDir,
+			Command:  strings.TrimSpace(command),
+		})
 	}
 	return results
 }
@@ -66,10 +92,12 @@ func ParseWMICOutput(out, abs string) []AgentProcess {
 		}
 		pidText := strings.TrimPrefix(line, "ProcessId=")
 		pid, err := strconv.Atoi(strings.TrimSpace(pidText))
-		if err == nil && commandMatchesProcess(cmdline, abs) {
+		agentDir, ok := agentDirForCommand(cmdline, abs)
+		if err == nil && ok {
 			results = append(results, AgentProcess{
-				PID:     pid,
-				Command: strings.TrimSpace(cmdline),
+				PID:      pid,
+				AgentDir: agentDir,
+				Command:  strings.TrimSpace(cmdline),
 			})
 		}
 		cmdline = ""
@@ -77,35 +105,148 @@ func ParseWMICOutput(out, abs string) []AgentProcess {
 	return results
 }
 
-func commandMatchesProcess(command, abs string) bool {
+func agentDirForCommand(command, abs string) (string, bool) {
 	if abs == "" {
-		lower := strings.ToLower(command)
-		return strings.Contains(lower, "-m lingtai run ") ||
-			strings.Contains(lower, "lingtai-agent run ")
+		return ExtractAgentDir(command)
 	}
-	return commandMatchesAgentDir(command, abs)
+	if commandMatchesAgentDir(command, abs) {
+		return abs, true
+	}
+	return "", false
+}
+
+// ExtractAgentDir returns the argument after a supported LingTai launch marker.
+// The launcher passes the agent directory as the final argv element; when ps
+// or WMIC joins argv back into text, taking the rest after the marker preserves
+// spaces inside that directory.
+func ExtractAgentDir(command string) (string, bool) {
+	rest, ok := agentDirRestAfterMarker(command)
+	if !ok {
+		return "", false
+	}
+	agentDir := extractAgentDirFromRest(rest)
+	if strings.TrimSpace(agentDir) == "" {
+		return "", false
+	}
+	return agentDir, true
 }
 
 func commandMatchesAgentDir(command, abs string) bool {
-	if !strings.Contains(strings.ToLower(command), "lingtai run") {
+	rest, ok := agentDirRestAfterMarker(command)
+	if !ok {
 		return false
 	}
 	candidates := []string{abs, filepath.ToSlash(abs)}
 	for _, candidate := range candidates {
-		for _, arg := range []string{candidate, `"` + candidate + `"`} {
-			needle := "lingtai run " + arg
-			if commandContainsArg(command, needle) {
-				return true
-			}
+		if restMatchesAgentCandidate(rest, candidate) {
+			return true
 		}
 	}
 	return false
 }
 
-func commandContainsArg(command, needle string) bool {
-	cmd := strings.ToLower(command)
-	n := strings.ToLower(needle)
-	return strings.Contains(cmd, n+" ") || strings.Contains(cmd, n+"\t") || strings.HasSuffix(cmd, n)
+var launchMarkers = []string{
+	"-m lingtai run ",
+	"lingtai-agent.exe run ",
+	"lingtai-agent run ",
+	"lingtai.exe run ",
+	"lingtai run ",
+}
+
+func agentDirRestAfterMarker(command string) (string, bool) {
+	lower := strings.ToLower(command)
+	for _, marker := range launchMarkers {
+		start := 0
+		for {
+			idx := strings.Index(lower[start:], marker)
+			if idx < 0 {
+				break
+			}
+			idx += start
+			if hasLaunchMarkerBoundary(command, idx) {
+				return strings.TrimSpace(command[idx+len(marker):]), true
+			}
+			start = idx + 1
+		}
+	}
+	return "", false
+}
+
+func hasLaunchMarkerBoundary(command string, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	prev := rune(command[idx-1])
+	return unicode.IsSpace(prev) || prev == '/' || prev == '\\' || prev == '"' || prev == '\''
+}
+
+func extractAgentDirFromRest(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if value, _, ok := splitQuoted(rest); ok {
+		return value
+	}
+	return rest
+}
+
+func restMatchesAgentCandidate(rest, candidate string) bool {
+	rest = strings.TrimSpace(rest)
+	candidate = strings.TrimSpace(candidate)
+	if rest == "" || candidate == "" {
+		return false
+	}
+	if value, tail, ok := splitQuoted(rest); ok {
+		if !strings.EqualFold(value, candidate) {
+			return false
+		}
+		return strings.TrimSpace(tail) == "" || startsWithWhitespace(tail)
+	}
+	if strings.EqualFold(rest, candidate) {
+		return true
+	}
+	if len(rest) <= len(candidate) {
+		return false
+	}
+	if !strings.EqualFold(rest[:len(candidate)], candidate) {
+		return false
+	}
+	return unicode.IsSpace(rune(rest[len(candidate)]))
+}
+
+func splitQuoted(s string) (value, tail string, ok bool) {
+	if s == "" || (s[0] != '"' && s[0] != '\'') {
+		return "", "", false
+	}
+	quote := s[0]
+	body := s[1:]
+	end := strings.IndexByte(body, quote)
+	if end < 0 {
+		return strings.TrimSpace(body), "", true
+	}
+	return strings.TrimSpace(body[:end]), body[end+1:], true
+}
+
+func startsWithWhitespace(s string) bool {
+	return s != "" && unicode.IsSpace(rune(s[0]))
+}
+
+func splitLeadingFields(line string, count int) ([]string, string, bool) {
+	rest := strings.TrimLeftFunc(line, unicode.IsSpace)
+	fields := make([]string, 0, count)
+	for len(fields) < count {
+		if rest == "" {
+			return nil, "", false
+		}
+		idx := strings.IndexFunc(rest, unicode.IsSpace)
+		if idx < 0 {
+			return nil, "", false
+		}
+		fields = append(fields, rest[:idx])
+		rest = strings.TrimLeftFunc(rest[idx:], unicode.IsSpace)
+	}
+	if strings.TrimSpace(rest) == "" {
+		return nil, "", false
+	}
+	return fields, rest, true
 }
 
 // FindAgentProcesses returns all running `lingtai run <agentDir>` processes
@@ -126,6 +267,19 @@ func FindAgentProcesses(agentDir string) []AgentProcess {
 	return ParsePSOutput(string(out), abs)
 }
 
+// FindAllAgentProcesses returns every visible LingTai agent process. On Unix it
+// uses `etime` as a display-only uptime string.
+func FindAllAgentProcesses() []AgentProcess {
+	if runtime.GOOS == "windows" {
+		return findAgentProcessesWindows("")
+	}
+	out, err := exec.Command("ps", "-eo", "pid=,etime=,command=").Output()
+	if err != nil {
+		return nil
+	}
+	return ParsePSListOutput(string(out))
+}
+
 func findAgentProcessesWindows(abs string) []AgentProcess {
 	out, err := windowsAgentProcessOutput()
 	if err != nil {
@@ -143,7 +297,7 @@ func windowsAgentProcessOutput() ([]byte, error) {
 		"wmic",
 		"process",
 		"where",
-		"commandline like '%lingtai run%'",
+		"commandline like '%lingtai%run%'",
 		"get",
 		"processid,commandline",
 		"/format:list",
@@ -151,7 +305,7 @@ func windowsAgentProcessOutput() ([]byte, error) {
 	if err == nil {
 		return out, nil
 	}
-	script := `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*lingtai run*' } | ForEach-Object { "CommandLine=$($_.CommandLine)"; "ProcessId=$($_.ProcessId)"; "" }`
+	script := `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*lingtai*run*' } | ForEach-Object { "CommandLine=$($_.CommandLine)"; "ProcessId=$($_.ProcessId)"; "" }`
 	return exec.Command(
 		"powershell.exe",
 		"-NoProfile",
@@ -161,8 +315,8 @@ func windowsAgentProcessOutput() ([]byte, error) {
 	).Output()
 }
 
-// IsAgentRunning returns true if any `python -m lingtai run <agentDir>`
-// (or `lingtai-agent run <agentDir>`) process exists on this machine.
+// IsAgentRunning returns true if any supported `lingtai run <agentDir>` launch
+// form is visible on this machine.
 func IsAgentRunning(agentDir string) bool {
 	return len(FindAgentProcesses(agentDir)) > 0
 }

--- a/tui/internal/processscan/check.go
+++ b/tui/internal/processscan/check.go
@@ -203,6 +203,9 @@ func restMatchesAgentCandidate(rest, candidate string) bool {
 	if strings.EqualFold(rest, candidate) {
 		return true
 	}
+	if containsWhitespace(candidate) {
+		return false
+	}
 	if len(rest) <= len(candidate) {
 		return false
 	}
@@ -227,6 +230,10 @@ func splitQuoted(s string) (value, tail string, ok bool) {
 
 func startsWithWhitespace(s string) bool {
 	return s != "" && unicode.IsSpace(rune(s[0]))
+}
+
+func containsWhitespace(s string) bool {
+	return strings.IndexFunc(s, unicode.IsSpace) >= 0
 }
 
 func splitLeadingFields(line string, count int) ([]string, string, bool) {

--- a/tui/internal/processscan/check_test.go
+++ b/tui/internal/processscan/check_test.go
@@ -2,12 +2,110 @@ package processscan
 
 import "testing"
 
+func TestParsePSListOutputPreservesAgentDirsWithSpaces(t *testing.T) {
+	out := `  1234 00:01:02 /usr/bin/python -m lingtai run /tmp/Project With Spaces/.lingtai/agent A
+  2345 01:02:03 /opt/bin/lingtai run /tmp/Project With Spaces/.lingtai/agent B
+  3456 1-02:03:04 /opt/bin/lingtai-agent run /tmp/Project With Spaces/.lingtai/agent C
+`
+	got := ParsePSListOutput(out)
+	if len(got) != 3 {
+		t.Fatalf("got %d procs, want 3: %+v", len(got), got)
+	}
+	wants := []struct {
+		pid    int
+		uptime string
+		dir    string
+	}{
+		{1234, "00:01:02", "/tmp/Project With Spaces/.lingtai/agent A"},
+		{2345, "01:02:03", "/tmp/Project With Spaces/.lingtai/agent B"},
+		{3456, "1-02:03:04", "/tmp/Project With Spaces/.lingtai/agent C"},
+	}
+	for i, want := range wants {
+		if got[i].PID != want.pid || got[i].Uptime != want.uptime || got[i].AgentDir != want.dir {
+			t.Fatalf("proc[%d] = %+v, want pid=%d uptime=%q dir=%q", i, got[i], want.pid, want.uptime, want.dir)
+		}
+	}
+}
+
+func TestParsePSListOutputRejectsMalformedRows(t *testing.T) {
+	out := `abc 00:01:02 /usr/bin/python -m lingtai run /tmp/project/.lingtai/a
+  1234 00:01:02 /usr/bin/python -m lingtai run
+  2345 00:01:02 /usr/bin/python -m other run /tmp/project/.lingtai/a
+  3456 00:01:02 /usr/bin/python -m lingtai
+`
+	if got := ParsePSListOutput(out); len(got) != 0 {
+		t.Fatalf("malformed rows should be skipped, got %+v", got)
+	}
+}
+
+func TestParsePSOutputMatchesAgentDirWithSpaces(t *testing.T) {
+	abs := "/tmp/Project With Spaces/.lingtai/agent A"
+	out := `  1234 /usr/bin/python -m lingtai run /tmp/Project With Spaces/.lingtai/agent A
+  2345 /usr/bin/python -m lingtai run /tmp/Project With Spaces/.lingtai/agent B
+`
+	got := ParsePSOutput(out, abs)
+	if len(got) != 1 {
+		t.Fatalf("got %d procs, want 1: %+v", len(got), got)
+	}
+	if got[0].PID != 1234 || got[0].AgentDir != abs {
+		t.Fatalf("unexpected match: %+v", got[0])
+	}
+}
+
+func TestExtractAgentDirFromWindowsCommandLinesWithSpaces(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "quoted python module",
+			cmd:  `C:\Python\python.exe -m lingtai run "C:\Users\Raw Lee\project\.lingtai\agent A"`,
+			want: `C:\Users\Raw Lee\project\.lingtai\agent A`,
+		},
+		{
+			name: "unquoted final arg",
+			cmd:  `C:\Python\python.exe -m lingtai run C:\Users\Raw Lee\project\.lingtai\agent A`,
+			want: `C:\Users\Raw Lee\project\.lingtai\agent A`,
+		},
+		{
+			name: "direct console script",
+			cmd:  `C:\Users\Raw Lee\AppData\Local\Programs\Python\Scripts\lingtai.exe run "C:\Users\Raw Lee\project\.lingtai\agent B"`,
+			want: `C:\Users\Raw Lee\project\.lingtai\agent B`,
+		},
+		{
+			name: "agent console script",
+			cmd:  `C:\Users\Raw Lee\AppData\Local\Programs\Python\Scripts\lingtai-agent.exe run "C:\Users\Raw Lee\project\.lingtai\agent C"`,
+			want: `C:\Users\Raw Lee\project\.lingtai\agent C`,
+		},
+		{
+			name: "non agent",
+			cmd:  `powershell.exe -NoProfile`,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ExtractAgentDir(tt.cmd)
+			if tt.want == "" {
+				if ok || got != "" {
+					t.Fatalf("ExtractAgentDir() = %q, %v; want no match", got, ok)
+				}
+				return
+			}
+			if !ok || got != tt.want {
+				t.Fatalf("ExtractAgentDir() = %q, %v; want %q, true", got, ok, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseWMICOutputMatchesQuotedWindowsPath(t *testing.T) {
-	abs := `C:\Users\rawle\AppData\Local\Temp\project\.lingtai\agent-a`
-	out := `CommandLine=C:\Python\python.exe -m lingtai run "C:\Users\rawle\AppData\Local\Temp\project\.lingtai\agent-a"
+	abs := `C:\Users\Raw Lee\AppData\Local\Temp\project\.lingtai\agent-a`
+	out := `CommandLine=C:\Python\python.exe -m lingtai run "C:\Users\Raw Lee\AppData\Local\Temp\project\.lingtai\agent-a"
 ProcessId=1234
 
-CommandLine=C:\Python\python.exe -m lingtai run "C:\Users\rawle\AppData\Local\Temp\project\.lingtai\agent-a-sibling"
+CommandLine=C:\Python\python.exe -m lingtai run "C:\Users\Raw Lee\AppData\Local\Temp\project\.lingtai\agent-a-sibling"
 ProcessId=5678
 `
 	got := ParseWMICOutput(out, abs)
@@ -23,15 +121,21 @@ func TestParseWMICOutputListsAllWhenAbsEmpty(t *testing.T) {
 	out := `CommandLine=C:\Python\python.exe -m lingtai run C:\tmp\a
 ProcessId=1234
 
+CommandLine=C:\Python\Scripts\lingtai.exe run C:\tmp\Project With Spaces\.lingtai\agent A
+ProcessId=2345
+
 CommandLine=C:\Python\python.exe -m other run C:\tmp\a
 ProcessId=5678
 `
 	got := ParseWMICOutput(out, "")
-	if len(got) != 1 {
-		t.Fatalf("got %d procs, want 1: %+v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("got %d procs, want 2: %+v", len(got), got)
 	}
-	if got[0].PID != 1234 {
-		t.Fatalf("PID = %d, want 1234", got[0].PID)
+	if got[0].PID != 1234 || got[0].AgentDir != `C:\tmp\a` {
+		t.Fatalf("first proc = %+v, want PID 1234 dir C:\\tmp\\a", got[0])
+	}
+	if got[1].PID != 2345 || got[1].AgentDir != `C:\tmp\Project With Spaces\.lingtai\agent A` {
+		t.Fatalf("second proc = %+v", got[1])
 	}
 }
 

--- a/tui/internal/processscan/check_test.go
+++ b/tui/internal/processscan/check_test.go
@@ -52,6 +52,20 @@ func TestParsePSOutputMatchesAgentDirWithSpaces(t *testing.T) {
 	}
 }
 
+func TestParsePSOutputRejectsUnquotedSpacedPrefixSibling(t *testing.T) {
+	abs := "/tmp/Project With Spaces/.lingtai/agent"
+	out := `  1234 /usr/bin/python -m lingtai run /tmp/Project With Spaces/.lingtai/agent beta
+  2345 /usr/bin/python -m lingtai run /tmp/Project With Spaces/.lingtai/agent
+`
+	got := ParsePSOutput(out, abs)
+	if len(got) != 1 {
+		t.Fatalf("got %d procs, want exact match only: %+v", len(got), got)
+	}
+	if got[0].PID != 2345 || got[0].AgentDir != abs {
+		t.Fatalf("unexpected match: %+v", got[0])
+	}
+}
+
 func TestExtractAgentDirFromWindowsCommandLinesWithSpaces(t *testing.T) {
 	tests := []struct {
 		name string
@@ -117,6 +131,23 @@ ProcessId=5678
 	}
 }
 
+func TestParseWMICOutputRejectsUnquotedSpacedPrefixSibling(t *testing.T) {
+	abs := `C:\Users\Raw Lee\AppData\Local\Temp\project\.lingtai\agent`
+	out := `CommandLine=C:\Python\python.exe -m lingtai run C:\Users\Raw Lee\AppData\Local\Temp\project\.lingtai\agent beta
+ProcessId=1234
+
+CommandLine=C:\Python\python.exe -m lingtai run C:\Users\Raw Lee\AppData\Local\Temp\project\.lingtai\agent
+ProcessId=2345
+`
+	got := ParseWMICOutput(out, abs)
+	if len(got) != 1 {
+		t.Fatalf("got %d procs, want exact match only: %+v", len(got), got)
+	}
+	if got[0].PID != 2345 || got[0].AgentDir != abs {
+		t.Fatalf("unexpected match: %+v", got[0])
+	}
+}
+
 func TestParseWMICOutputListsAllWhenAbsEmpty(t *testing.T) {
 	out := `CommandLine=C:\Python\python.exe -m lingtai run C:\tmp\a
 ProcessId=1234
@@ -149,5 +180,19 @@ func TestCommandMatchesAgentDirEOLAndArgBoundary(t *testing.T) {
 	}
 	if commandMatchesAgentDir(`python -m lingtai run /work/foo-sibling`, abs) {
 		t.Fatal("prefix sibling should not match")
+	}
+
+	spacedAbs := `/work/Project With Spaces/.lingtai/agent`
+	if !commandMatchesAgentDir(`python -m lingtai run /work/Project With Spaces/.lingtai/agent`, spacedAbs) {
+		t.Fatal("expected exact unquoted spaced match")
+	}
+	if commandMatchesAgentDir(`python -m lingtai run /work/Project With Spaces/.lingtai/agent beta`, spacedAbs) {
+		t.Fatal("unquoted spaced prefix sibling should not match")
+	}
+	if commandMatchesAgentDir(`python -m lingtai run /work/Project With Spaces/.lingtai/agent --debug`, spacedAbs) {
+		t.Fatal("unquoted spaced trailing args are ambiguous and should not match")
+	}
+	if !commandMatchesAgentDir(`python -m lingtai run "/work/Project With Spaces/.lingtai/agent" --debug`, spacedAbs) {
+		t.Fatal("quoted spaced arg-boundary match should remain supported")
 	}
 }

--- a/tui/internal/processscan/check_test.go
+++ b/tui/internal/processscan/check_test.go
@@ -196,3 +196,14 @@ func TestCommandMatchesAgentDirEOLAndArgBoundary(t *testing.T) {
 		t.Fatal("quoted spaced arg-boundary match should remain supported")
 	}
 }
+
+func TestFindAllAgentProcessesReturnsScanError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // no ps / wmic / powershell reachable
+	procs, err := FindAllAgentProcesses()
+	if err == nil {
+		t.Fatalf("expected an error when the process-scan command is unavailable, got procs=%v", procs)
+	}
+	if len(procs) != 0 {
+		t.Fatalf("expected no processes alongside the error, got %v", procs)
+	}
+}

--- a/tui/list_common.go
+++ b/tui/list_common.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/anthropics/lingtai-tui/internal/fs"
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 	uitui "github.com/anthropics/lingtai-tui/internal/tui"
 )
 
@@ -63,6 +64,54 @@ type listJSONProc struct {
 	ReadError  string             `json:"read_error,omitempty"`
 	Heartbeat  fs.HeartbeatStatus `json:"heartbeat"`
 	LockExists bool               `json:"lock_exists"`
+}
+
+func listProcsFromAgentProcesses(found []processscan.AgentProcess, filterDir string, selfPID int) []listProc {
+	procs := make([]listProc, 0, len(found))
+	for _, proc := range found {
+		if proc.PID == selfPID {
+			continue
+		}
+		agentDir := proc.AgentDir
+		if agentDir == "" {
+			var ok bool
+			agentDir, ok = processscan.ExtractAgentDir(proc.Command)
+			if !ok {
+				continue
+			}
+		}
+		if !agentDirInFilter(agentDir, filterDir) {
+			continue
+		}
+		procs = append(procs, listProc{
+			PID:     fmt.Sprint(proc.PID),
+			Uptime:  proc.Uptime,
+			Agent:   filepath.Base(agentDir),
+			Project: projectFromAgentDir(agentDir),
+			Dir:     agentDir,
+		})
+	}
+	return procs
+}
+
+func agentDirInFilter(agentDir, filterDir string) bool {
+	if filterDir == "" {
+		return true
+	}
+	lingtaiDir := filepath.Join(filterDir, ".lingtai")
+	if strings.HasPrefix(agentDir, lingtaiDir+string(filepath.Separator)) {
+		return true
+	}
+	return strings.HasPrefix(filepath.ToSlash(agentDir), filepath.ToSlash(lingtaiDir)+"/")
+}
+
+func projectFromAgentDir(agentDir string) string {
+	slashDir := filepath.ToSlash(agentDir)
+	idx := strings.Index(slashDir, "/.lingtai/")
+	if idx < 0 {
+		return ""
+	}
+	return agentDir[:idx]
 }
 
 func parseListArgs(args []string) (listOptions, error) {

--- a/tui/list_common_test.go
+++ b/tui/list_common_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
 func TestParseListArgsModesAndDir(t *testing.T) {
@@ -22,6 +24,50 @@ func TestParseListArgsModesAndDir(t *testing.T) {
 	want, _ := filepath.Abs("./project")
 	if opts.FilterDir != want {
 		t.Fatalf("FilterDir=%q, want %q", opts.FilterDir, want)
+	}
+}
+
+func TestListProcsFromAgentProcessesPreservesSpacesAndFilter(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "Project With Spaces")
+	agentDir := filepath.Join(project, ".lingtai", "agent A")
+	otherProject := filepath.Join(root, "Other Project")
+	otherAgentDir := filepath.Join(otherProject, ".lingtai", "agent B")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := listProcsFromAgentProcesses([]processscan.AgentProcess{
+		{PID: 111, Uptime: "00:01:02", AgentDir: agentDir},
+		{PID: 222, Uptime: "00:02:03", AgentDir: otherAgentDir},
+		{PID: 333, Uptime: "00:03:04", AgentDir: agentDir},
+	}, project, 333)
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	proc := got[0]
+	if proc.PID != "111" || proc.Uptime != "00:01:02" {
+		t.Fatalf("unexpected pid/uptime: %+v", proc)
+	}
+	if proc.Agent != "agent A" || proc.Project != project || proc.Dir != agentDir {
+		t.Fatalf("space-containing path was not preserved: %+v", proc)
+	}
+	if phantoms := detectPhantomDirs(got, ""); phantoms[project] {
+		t.Fatalf("existing project with spaces should not be phantom: %+v", phantoms)
+	}
+}
+
+func TestCollapseListProcsKeepsDistinctSpacePaths(t *testing.T) {
+	root := t.TempDir()
+	dirA := filepath.Join(root, "Project With Spaces", ".lingtai", "agent A")
+	dirB := filepath.Join(root, "Project With Spaces", ".lingtai", "agent B")
+	got := collapseListProcsByAgentDir([]listProc{
+		{PID: "111", Agent: "agent A", Dir: dirA},
+		{PID: "222", Agent: "agent B", Dir: dirB},
+	})
+	if len(got) != 2 {
+		t.Fatalf("distinct full dirs should not collapse, got %+v", got)
 	}
 }
 

--- a/tui/list_unix.go
+++ b/tui/list_unix.go
@@ -5,11 +5,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
 func listMain() {
@@ -18,55 +16,7 @@ func listMain() {
 		listUsageError(err)
 	}
 
-	out, err := exec.Command("ps", "aux").Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error running ps: %v\n", err)
-		os.Exit(1)
-	}
-
-	var procs []listProc
-	for _, line := range strings.Split(string(out), "\n") {
-		if !strings.Contains(line, "lingtai run") || strings.Contains(line, "grep") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 11 {
-			continue
-		}
-		pid, err := strconv.Atoi(fields[1])
-		if err != nil || pid == os.Getpid() {
-			continue
-		}
-
-		// Parse agent dir from command args: ... lingtai run <dir>
-		var agentDir string
-		for i, f := range fields {
-			if f == "run" && i+1 < len(fields) {
-				agentDir = fields[i+1]
-				break
-			}
-		}
-
-		// If filtering by dir, only include processes under <dir>/.lingtai/
-		if opts.FilterDir != "" {
-			lingtaiPrefix := filepath.Join(opts.FilterDir, ".lingtai") + string(filepath.Separator)
-			if !strings.HasPrefix(agentDir, lingtaiPrefix) {
-				continue
-			}
-		}
-
-		agent := filepath.Base(agentDir)
-		project := ""
-		// Walk up to find .lingtai parent
-		if idx := strings.Index(agentDir, "/.lingtai/"); idx >= 0 {
-			project = agentDir[:idx]
-		}
-
-		// Get process start time from ps output. This is replaced with elapsed time below when available.
-		elapsed := fields[9]
-
-		procs = append(procs, listProc{PID: fields[1], Uptime: elapsed, Agent: agent, Project: project, Dir: agentDir})
-	}
+	procs := listProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), opts.FilterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if opts.JSON {
@@ -79,38 +29,6 @@ func listMain() {
 			fmt.Println("No lingtai processes running.")
 		}
 		return
-	}
-
-	// Also try to get elapsed time via ps -o etimes.
-	pidStrs := make([]string, len(procs))
-	procByPID := map[string]*listProc{}
-	for i := range procs {
-		pidStrs[i] = procs[i].PID
-		procByPID[procs[i].PID] = &procs[i]
-	}
-	if out2, err := exec.Command("ps", "-o", "pid=,etimes=", "-p", strings.Join(pidStrs, ",")).Output(); err == nil {
-		for _, line := range strings.Split(string(out2), "\n") {
-			fields := strings.Fields(line)
-			if len(fields) != 2 {
-				continue
-			}
-			secs, err := strconv.Atoi(fields[1])
-			if err != nil {
-				continue
-			}
-			d := time.Duration(secs) * time.Second
-			elapsed := ""
-			if d >= 24*time.Hour {
-				elapsed = fmt.Sprintf("%dd %dh", int(d.Hours())/24, int(d.Hours())%24)
-			} else if d >= time.Hour {
-				elapsed = fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
-			} else {
-				elapsed = fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
-			}
-			if proc := procByPID[fields[0]]; proc != nil {
-				proc.Uptime = elapsed
-			}
-		}
 	}
 
 	phantomDirs := detectPhantomDirs(procs, opts.FilterDir)

--- a/tui/list_unix.go
+++ b/tui/list_unix.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
@@ -16,7 +19,15 @@ func listMain() {
 		listUsageError(err)
 	}
 
-	procs := listProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), opts.FilterDir, os.Getpid())
+	found, err := processscan.FindAllAgentProcesses()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error running ps: %v\n", err)
+		os.Exit(1)
+	}
+	procs := listProcsFromAgentProcesses(found, opts.FilterDir, os.Getpid())
+	for i := range procs {
+		procs[i].Uptime = humanUptimeFromEtime(procs[i].Uptime)
+	}
 
 	if len(procs) == 0 {
 		if opts.JSON {
@@ -41,6 +52,51 @@ func listMain() {
 	printList(os.Stdout, procs, phantomDirs, opts, true)
 	fmt.Printf("\n%d process(es) running.\n", len(procs))
 	printListWarnings(os.Stdout, phantomDirs, opts.FilterDir)
+}
+
+// humanUptimeFromEtime converts a ps etime value ([[dd-]hh:]mm:ss) into the
+// human-readable uptime the UPTIME column has always shown ("2d 3h", "1h 2m",
+// "4m 9s"). Unparseable values are shown as-is rather than guessed.
+func humanUptimeFromEtime(etime string) string {
+	secs, ok := parseEtimeSeconds(etime)
+	if !ok {
+		return etime
+	}
+	d := time.Duration(secs) * time.Second
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd %dh", int(d.Hours())/24, int(d.Hours())%24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
+	default:
+		return fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+}
+
+func parseEtimeSeconds(etime string) (int, bool) {
+	etime = strings.TrimSpace(etime)
+	days := 0
+	if day, rest, ok := strings.Cut(etime, "-"); ok {
+		d, err := strconv.Atoi(day)
+		if err != nil || d < 0 {
+			return 0, false
+		}
+		days = d
+		etime = rest
+	}
+	parts := strings.Split(etime, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, false
+	}
+	secs := 0
+	for _, part := range parts {
+		v, err := strconv.Atoi(part)
+		if err != nil || v < 0 {
+			return 0, false
+		}
+		secs = secs*60 + v
+	}
+	return days*24*60*60 + secs, true
 }
 
 func detectPhantomDirs(procs []listProc, filterDir string) map[string]bool {

--- a/tui/list_unix_test.go
+++ b/tui/list_unix_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestHumanUptimeFromEtime(t *testing.T) {
+	cases := []struct{ etime, want string }{
+		{"04:09", "4m 9s"},
+		{"00:05", "0m 5s"},
+		{"01:02:03", "1h 2m"},
+		{"23:59:59", "23h 59m"},
+		{"1-00:00:01", "1d 0h"},
+		{"2-03:04:05", "2d 3h"},
+		{" 12:34 ", "12m 34s"},
+		// Unparseable values pass through untouched rather than being guessed.
+		{"", ""},
+		{"?", "?"},
+		{"1:2:3:4", "1:2:3:4"},
+		{"x-00:01", "x-00:01"},
+	}
+	for _, c := range cases {
+		if got := humanUptimeFromEtime(c.etime); got != c.want {
+			t.Errorf("humanUptimeFromEtime(%q) = %q, want %q", c.etime, got, c.want)
+		}
+	}
+}
+
+func TestListMainFailsLoudOnScanError(t *testing.T) {
+	if os.Getenv("LINGTAI_TEST_LIST_SCAN_FAIL") == "1" {
+		os.Args = []string{"lingtai-tui", "list"}
+		listMain()
+		os.Exit(0)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestListMainFailsLoudOnScanError$")
+	cmd.Env = append(os.Environ(),
+		"LINGTAI_TEST_LIST_SCAN_FAIL=1",
+		"PATH="+t.TempDir(), // ps is unreachable, so the scan command fails
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected nonzero exit when ps is unavailable, got err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if code := exitErr.ExitCode(); code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "error running ps") {
+		t.Fatalf("stderr = %q, want it to report the ps failure", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "No lingtai processes running") {
+		t.Fatalf("stdout = %q, scan failure must not masquerade as an empty process list", stdout.String())
+	}
+}

--- a/tui/list_windows.go
+++ b/tui/list_windows.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
@@ -17,30 +16,7 @@ func listMain() {
 		listUsageError(err)
 	}
 
-	var procs []listProc
-	for _, proc := range processscan.FindWindowsAgentProcesses("") {
-		cmdline := proc.Command
-		agentDir := agentDirFromWindowsCommandLine(cmdline)
-		agent := "unknown"
-		if agentDir != "" {
-			agent = filepath.Base(agentDir)
-		}
-
-		// Filter by dir if specified.
-		if opts.FilterDir != "" {
-			lingtaiPrefix := filepath.Join(opts.FilterDir, ".lingtai") + string(filepath.Separator)
-			if !strings.HasPrefix(agentDir, lingtaiPrefix) {
-				continue
-			}
-		}
-
-		project := ""
-		if idx := strings.Index(agentDir, `\.lingtai\`); idx >= 0 {
-			project = agentDir[:idx]
-		}
-
-		procs = append(procs, listProc{PID: fmt.Sprint(proc.PID), Agent: agent, Dir: agentDir, Project: project})
-	}
+	procs := listProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), opts.FilterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if opts.JSON {
@@ -92,26 +68,9 @@ func detectPhantomDirs(procs []listProc, filterDir string) map[string]bool {
 }
 
 func agentDirFromWindowsCommandLine(cmdline string) string {
-	lower := strings.ToLower(cmdline)
-	idx := strings.Index(lower, "lingtai run ")
-	if idx < 0 {
+	agentDir, ok := processscan.ExtractAgentDir(cmdline)
+	if !ok {
 		return ""
 	}
-	rest := strings.TrimSpace(cmdline[idx+len("lingtai run "):])
-	if rest == "" {
-		return ""
-	}
-	if strings.HasPrefix(rest, `"`) {
-		rest = strings.TrimPrefix(rest, `"`)
-		end := strings.Index(rest, `"`)
-		if end < 0 {
-			return strings.TrimSpace(rest)
-		}
-		return strings.TrimSpace(rest[:end])
-	}
-	fields := strings.Fields(rest)
-	if len(fields) == 0 {
-		return ""
-	}
-	return strings.Trim(fields[0], `"`)
+	return agentDir
 }

--- a/tui/list_windows.go
+++ b/tui/list_windows.go
@@ -16,7 +16,12 @@ func listMain() {
 		listUsageError(err)
 	}
 
-	procs := listProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), opts.FilterDir, os.Getpid())
+	found, err := processscan.FindAllAgentProcesses()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error listing processes: %v\n", err)
+		os.Exit(1)
+	}
+	procs := listProcsFromAgentProcesses(found, opts.FilterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if opts.JSON {

--- a/tui/list_windows_test.go
+++ b/tui/list_windows_test.go
@@ -16,9 +16,14 @@ func TestAgentDirFromWindowsCommandLine(t *testing.T) {
 			want: `C:\Users\Raw Lee\project\.lingtai\contract-agent`,
 		},
 		{
-			name: "unquoted path",
-			cmd:  `C:\Python\python.exe -m lingtai run C:\Users\rawle\project\.lingtai\contract-agent`,
-			want: `C:\Users\rawle\project\.lingtai\contract-agent`,
+			name: "unquoted path with spaces",
+			cmd:  `C:\Python\python.exe -m lingtai run C:\Users\Raw Lee\project\.lingtai\contract agent`,
+			want: `C:\Users\Raw Lee\project\.lingtai\contract agent`,
+		},
+		{
+			name: "direct console script",
+			cmd:  `C:\Python\Scripts\lingtai.exe run "C:\Users\Raw Lee\project\.lingtai\contract-agent"`,
+			want: `C:\Users\Raw Lee\project\.lingtai\contract-agent`,
 		},
 		{
 			name: "non lingtai command",

--- a/tui/purge_common.go
+++ b/tui/purge_common.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
+)
+
+type purgeProc struct {
+	pid   int
+	agent string
+	dir   string
+}
+
+func purgeProcsFromAgentProcesses(found []processscan.AgentProcess, filterDir string, selfPID int) []purgeProc {
+	procs := make([]purgeProc, 0, len(found))
+	for _, proc := range found {
+		if proc.PID == selfPID {
+			continue
+		}
+		agentDir := proc.AgentDir
+		if agentDir == "" {
+			var ok bool
+			agentDir, ok = processscan.ExtractAgentDir(proc.Command)
+			if !ok {
+				continue
+			}
+		}
+		if !agentDirInFilter(agentDir, filterDir) {
+			continue
+		}
+		procs = append(procs, purgeProc{
+			pid:   proc.PID,
+			agent: filepath.Base(agentDir),
+			dir:   agentDir,
+		})
+	}
+	return procs
+}

--- a/tui/purge_common_test.go
+++ b/tui/purge_common_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
+)
+
+func TestPurgeProcsFromAgentProcessesPreservesSpacesAndFilter(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "Project With Spaces")
+	agentDir := filepath.Join(project, ".lingtai", "agent A")
+	otherAgentDir := filepath.Join(root, "Other Project", ".lingtai", "agent B")
+
+	got := purgeProcsFromAgentProcesses([]processscan.AgentProcess{
+		{PID: 111, AgentDir: agentDir},
+		{PID: 222, AgentDir: otherAgentDir},
+		{PID: 333, AgentDir: agentDir},
+	}, project, 333)
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].pid != 111 || got[0].agent != "agent A" || got[0].dir != agentDir {
+		t.Fatalf("space-containing purge target was not preserved: %+v", got[0])
+	}
+}

--- a/tui/purge_unix.go
+++ b/tui/purge_unix.go
@@ -21,7 +21,12 @@ func purgeMain() {
 		filterDir, _ = filepath.Abs(os.Args[2])
 	}
 
-	procs := purgeProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), filterDir, os.Getpid())
+	found, err := processscan.FindAllAgentProcesses()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error running ps: %v\n", err)
+		os.Exit(1)
+	}
+	procs := purgeProcsFromAgentProcesses(found, filterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if filterDir != "" {

--- a/tui/purge_unix.go
+++ b/tui/purge_unix.go
@@ -6,12 +6,12 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
 func purgeMain() {
@@ -21,54 +21,7 @@ func purgeMain() {
 		filterDir, _ = filepath.Abs(os.Args[2])
 	}
 
-	out, err := exec.Command("ps", "aux").Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error running ps: %v\n", err)
-		os.Exit(1)
-	}
-
-	type proc struct {
-		pid   int
-		agent string
-		dir   string
-	}
-
-	var procs []proc
-	for _, line := range strings.Split(string(out), "\n") {
-		if !strings.Contains(line, "lingtai run") || strings.Contains(line, "grep") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		pid, err := strconv.Atoi(fields[1])
-		if err != nil || pid == os.Getpid() {
-			continue
-		}
-
-		var agentDir string
-		for i, f := range fields {
-			if f == "run" && i+1 < len(fields) {
-				agentDir = fields[i+1]
-				break
-			}
-		}
-
-		// Filter by dir if specified
-		if filterDir != "" {
-			lingtaiPrefix := filepath.Join(filterDir, ".lingtai") + string(filepath.Separator)
-			if !strings.HasPrefix(agentDir, lingtaiPrefix) {
-				continue
-			}
-		}
-
-		procs = append(procs, proc{
-			pid:   pid,
-			agent: filepath.Base(agentDir),
-			dir:   agentDir,
-		})
-	}
+	procs := purgeProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), filterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if filterDir != "" {

--- a/tui/purge_unix_test.go
+++ b/tui/purge_unix_test.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPurgeMainFailsLoudOnScanError(t *testing.T) {
+	if os.Getenv("LINGTAI_TEST_PURGE_SCAN_FAIL") == "1" {
+		os.Args = []string{"lingtai-tui", "purge"}
+		purgeMain()
+		os.Exit(0)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestPurgeMainFailsLoudOnScanError$")
+	cmd.Env = append(os.Environ(),
+		"LINGTAI_TEST_PURGE_SCAN_FAIL=1",
+		"PATH="+t.TempDir(), // ps is unreachable, so the scan command fails
+	)
+	cmd.Stdin = strings.NewReader("n\n") // never reached; keeps a regression from hanging on the kill prompt
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected nonzero exit when ps is unavailable, got err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if code := exitErr.ExitCode(); code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "error running ps") {
+		t.Fatalf("stderr = %q, want it to report the ps failure", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "No lingtai processes found") {
+		t.Fatalf("stdout = %q, scan failure must not masquerade as an empty process list", stdout.String())
+	}
+}

--- a/tui/purge_windows.go
+++ b/tui/purge_windows.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
 func purgeMain() {
@@ -18,54 +20,7 @@ func purgeMain() {
 		filterDir, _ = filepath.Abs(os.Args[2])
 	}
 
-	out, err := exec.Command("wmic", "process", "where",
-		"commandline like '%lingtai run%'",
-		"get", "processid,commandline", "/format:list").Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error listing processes: %v\n", err)
-		os.Exit(1)
-	}
-
-	type proc struct {
-		pid   string
-		agent string
-		dir   string
-	}
-
-	var procs []proc
-	var cmdline, pid string
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "CommandLine=") {
-			cmdline = strings.TrimPrefix(line, "CommandLine=")
-		}
-		if strings.HasPrefix(line, "ProcessId=") {
-			pid = strings.TrimPrefix(line, "ProcessId=")
-			if cmdline != "" && strings.Contains(cmdline, "lingtai run") {
-				agentDir := ""
-				agent := "unknown"
-				if idx := strings.Index(cmdline, "lingtai run "); idx >= 0 {
-					agentDir = cmdline[idx+len("lingtai run "):]
-					agentDir = strings.TrimSpace(strings.Split(agentDir, " ")[0])
-					agent = filepath.Base(agentDir)
-				}
-
-				// Filter by dir if specified
-				if filterDir != "" {
-					lingtaiPrefix := filepath.Join(filterDir, ".lingtai") + string(filepath.Separator)
-					if !strings.HasPrefix(agentDir, lingtaiPrefix) {
-						cmdline = ""
-						pid = ""
-						continue
-					}
-				}
-
-				procs = append(procs, proc{pid: pid, agent: agent, dir: agentDir})
-			}
-			cmdline = ""
-			pid = ""
-		}
-	}
+	procs := purgeProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), filterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if filterDir != "" {
@@ -82,7 +37,7 @@ func purgeMain() {
 	}
 	fmt.Printf("%-8s %-30s %s\n", "PID", "AGENT", "DIRECTORY")
 	for _, p := range procs {
-		fmt.Printf("%-8s %-30s %s\n", p.pid, p.agent, p.dir)
+		fmt.Printf("%-8d %-30s %s\n", p.pid, p.agent, p.dir)
 	}
 	fmt.Printf("\n%d process(es) in %s. Kill all? [y/N] ", len(procs), scope)
 
@@ -96,7 +51,7 @@ func purgeMain() {
 
 	killed := 0
 	for _, p := range procs {
-		cmd := exec.Command("taskkill", "/F", "/PID", p.pid)
+		cmd := exec.Command("taskkill", "/F", "/PID", fmt.Sprint(p.pid))
 		if cmd.Run() == nil {
 			killed++
 		}

--- a/tui/purge_windows.go
+++ b/tui/purge_windows.go
@@ -20,7 +20,12 @@ func purgeMain() {
 		filterDir, _ = filepath.Abs(os.Args[2])
 	}
 
-	procs := purgeProcsFromAgentProcesses(processscan.FindAllAgentProcesses(), filterDir, os.Getpid())
+	found, err := processscan.FindAllAgentProcesses()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error listing processes: %v\n", err)
+		os.Exit(1)
+	}
+	procs := purgeProcsFromAgentProcesses(found, filterDir, os.Getpid())
 
 	if len(procs) == 0 {
 		if filterDir != "" {


### PR DESCRIPTION
## Summary

Fixes #563.

This PR fixes TUI agent discovery when project or agent paths contain spaces. The existing list/purge rediscovery code split process rows with whitespace tokenization and then took the token after `lingtai run`, so an agent directory like `/tmp/Project With Spaces/.lingtai/agent A` was truncated to `/tmp/Project`. That broke scoped `list`/`purge`, phantom/stale directory handling, and display grouping.

Changes:

- Add shared process-scan parsing that separates the leading `ps` columns from the command and preserves the full final `lingtai run <agentDir>` argument, including spaces.
- Route Unix list/purge process discovery through the shared scanner instead of bespoke `strings.Fields` parsing.
- Fix Windows list/purge command-line parsing so quoted and unquoted spaced agent dirs are preserved.
- Tighten known-agent matching so an expected spaced path such as `.../agent` does not match a prefix sibling like `.../agent beta`.
- Add regressions for spaced paths, exact known-agent matching, list/purge behavior, Windows parsing, and relevant collapse/display behavior.
- Update anatomy notes for the shared process-scan responsibility.

## Non-goals

- No launcher redesign and no procfs/process-enumeration redesign.
- No authentication, portal, runtime, or live-agent behavior changes.
- Agent counting behavior is left essentially unchanged except where covered by the shared scanner path; broader Windows self-match/substring hardening can be a separate follow-up if needed.

## Validation

Passed:

- `git diff --check canonical/main...HEAD`
- `cd tui && go test ./internal/processscan ./internal/process -count=1`
- `cd tui && go test . -run 'Test.*(List|Purge|Agent|Process|Space|Phantom|Collapse)' -count=1`
- `cd tui && GOOS=windows GOARCH=amd64 go test -c -o /tmp/lingtai-issue-563-windows.test.exe .`
- `cd tui && go vet ./...`

Full-suite note:

- `cd tui && go test ./... -count=1` still fails at `internal/tui TestPortalURLTimeoutKillsChild` with the known local/baseline fake-portal PID failure.
- I reproduced the same `internal/tui` package failure on untouched `canonical/main`, so it is not introduced by this PR.

## Review

The initial fix received one blocker around prefix-sibling known-agent matching. A follow-up commit tightened the matcher and added regressions. Three independent post-fix reviews found no remaining blockers and considered the branch public-PR-ready.
