### PR TITLE
Fix tool description dump i18n paths

### DIFF
--- a/scripts/dump_tool_descriptions.py
+++ b/scripts/dump_tool_descriptions.py
@@ -1,30 +1,36 @@
 #!/usr/bin/env python3
-"""Dump all tool descriptions from i18n files as a single markdown with all locales.
+"""Dump all tool descriptions from lingtai-kernel i18n files.
 
 Usage:
     python scripts/dump_tool_descriptions.py
+    python scripts/dump_tool_descriptions.py --kernel-repo /path/to/lingtai-kernel
 
-Reads from both lingtai-kernel and lingtai i18n JSONs.
+By default, reads both kernel intrinsic and capability i18n JSONs from a
+``lingtai-kernel`` checkout next to this repo. Override the checkout path with
+``--kernel-repo`` or the ``LINGTAI_KERNEL_REPO`` environment variable.
 Outputs one markdown with en / zh / wen columns per tool.
 """
 from __future__ import annotations
 
+import argparse
 import json
+import os
+import sys
 from pathlib import Path
 
 LANGS = ["en", "zh", "wen"]
 LANG_LABELS = {"en": "English", "zh": "中文", "wen": "文言"}
 
 BASE = Path(__file__).resolve().parent.parent
-KERNEL_I18N = BASE.parent / "lingtai-kernel" / "src" / "lingtai_kernel" / "i18n"
-LINGTAI_I18N = BASE / "src" / "lingtai" / "i18n"
+DEFAULT_KERNEL_REPO = BASE.parent / "lingtai-kernel"
+OVERRIDE_HELP = "Use --kernel-repo or LINGTAI_KERNEL_REPO to set the lingtai-kernel checkout."
 
 
 def load_descriptions(path: Path) -> dict[str, str]:
     """Load i18n JSON and return only keys ending with '.description'."""
     if not path.is_file():
-        return {}
-    data = json.loads(path.read_text())
+        sys.exit(f"error: missing locale file: {path.resolve()}")
+    data = json.loads(path.read_text(encoding="utf-8"))
     return {k: v for k, v in data.items() if k.endswith(".description")}
 
 
@@ -43,9 +49,42 @@ def collect(i18n_dir: Path) -> dict[str, dict[str, str]]:
     return tools
 
 
-def print_section(title: str, tools: dict[str, dict[str, str]]) -> None:
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Dump tool descriptions from a lingtai-kernel checkout."
+    )
+    parser.add_argument(
+        "--kernel-repo",
+        help="Path to the lingtai-kernel checkout. Overrides LINGTAI_KERNEL_REPO.",
+    )
+    return parser.parse_args()
+
+
+def resolve_kernel_repo(args: argparse.Namespace) -> Path:
+    configured = args.kernel_repo or os.environ.get("LINGTAI_KERNEL_REPO")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return DEFAULT_KERNEL_REPO.resolve()
+
+
+def validate_dir(path: Path) -> None:
+    if not path.is_dir():
+        sys.exit(f"error: missing i18n directory: {path.resolve()}. {OVERRIDE_HELP}")
+
+
+def validate_kernel_repo(kernel_repo: Path) -> None:
+    if not kernel_repo.is_dir():
+        sys.exit(f"error: missing kernel repo: {kernel_repo.resolve()}. {OVERRIDE_HELP}")
+
+
+def validate_section(title: str, i18n_dir: Path, tools: dict[str, dict[str, str]]) -> None:
     if not tools:
-        return
+        sys.exit(
+            f"error: no .description entries found for {title} in {i18n_dir.resolve()}"
+        )
+
+
+def print_section(title: str, tools: dict[str, dict[str, str]]) -> None:
     print(f"## {title}\n")
     for name, langs in tools.items():
         print(f"### {name}\n")
@@ -55,8 +94,19 @@ def print_section(title: str, tools: dict[str, dict[str, str]]) -> None:
 
 
 def main() -> None:
-    kernel = collect(KERNEL_I18N)
-    lingtai = collect(LINGTAI_I18N)
+    args = parse_args()
+    kernel_repo = resolve_kernel_repo(args)
+    kernel_i18n = kernel_repo / "src" / "lingtai_kernel" / "i18n"
+    lingtai_i18n = kernel_repo / "src" / "lingtai" / "i18n"
+
+    validate_kernel_repo(kernel_repo)
+    validate_dir(kernel_i18n)
+    validate_dir(lingtai_i18n)
+
+    kernel = collect(kernel_i18n)
+    lingtai = collect(lingtai_i18n)
+    validate_section("Kernel Intrinsics", kernel_i18n, kernel)
+    validate_section("Capabilities", lingtai_i18n, lingtai)
 
     print("# Tool Descriptions\n")
     print_section("Kernel Intrinsics", kernel)

--- a/scripts/test_dump_tool_descriptions.py
+++ b/scripts/test_dump_tool_descriptions.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Stdlib smoke tests for dump_tool_descriptions.py."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "dump_tool_descriptions.py"
+
+
+def write_json(path: Path, payload: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def create_kernel_repo(root: Path, marker: str = "default") -> Path:
+    kernel_i18n = root / "src" / "lingtai_kernel" / "i18n"
+    capability_i18n = root / "src" / "lingtai" / "i18n"
+    for lang, label in (("en", "English"), ("zh", "Chinese"), ("wen", "Classical")):
+        write_json(
+            kernel_i18n / f"{lang}.json",
+            {
+                "intrinsic.description": f"{label} intrinsic {marker}",
+                "intrinsic.name": f"ignored kernel {marker}",
+            },
+        )
+        write_json(
+            capability_i18n / f"{lang}.json",
+            {
+                "read.description": f"{label} capability {marker}",
+                "read.name": f"ignored capability {marker}",
+            },
+        )
+    return root
+
+
+class DumpToolDescriptionsTest(unittest.TestCase):
+    def run_script(self, *args: str, env_updates=None):
+        env = os.environ.copy()
+        env.pop("LINGTAI_KERNEL_REPO", None)
+        if env_updates:
+            env.update(env_updates)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            env=env,
+            check=False,
+        )
+
+    def test_happy_path_includes_both_sections_and_locale_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kernel_repo = create_kernel_repo(Path(tmp) / "lingtai-kernel")
+            wen_path = kernel_repo / "src" / "lingtai" / "i18n" / "wen.json"
+            write_json(wen_path, {"other.description": "Classical capability fallback"})
+
+            result = self.run_script("--kernel-repo", str(kernel_repo))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertIn("# Tool Descriptions", result.stdout)
+        self.assertIn("## Kernel Intrinsics", result.stdout)
+        self.assertIn("## Capabilities", result.stdout)
+        self.assertIn("**English:**", result.stdout)
+        self.assertIn("**中文:**", result.stdout)
+        self.assertIn("**文言:**", result.stdout)
+        self.assertIn("### intrinsic", result.stdout)
+        self.assertIn("### read", result.stdout)
+        self.assertIn("—", result.stdout)
+
+    def test_missing_capability_dir_fails_loudly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kernel_repo = Path(tmp) / "lingtai-kernel"
+            kernel_i18n = kernel_repo / "src" / "lingtai_kernel" / "i18n"
+            for lang in ("en", "zh", "wen"):
+                write_json(kernel_i18n / f"{lang}.json", {"intrinsic.description": lang})
+
+            result = self.run_script("--kernel-repo", str(kernel_repo))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("src/lingtai/i18n", result.stderr)
+        self.assertIn("--kernel-repo", result.stderr)
+        self.assertIn("LINGTAI_KERNEL_REPO", result.stderr)
+
+    def test_nonexistent_kernel_repo_fails_with_override_hint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing-kernel"
+            result = self.run_script("--kernel-repo", str(missing))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn(str(missing.resolve()), result.stderr)
+        self.assertIn("--kernel-repo", result.stderr)
+        self.assertIn("LINGTAI_KERNEL_REPO", result.stderr)
+
+    def test_env_var_works_and_cli_arg_takes_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env_repo = create_kernel_repo(Path(tmp) / "env-kernel", "env")
+            cli_repo = create_kernel_repo(Path(tmp) / "cli-kernel", "cli")
+
+            env_result = self.run_script(
+                env_updates={"LINGTAI_KERNEL_REPO": str(env_repo)}
+            )
+            cli_result = self.run_script(
+                "--kernel-repo",
+                str(cli_repo),
+                env_updates={"LINGTAI_KERNEL_REPO": str(env_repo)},
+            )
+
+        self.assertEqual(env_result.returncode, 0, env_result.stderr)
+        self.assertIn("English capability env", env_result.stdout)
+        self.assertNotIn("English capability cli", env_result.stdout)
+        self.assertEqual(cli_result.returncode, 0, cli_result.stderr)
+        self.assertIn("English capability cli", cli_result.stdout)
+        self.assertNotIn("English capability env", cli_result.stdout)
+
+    def test_missing_locale_file_fails_and_names_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kernel_repo = create_kernel_repo(Path(tmp) / "lingtai-kernel")
+            missing = kernel_repo / "src" / "lingtai" / "i18n" / "zh.json"
+            missing.unlink()
+
+            result = self.run_script("--kernel-repo", str(kernel_repo))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn(str(missing.resolve()), result.stderr)
+
+    def test_non_description_keys_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kernel_repo = create_kernel_repo(Path(tmp) / "lingtai-kernel", "visible")
+
+            result = self.run_script("--kernel-repo", str(kernel_repo))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("English capability visible", result.stdout)
+        self.assertNotIn("ignored capability visible", result.stdout)
+        self.assertNotIn("ignored kernel visible", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #571

## Summary

`dump_tool_descriptions.py` still looked for capability descriptions under this repo's old Python path (`src/lingtai/i18n`). After the Python split, those files live in the sibling `lingtai-kernel` checkout, so the script silently emitted only the kernel-intrinsics section while exiting successfully.

This PR updates the script to:

- read both intrinsic and capability i18n JSON from one `lingtai-kernel` checkout;
- support `--kernel-repo PATH`, `LINGTAI_KERNEL_REPO`, and the existing sibling-checkout layout as the default;
- fail before printing any markdown if the kernel checkout, required i18n directories, required locale files, or required sections are missing/empty;
- preserve the existing markdown shape and the em-dash placeholder for individual missing translations;
- add stdlib-only tests with synthetic checkouts so coverage does not depend on a developer's local repo layout.

## Non-goals

- Does not modify `lingtai-kernel`.
- Does not vendor or copy i18n JSON.
- Does not regenerate `docs/tool-descriptions.md`; this PR fixes the generator path/failure behavior only.
- Does not add dependencies or CI wiring.

## Validation

- `python3 -m py_compile scripts/dump_tool_descriptions.py scripts/test_dump_tool_descriptions.py` — passed
- `python3 scripts/test_dump_tool_descriptions.py` — 6 tests passed
- `python3 scripts/dump_tool_descriptions.py --kernel-repo <lingtai-kernel checkout>` — passed; output included both `## Kernel Intrinsics` and `## Capabilities`, with spot-checked tools `read`, `write`, `edit`, `glob`, `grep`, `bash`, `daemon`, and `skills`
- Absolute-path/CWD smoke from outside the repo — passed
- Missing-kernel failure smoke — nonzero exit, zero-byte stdout, actionable stderr
- `git diff --check canonical/main...HEAD` — passed

Independent Codex, Claude Code, and GLM reviews found no blockers and marked the change public-PR-ready. The only noted nits are optional future hardening: cleaner malformed-JSON errors and an override hint on missing-locale-file errors.