### PR TITLE
Sync init example with template

### DIFF
--- a/examples/init.jsonc
+++ b/examples/init.jsonc
@@ -29,13 +29,11 @@
     // LLM configuration
     // -------------------------------------------------------
     "llm": {
-      // Provider: "minimax", "zhipu", "anthropic", "openai", "gemini",
+      // Provider: "minimax", "anthropic", "openai", "gemini", "openrouter",
       //           "deepseek", "grok", "qwen", "glm", "kimi" (OpenAI-compatible via custom adapter),
       //           or "custom" (generic — set api_compat + base_url for any OpenAI/Anthropic/Gemini-compatible API).
-      //
-      // "zhipu" uses GLM Coding Plan (subscription-based, OpenAI-compatible).
-      //   China endpoint:  https://open.bigmodel.cn/api/coding/paas/v4
-      //   Intl endpoint:   https://api.z.ai/api/coding/paas/v4
+      // "openrouter" is first-class (base_url fixed to https://openrouter.ai/api/v1,
+      // reasoning text suppressed by default since context.md would strip it anyway).
       "provider": "minimax",
 
       // Model name as recognized by the provider's API.
@@ -58,85 +56,53 @@
     // -------------------------------------------------------
     // Capabilities — the agent's tool surface
     // -------------------------------------------------------
-    // Each key is a capability name. Value is {} for defaults
-    // or a dict of kwargs passed to the capability's setup().
+    // The kernel boots the `lingtai.core.*` floor by default on every
+    // agent: knowledge, skills, bash, avatar, daemon, mcp, read, write,
+    // edit, glob, grep — plus the always-on intrinsics psyche and email.
+    // You do NOT need to list those here unless you want to OVERRIDE
+    // their default kwargs (e.g. give `bash` a deny-list policy file
+    // instead of the default yolo mode).
     //
-    // "file" is a group shorthand that expands to:
-    //   read, write, edit, glob, grep
+    // Top-level "disable" (sibling of "capabilities") opts a capability
+    // out entirely: e.g. "disable": ["avatar"].
+    //
+    // Entries below are either:
+    //   1. Overrides for default-on capabilities (bash, skills here).
+    //   2. Opt-in capabilities not in the default set (vision, web_search).
     // -------------------------------------------------------
     "capabilities": {
-      // --- File I/O (read, write, edit, glob, grep) ---
-      // Lets the agent read/write/edit files and search by pattern.
-      "file": {},
-
-      // --- Shell access ---
-      // policy_file: path to JSON deny-list (see bash_policy.json).
-      // Alternative: { "yolo": true } to allow ALL commands (dangerous!).
+      // --- Shell access (override) ---
+      // Kernel default is { "yolo": true } (no deny-list). The TUI ships
+      // a deny-list at bash_policy.json so agents started via lingtai-tui
+      // get the sandboxed surface by default.
       "bash": { "policy_file": "bash_policy.json" },
 
-      // --- Identity & pad (upgrades eigen intrinsic) ---
-      // Evolving character, knowledge codex integration,
-      // pad.edit with file imports. Includes molt (context compaction).
-      "psyche": {},
+      // --- Skills catalog (override) ---
+      // `skills` is default-on; this entry adds extra search paths to the
+      // prompt catalog. Defaults overlaid:
+      //   ../.library_shared       — network-shared skill shelf
+      //   ~/.lingtai-tui/utilities — TUI-shipped utility skills
+      // Edit and call system.refresh to apply. init.json is ground truth.
+      "skills": { "paths": ["../.library_shared", "~/.lingtai-tui/utilities"] },
 
-      // --- Knowledge codex ---
-      // Persistent knowledge store. Works with psyche for
-      // importing codex entries into working pad.
-      "codex": {},
-
-      // --- Email (upgrades mail intrinsic) ---
-      // Filesystem-based mailbox with reply, CC/BCC, contacts,
-      // archive, delayed send, scheduled recurring sends.
-      // Used for inter-agent communication.
-      "email": {},
-
-      // --- Avatar (分身) ---
-      // Spawn independent child agents as separate processes.
-      // Each avatar gets its own working directory and LLM session.
-      // Survives parent death.
-      "avatar": {},
-
-      // --- Daemon (神識) ---
-      // Ephemeral sub-agent sessions running in parallel threads.
-      // Override kernel defaults by passing keys, e.g.
-      //   {"max_emanations": N, "max_turns": N, "timeout": N}.
-      "daemon": {},
-
-      // --- Vision (image understanding) ---
+      // --- Vision (opt-in) ---
       // Providers: "minimax", "anthropic", "openai", "gemini", "local" (no API key).
       "vision": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
 
-      // --- Web search ---
+      // --- Web search (opt-in) ---
       // Providers: "minimax", "anthropic", "openai", "gemini", "duckduckgo" (no API key).
-      "web_search": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
+      "web_search": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" }
 
-      // --- Web page reader ---
-      // Fetches and extracts readable content from URLs using trafilatura (local, no API key).
-      "web_read": {},
-
-      // --- Text-to-speech ---
-      // Providers: "minimax", "gemini".
-      "talk": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
-
-      // --- Music generation ---
-      // Providers: "minimax".
-      "compose": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
-
-      // --- Image generation ---
-      // Providers: "minimax", "gemini".
-      "draw": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
-
-      // --- Audio transcription ---
-      // Providers: "whisper" (local, no API key), "gemini".
-      "listen": { "provider": "whisper" }
+      // --- Removed capabilities (for reference) ---
+      // "web_read"        — folded into the `web-browsing` skill.
+      // "compose"/"video"/"draw"/"talk" — use the `media-creation` skill + an MCP server.
+      // "listen"          — use the `listen` skill (faster-whisper + librosa).
     },
 
     // -------------------------------------------------------
-    // Soul — the agent's subconscious
-    // -------------------------------------------------------
-    // delay: seconds between soul ticks (subconscious reflection).
-    // Higher = less frequent self-reflection, lower resource usage.
-    "soul": { "delay": 120 },
+    // Soul flow is opt-in via LINGTAI_SOUL_FLOW_ENABLED (for example, through /setup).
+    // soul.delay is only the cadence after opt-in; omit it to inherit the kernel default.
+    // Add "soul": { "delay": <seconds> } only when overriding cadence.
 
     // -------------------------------------------------------
     // Lifecycle limits
@@ -151,6 +117,47 @@
     // Safety limit — agent sleeps once the budget is exhausted.
     "max_turns": 500,
 
+    // Max LLM API requests per minute, gated at the adapter layer.
+    // Shared across all agents in the same TUI process that use the same
+    // (provider, base_url) — so a network of N agents cooperatively shares
+    // this cap instead of each hitting the provider independently. Set to
+    // 0 to disable gating. Default 60 is conservative; bump for paid
+    // high-tier providers, lower for free tiers.
+    "max_rpm": 60,
+
+    // Whether to serialize chat history into system/context.md mid-session.
+    // When true (default), every Nth idle flush rebuilds context.md and
+    // nukes the live wire chat — the serialized replay becomes the agent's
+    // memory of prior turns. When false, history stays on the wire until
+    // molt.
+    // The serializer strips inline <think>/<thought>/<thinking> reasoning
+    // tags emitted by OpenAI-compat providers, so serialization is safe
+    // regardless of adapter. Set to false only if you want wire-only
+    // history (e.g. to maximize the cacheable growing-prefix shape, trading
+    // off restart durability since context.md won't survive a crash).
+    "context_serialization_enabled": true,
+
+    // When context_serialization_enabled is true, number of idle flushes
+    // between context.md rebuild+nuke pairs. Each idle always appends new
+    // turns to chat_history.jsonl (cheap); only every Nth idle rebuilds
+    // context.md and wipes the live chat. Larger N = wire chat carries
+    // the tail across more idles, keeping Batch 3 of the system prompt
+    // byte-stable longer (higher prompt-cache hit rate) at the cost of a
+    // slightly larger wire chat between rebuilds. Default 3.
+    "context_rebuild_every_n_idles": 3,
+
+    // -------------------------------------------------------
+    // Pseudo-agent outbox subscriptions
+    // -------------------------------------------------------
+    // Paths (relative to this agent's working directory) of pseudo-agent
+    // folders whose outbox this agent polls. Pseudo-agents are mailbox-only
+    // entities — they have .agent.json but no running process (admin: null),
+    // so mail "from" them is written into their own outbox for subscribed
+    // real agents to pick up. The default polls the human folder so a
+    // human-typed message delivered via the TUI reaches the orchestrator.
+    // Polling is mechanical — the agent's LLM never sees this list.
+    "pseudo_agent_subscriptions": ["../human"],
+
     // -------------------------------------------------------
     // Admin privileges
     // -------------------------------------------------------
@@ -164,17 +171,42 @@
   },
 
   // =============================================================
-  // Addons — external service integrations
+  // Addons — curated MCP server integrations
   // =============================================================
-  // Addons connect the agent to external services (IMAP email, Telegram).
-  // Each addon requires an explicit declaration pointing to a config file.
-  // The config file holds credentials (via *_env references to .env)
-  // and connection details. See examples/imap.jsonc and examples/telegram.jsonc.
+  // As of v0.7.3, addons are MCP servers that ship as separate PyPI
+  // packages (lingtai-imap, lingtai-telegram, lingtai-feishu, lingtai-wechat),
+  // installed alongside the kernel by `pip install lingtai`. The TUI
+  // wires them up in two halves:
   //
-  //   "addons": {
-  //     "imap": { "config": "~/.lingtai/.addons/imap/gmail/config.json" },
-  //     "telegram": { "config": "~/.lingtai/.addons/telegram/mybot/config.json" }
+  // 1. The `addons:` list below — names of curated MCPs the agent
+  //    should "register" on boot. The kernel's `mcp` capability looks
+  //    each name up in its catalog and decompresses the record into
+  //    <agent>/mcp_registry.jsonl (idempotent, append-only).
+  //
+  // 2. The `mcp:` activation map below — for each registered MCP,
+  //    the subprocess spec (which Python interpreter, which module,
+  //    which env vars). Activation is gated by registry membership,
+  //    so a name in `mcp:` without a matching `addons:` entry would
+  //    be skipped with a warning.
+  //
+  // Default for new agents (auto-populated by the TUI wizard):
+  //
+  //   "addons": ["imap", "telegram", "feishu", "wechat"],
+  //   "mcp": {
+  //     "imap":     { "type": "stdio", "command": "<venv>/bin/python",
+  //                   "args": ["-m", "lingtai_imap"],
+  //                   "env": { "LINGTAI_IMAP_CONFIG": ".secrets/imap.json" } },
+  //     "telegram": { ... }, "feishu": { ... }, "wechat": { ... }
   //   }
+  //
+  // The `command` always points at the local venv Python where pip
+  // installed the MCP packages — no remote fetch at runtime.
+  //
+  // Per-MCP secrets live in <agent>/.secrets/<name>.json — plaintext JSON
+  // (no *_env indirection in the new MCP shape). Each MCP's README
+  // documents the schema; setup skills are available via the agent's
+  // library tool. Canonical contract spec: lingtai-kernel-anatomy skill,
+  // reference/mcp-protocol.md.
 
   // =============================================================
   // Agent personality & initial state
@@ -185,23 +217,15 @@
   //   "covenant_file": "covenant.md"                 ← reads from file
   // If both are present, the file takes precedence.
 
-  // NOTE: `principle` is a legacy field — the kernel migrates it but no
-  // longer honors an inline value here. The guiding principle now lives in
-  // system/principle.md (resolved via principle_file). Don't add it back.
+  // Principle is kernel-owned prompt content and is not configured here.
 
   // Covenant — protected prompt section the agent cannot modify.
   // Core behavioral rules that persist across molts.
   "covenant": "You are a helpful assistant.",
   // Or use a file: "covenant_file": "covenant.md"
 
-  // Procedures — operational knowledge (e.g. molt checklist).
-  // Protected prompt section, persists as system/procedures.md.
-  // Or use a file: "procedures_file": "procedures.md"
-
-  // Brief — externally-maintained context written by the secretary agent.
-  // Protected prompt section, re-read from disk on /refresh and /cpr.
-  // Not inherited by avatars.
-  // Or use a file: "brief_file": "~/.lingtai-tui/brief/projects/<hash>/brief.md"
+  // Procedures prompt content is managed by the TUI as system/procedures.md;
+  // init.json procedures/procedures_file overrides are no longer honored by the kernel.
 
   // Initial pad — pre-loaded into system/pad.md.
   // The agent can edit this via the eigen intrinsic.
@@ -211,6 +235,6 @@
   // Character / 灵台 is NOT seeded here. It is durable state the agent owns
   // and authors for itself after creation — managed via system/lingtai.md
   // (psyche), not written into init.json by the TUI. There is no seed field
-  // for it in this example; omitting it lets the agent start with an empty
+  // for it in this file; omitting it lets the agent start with an empty
   // character and write its own.
 }

--- a/tui/internal/preset/examples_sync_test.go
+++ b/tui/internal/preset/examples_sync_test.go
@@ -1,0 +1,84 @@
+package preset
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestExamplesInitMatchesTemplate(t *testing.T) {
+	template := readInitTemplate(t)
+	example := readRepoInitExample(t)
+
+	if !bytes.Equal(template, example) {
+		t.Fatal("examples/init.jsonc has drifted from tui/internal/preset/templates/init.jsonc; run: cp tui/internal/preset/templates/init.jsonc examples/init.jsonc")
+	}
+}
+
+func TestInitTemplateHasNoRetiredOrSeedEntries(t *testing.T) {
+	files := map[string][]byte{
+		"tui/internal/preset/templates/init.jsonc": readInitTemplate(t),
+		"examples/init.jsonc":                      readRepoInitExample(t),
+	}
+	forbiddenKeys := []string{
+		"brief",
+		"brief_file",
+		"procedures",
+		"procedures_file",
+		"principle",
+		"principle_file",
+		"substrate",
+		"substrate_file",
+		"prompt",
+		"prompt_file",
+		"lingtai",
+		"lingtai_file",
+		"stamina",
+		"molt_pressure",
+		"molt_prompt",
+		"psyche",
+		"email",
+		"codex",
+		"web_read",
+		"talk",
+		"compose",
+		"draw",
+		"listen",
+	}
+
+	for name, data := range files {
+		for _, key := range forbiddenKeys {
+			assertNoJSONCKeyEntry(t, name, string(data), key)
+		}
+	}
+}
+
+func assertNoJSONCKeyEntry(t *testing.T, name, text, key string) {
+	t.Helper()
+	keyEntry := regexp.MustCompile(`"` + regexp.QuoteMeta(key) + `"\s*:`)
+	for lineNum, line := range strings.Split(text, "\n") {
+		if keyEntry.MatchString(line) {
+			t.Errorf("%s:%d still contains forbidden init key entry %q", name, lineNum+1, key)
+		}
+	}
+}
+
+func readInitTemplate(t *testing.T) []byte {
+	t.Helper()
+	data, err := templatesFS.ReadFile("templates/init.jsonc")
+	if err != nil {
+		t.Fatalf("read embedded init template: %v", err)
+	}
+	return data
+}
+
+func readRepoInitExample(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile("../../../examples/init.jsonc")
+	if err != nil {
+		t.Fatalf("read examples/init.jsonc: %v", err)
+	}
+	return data
+}

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -217,23 +217,15 @@
   //   "covenant_file": "covenant.md"                 ← reads from file
   // If both are present, the file takes precedence.
 
-  // NOTE: `principle` is a legacy field — the kernel migrates it but no
-  // longer honors an inline value here. The guiding principle now lives in
-  // system/principle.md (resolved via principle_file). Don't add it back.
+  // Principle is kernel-owned prompt content and is not configured here.
 
   // Covenant — protected prompt section the agent cannot modify.
   // Core behavioral rules that persist across molts.
   "covenant": "You are a helpful assistant.",
   // Or use a file: "covenant_file": "covenant.md"
 
-  // Procedures — operational knowledge (e.g. molt checklist).
-  // Protected prompt section, persists as system/procedures.md.
-  // Or use a file: "procedures_file": "procedures.md"
-
-  // Brief — externally-maintained context written by the secretary agent.
-  // Protected prompt section, re-read from disk on /refresh and /cpr.
-  // Not inherited by avatars.
-  // Or use a file: "brief_file": "~/.lingtai-tui/brief/projects/<hash>/brief.md"
+  // Procedures prompt content is managed by the TUI as system/procedures.md;
+  // init.json procedures/procedures_file overrides are no longer honored by the kernel.
 
   // Initial pad — pre-loaded into system/pad.md.
   // The agent can edit this via the eigen intrinsic.
@@ -243,6 +235,6 @@
   // Character / 灵台 is NOT seeded here. It is durable state the agent owns
   // and authors for itself after creation — managed via system/lingtai.md
   // (psyche), not written into init.json by the TUI. There is no seed field
-  // for it in this template; omitting it lets the agent start with an empty
+  // for it in this file; omitting it lets the agent start with an empty
   // character and write its own.
 }


### PR DESCRIPTION
## Summary

Fixes #569 by making the shipped `examples/init.jsonc` a byte-for-byte copy of the current TUI init template and by correcting the stale prompt-section comments in that template.

What changed:

- Updates the init template comments so they no longer imply `principle_file`, `brief` / `brief_file`, or `procedures` / `procedures_file` are live init.json knobs.
- Replaces `examples/init.jsonc` with the corrected modern template so the public example no longer drifts from the first-run template.
- Adds focused preset tests that enforce:
  - `examples/init.jsonc` stays byte-identical to `tui/internal/preset/templates/init.jsonc`.
  - retired/seed/default-on capability names do not reappear as JSONC key entries in either file.

## Notes / non-goals

- This PR intentionally keeps the scope to the init template, the public example, and tests.
- It does not rewrite addon example files or addon templates.
- It does not change generator behavior for legacy `principle_file` / `procedures_file` emission; that cleanup remains a follow-up and is not needed for this docs/example fix.
- The new sync test intentionally makes `examples/init.jsonc` and the TUI template one shared artifact. Future intentional divergence should update or loosen that invariant deliberately.

## Validation

- `git diff --check canonical/main...HEAD`
- `cmp -s tui/internal/preset/templates/init.jsonc examples/init.jsonc`
- retired-key-entry scan over both init JSONC files
- `cd tui && go test ./internal/preset -run 'TestExamplesInitMatchesTemplate|TestInitTemplateHasNoRetiredOrSeedEntries' -count=1`
- `cd tui && go test ./internal/preset -count=1`
- `cd tui && go vet ./internal/preset`
- `cd tui && go build ./...`

Independent Codex, Claude Code, and GLM reviews found no blockers. Claude/GLM noted only PR-body caveats: the enforced byte-for-byte invariant, the intentionally broad retired-key guard, and the unrelated known `internal/tui TestPortalURLTimeoutKillsChild` flake observed during a full-suite attempt that passed on direct rerun.
