### PR TITLE
Harden i18n locale fallback handling

### DIFF
--- a/portal/i18n/i18n.go
+++ b/portal/i18n/i18n.go
@@ -11,36 +11,61 @@ import (
 var localeFS embed.FS
 
 var (
-	mu      sync.RWMutex
-	lang    = "en"
-	strings map[string]string
+	mu             sync.RWMutex
+	lang           = "en"
+	activeStrings  map[string]string
+	englishStrings map[string]string
 )
 
-func init() { load("en") }
+var supportedLocales = map[string]bool{
+	"en":  true,
+	"zh":  true,
+	"wen": true,
+}
 
-func SetLang(l string) {
+func init() {
+	m, err := load("en")
+	if err != nil {
+		panic(err)
+	}
+	activeStrings = m
+	englishStrings = m
+}
+
+func SetLang(l string) error {
+	m, err := load(l)
+	if err != nil {
+		return err
+	}
 	mu.Lock()
 	defer mu.Unlock()
 	lang = l
-	load(l)
+	activeStrings = m
+	return nil
 }
 
-func load(l string) {
+func load(l string) (map[string]string, error) {
+	if !supportedLocales[l] {
+		return nil, fmt.Errorf("unsupported language %q", l)
+	}
 	data, err := localeFS.ReadFile(l + ".json")
 	if err != nil {
-		return
+		return nil, fmt.Errorf("load language %q: %w", l, err)
 	}
 	var m map[string]string
 	if err := json.Unmarshal(data, &m); err != nil {
-		return
+		return nil, fmt.Errorf("parse language %q: %w", l, err)
 	}
-	strings = m
+	return m, nil
 }
 
 func T(key string) string {
 	mu.RLock()
 	defer mu.RUnlock()
-	if s, ok := strings[key]; ok {
+	if s, ok := activeStrings[key]; ok {
+		return s
+	}
+	if s, ok := englishStrings[key]; ok {
 		return s
 	}
 	return key

--- a/portal/i18n/i18n_test.go
+++ b/portal/i18n/i18n_test.go
@@ -1,0 +1,142 @@
+package i18n
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func loadLocaleForTest(t *testing.T, locale string) map[string]string {
+	t.Helper()
+	data, err := localeFS.ReadFile(locale + ".json")
+	if err != nil {
+		t.Fatalf("read %s locale: %v", locale, err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse %s locale: %v", locale, err)
+	}
+	return m
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	cp := make(map[string]string, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
+func withActiveStringsForTest(t *testing.T, m map[string]string) {
+	t.Helper()
+	mu.Lock()
+	old := activeStrings
+	activeStrings = m
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		activeStrings = old
+		mu.Unlock()
+	})
+}
+
+func TestSetLang_SwitchesLanguage(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	if got := T("settings.language"); got != "语言" {
+		t.Fatalf("after SetLang(\"zh\"), T(settings.language) = %q, want %q", got, "语言")
+	}
+}
+
+func TestSetLang_InvalidLanguageLeavesStateUnchanged(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	beforeLang := Lang()
+	beforeText := T("settings.language")
+
+	if err := SetLang("fr"); err == nil {
+		t.Fatal("SetLang(\"fr\") returned nil error")
+	}
+	if got := Lang(); got != beforeLang {
+		t.Fatalf("Lang() after invalid SetLang = %q, want %q", got, beforeLang)
+	}
+	if got := T("settings.language"); got != beforeText {
+		t.Fatalf("T(settings.language) after invalid SetLang = %q, want %q", got, beforeText)
+	}
+}
+
+func TestSetLang_ValidSwitchWorksAfterInvalidLanguage(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	if err := SetLang("fr"); err == nil {
+		t.Fatal("SetLang(\"fr\") returned nil error")
+	}
+	if err := SetLang("wen"); err != nil {
+		t.Fatalf("SetLang(\"wen\") after invalid language returned error: %v", err)
+	}
+	if got := T("settings.language"); got != "言" {
+		t.Fatalf("T(settings.language) after SetLang(\"wen\") = %q, want %q", got, "言")
+	}
+}
+
+func TestT_FallsBackToEnglishWhenActiveLocaleMissesKey(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	key := "settings.language"
+	zh := loadLocaleForTest(t, "zh")
+	gap := copyStringMap(zh)
+	delete(gap, key)
+	withActiveStringsForTest(t, gap)
+
+	if got, want := T(key), "Language"; got != want {
+		t.Fatalf("T(%q) = %q, want English fallback %q", key, got, want)
+	}
+}
+
+func TestT_MissingEverywhereReturnsKey(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	key := "__i18n_missing_everywhere__"
+	if got := T(key); got != key {
+		t.Fatalf("T(%q) = %q, want raw key", key, got)
+	}
+}
+
+func TestLocaleJSONKeySetsAreComplete(t *testing.T) {
+	en := loadLocaleForTest(t, "en")
+	for _, locale := range []string{"en", "zh", "wen"} {
+		m := loadLocaleForTest(t, locale)
+		for key, value := range m {
+			if value == "" {
+				t.Fatalf("%s locale has empty value for key %q", locale, key)
+			}
+		}
+		if len(m) != len(en) {
+			t.Fatalf("%s locale has %d keys, want %d", locale, len(m), len(en))
+		}
+		for key := range en {
+			if _, ok := m[key]; !ok {
+				t.Fatalf("%s locale missing key %q", locale, key)
+			}
+		}
+		for key := range m {
+			if _, ok := en[key]; !ok {
+				t.Fatalf("%s locale has extra key %q", locale, key)
+			}
+		}
+	}
+}

--- a/portal/main.go
+++ b/portal/main.go
@@ -42,6 +42,11 @@ func main() {
 	flag.StringVar(&lang, "lang", "en", "Language (en, zh, wen)")
 	flag.Parse()
 
+	if err := i18n.SetLang(lang); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid --lang %q: %v\n", lang, err)
+		os.Exit(1)
+	}
+
 	// Resolve project directory
 	if dir == "" {
 		dir, _ = os.Getwd()
@@ -53,9 +58,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "No .lingtai/ found in %s\n", dir)
 		os.Exit(1)
 	}
-
-	// Set language
-	i18n.SetLang(lang)
 
 	// Run migrations
 	if err := migrate.Run(lingtaiDir); err != nil {

--- a/tui/i18n/i18n.go
+++ b/tui/i18n/i18n.go
@@ -11,36 +11,89 @@ import (
 var localeFS embed.FS
 
 var (
-	mu      sync.RWMutex
-	lang    = "en"
-	strings map[string]string
+	mu             sync.RWMutex
+	lang           = "en"
+	activeStrings  map[string]string
+	englishStrings map[string]string
+
+	cacheMu sync.RWMutex
+	cache   = map[string]map[string]string{}
 )
 
-func init() { load("en") }
+var supportedLocales = map[string]bool{
+	"en":  true,
+	"zh":  true,
+	"wen": true,
+}
 
-func SetLang(l string) {
+func init() {
+	m, err := load("en")
+	if err != nil {
+		panic(err)
+	}
+	activeStrings = m
+	englishStrings = m
+	cache["en"] = m
+}
+
+func SetLang(l string) error {
+	m, err := cachedLocale(l)
+	if err != nil {
+		return err
+	}
 	mu.Lock()
 	defer mu.Unlock()
 	lang = l
-	load(l)
+	activeStrings = m
+	return nil
 }
 
-func load(l string) {
+func cachedLocale(l string) (map[string]string, error) {
+	if !supportedLocales[l] {
+		return nil, fmt.Errorf("unsupported language %q", l)
+	}
+	cacheMu.RLock()
+	m, ok := cache[l]
+	cacheMu.RUnlock()
+	if ok {
+		return m, nil
+	}
+
+	m, err := load(l)
+	if err != nil {
+		return nil, err
+	}
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if cached, ok := cache[l]; ok {
+		return cached, nil
+	}
+	cache[l] = m
+	return m, nil
+}
+
+func load(l string) (map[string]string, error) {
+	if !supportedLocales[l] {
+		return nil, fmt.Errorf("unsupported language %q", l)
+	}
 	data, err := localeFS.ReadFile(l + ".json")
 	if err != nil {
-		return
+		return nil, fmt.Errorf("load language %q: %w", l, err)
 	}
 	var m map[string]string
 	if err := json.Unmarshal(data, &m); err != nil {
-		return
+		return nil, fmt.Errorf("parse language %q: %w", l, err)
 	}
-	strings = m
+	return m, nil
 }
 
 func T(key string) string {
 	mu.RLock()
 	defer mu.RUnlock()
-	if s, ok := strings[key]; ok {
+	if s, ok := activeStrings[key]; ok {
+		return s
+	}
+	if s, ok := englishStrings[key]; ok {
 		return s
 	}
 	return key
@@ -53,15 +106,14 @@ func TF(key string, args ...any) string {
 // TIn looks up a key in a specific locale without changing global state.
 // Falls back to the current TUI locale if the requested locale is unavailable.
 func TIn(locale, key string) string {
-	data, err := localeFS.ReadFile(locale + ".json")
+	m, err := cachedLocale(locale)
 	if err != nil {
 		return T(key)
 	}
-	var m map[string]string
-	if err := json.Unmarshal(data, &m); err != nil {
-		return T(key)
-	}
 	if s, ok := m[key]; ok {
+		return s
+	}
+	if s, ok := englishStrings[key]; ok {
 		return s
 	}
 	return key

--- a/tui/i18n/i18n_test.go
+++ b/tui/i18n/i18n_test.go
@@ -1,9 +1,12 @@
 package i18n
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
-// contains is a local substring check; the package already declares a
-// package-level `strings` var, so we cannot import the strings package here.
+// contains is a local substring check.
 func contains(haystack, needle string) bool {
 	if len(needle) > len(haystack) {
 		return false
@@ -14,6 +17,70 @@ func contains(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+func loadLocaleForTest(t *testing.T, locale string) map[string]string {
+	t.Helper()
+	data, err := localeFS.ReadFile(locale + ".json")
+	if err != nil {
+		t.Fatalf("read %s locale: %v", locale, err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse %s locale: %v", locale, err)
+	}
+	return m
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	cp := make(map[string]string, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
+func withActiveStringsForTest(t *testing.T, m map[string]string) {
+	t.Helper()
+	mu.Lock()
+	old := activeStrings
+	activeStrings = m
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		activeStrings = old
+		mu.Unlock()
+	})
+}
+
+func withCachedLocaleForTest(t *testing.T, locale string, m map[string]string) {
+	t.Helper()
+	cacheMu.Lock()
+	old, hadOld := cache[locale]
+	cache[locale] = m
+	cacheMu.Unlock()
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		if hadOld {
+			cache[locale] = old
+		} else {
+			delete(cache, locale)
+		}
+		cacheMu.Unlock()
+	})
+}
+
+func resetCacheForTest(t *testing.T) {
+	t.Helper()
+	cacheMu.Lock()
+	old := cache
+	cache = map[string]map[string]string{"en": englishStrings}
+	cacheMu.Unlock()
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		cache = old
+		cacheMu.Unlock()
+	})
 }
 
 func hasCJK(s string) bool {
@@ -111,14 +178,80 @@ func TestT_UnknownKeyReturnsKey(t *testing.T) {
 	}
 }
 
+func TestT_FallsBackToEnglishWhenActiveLocaleMissesKey(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	key := "settings.language"
+	zh := loadLocaleForTest(t, "zh")
+	gap := copyStringMap(zh)
+	delete(gap, key)
+	withActiveStringsForTest(t, gap)
+
+	if got, want := T(key), "Language"; got != want {
+		t.Fatalf("T(%q) = %q, want English fallback %q", key, got, want)
+	}
+}
+
+func TestT_MissingEverywhereReturnsKey(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	key := "__i18n_missing_everywhere__"
+	if got := T(key); got != key {
+		t.Fatalf("T(%q) = %q, want raw key", key, got)
+	}
+}
+
 func TestSetLang_SwitchesLanguage(t *testing.T) {
 	SetLang("zh")
-	got := T("app.title")
-	if got != "灵台" {
-		t.Errorf("after SetLang(\"zh\"), T(\"app.title\") = %q, want %q", got, "灵台")
+	got := T("settings.language")
+	if got != "语言" {
+		t.Errorf("after SetLang(\"zh\"), T(\"settings.language\") = %q, want %q", got, "语言")
 	}
 	// Restore
 	SetLang("en")
+}
+
+func TestSetLang_InvalidLanguageLeavesStateUnchanged(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	beforeLang := Lang()
+	beforeText := T("mail.initial_loading")
+
+	if err := SetLang("fr"); err == nil {
+		t.Fatal("SetLang(\"fr\") returned nil error")
+	}
+	if got := Lang(); got != beforeLang {
+		t.Fatalf("Lang() after invalid SetLang = %q, want %q", got, beforeLang)
+	}
+	if got := T("mail.initial_loading"); got != beforeText {
+		t.Fatalf("T(mail.initial_loading) after invalid SetLang = %q, want %q", got, beforeText)
+	}
+}
+
+func TestSetLang_ValidSwitchWorksAfterInvalidLanguage(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	if err := SetLang("fr"); err == nil {
+		t.Fatal("SetLang(\"fr\") returned nil error")
+	}
+	if err := SetLang("wen"); err != nil {
+		t.Fatalf("SetLang(\"wen\") after invalid language returned error: %v", err)
+	}
+	if got := T("settings.language"); got != "言" {
+		t.Fatalf("T(settings.language) after SetLang(\"wen\") = %q, want %q", got, "言")
+	}
 }
 
 func TestTF_FormatsArgs(t *testing.T) {
@@ -140,4 +273,91 @@ func TestLang_ReturnsCurrentLanguage(t *testing.T) {
 		t.Errorf("Lang() = %q, want %q", Lang(), "zh")
 	}
 	SetLang("en")
+}
+
+func TestLocaleJSONKeySetsAreComplete(t *testing.T) {
+	en := loadLocaleForTest(t, "en")
+	for _, locale := range []string{"en", "zh", "wen"} {
+		m := loadLocaleForTest(t, locale)
+		for key, value := range m {
+			if value == "" {
+				t.Fatalf("%s locale has empty value for key %q", locale, key)
+			}
+		}
+		if len(m) != len(en) {
+			t.Fatalf("%s locale has %d keys, want %d", locale, len(m), len(en))
+		}
+		for key := range en {
+			if _, ok := m[key]; !ok {
+				t.Fatalf("%s locale missing key %q", locale, key)
+			}
+		}
+		for key := range m {
+			if _, ok := en[key]; !ok {
+				t.Fatalf("%s locale has extra key %q", locale, key)
+			}
+		}
+	}
+}
+
+func TestTInUsesRequestedLocale(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("en"); err != nil {
+		t.Fatalf("SetLang(\"en\") returned error: %v", err)
+	}
+	if got := TIn("zh", "settings.language"); got != "语言" {
+		t.Fatalf("TIn(\"zh\", \"settings.language\") = %q, want %q", got, "语言")
+	}
+}
+
+func TestTInUnknownLocaleFallsBackThroughCurrentLocale(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	if err := SetLang("zh"); err != nil {
+		t.Fatalf("SetLang(\"zh\") returned error: %v", err)
+	}
+	if got := TIn("fr", "settings.language"); got != "语言" {
+		t.Fatalf("TIn unknown locale = %q, want current locale translation", got)
+	}
+}
+
+func TestTInRequestedLocaleMissingKeyFallsBackToEnglish(t *testing.T) {
+	t.Cleanup(func() { SetLang("en") })
+
+	key := "settings.language"
+	zh := loadLocaleForTest(t, "zh")
+	gap := copyStringMap(zh)
+	delete(gap, key)
+	withCachedLocaleForTest(t, "zh", gap)
+
+	if got, want := TIn("zh", key), "Language"; got != want {
+		t.Fatalf("TIn(\"zh\", %q) = %q, want English fallback %q", key, got, want)
+	}
+}
+
+func TestTInCachesLocaleMaps(t *testing.T) {
+	resetCacheForTest(t)
+
+	if got := TIn("zh", "settings.language"); got != "语言" {
+		t.Fatalf("first TIn(\"zh\") = %q, want %q", got, "语言")
+	}
+	cacheMu.RLock()
+	first := cache["zh"]
+	firstPtr := reflect.ValueOf(first).Pointer()
+	cacheMu.RUnlock()
+	if first == nil {
+		t.Fatal("TIn did not populate zh cache")
+	}
+
+	if got := TIn("zh", "common.quit"); got != "退出" {
+		t.Fatalf("second TIn(\"zh\") = %q, want %q", got, "退出")
+	}
+	cacheMu.RLock()
+	second := cache["zh"]
+	secondPtr := reflect.ValueOf(second).Pointer()
+	cacheMu.RUnlock()
+	if firstPtr == 0 || firstPtr != secondPtr {
+		t.Fatalf("zh cache identity changed: first=%d second=%d", firstPtr, secondPtr)
+	}
 }

--- a/tui/main.go
+++ b/tui/main.go
@@ -131,7 +131,10 @@ func main() {
 	// locale rather than the i18n default. tuiCfg is reused below.
 	config.MigrateLegacyLanguage(globalDir)
 	tuiCfg := config.LoadTUIConfig(globalDir)
-	i18n.SetLang(tuiCfg.Language)
+	if err := i18n.SetLang(tuiCfg.Language); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: invalid configured language %q: %v; continuing with %q\n", tuiCfg.Language, err, i18n.Lang())
+		tuiCfg.Language = i18n.Lang()
+	}
 
 	// Test Codex OAuth validity on every launch across ALL stored accounts
 	// (legacy ~/.lingtai-tui/codex-auth.json plus per-account files under


### PR DESCRIPTION
## Summary

Fixes Lingtai-AI/lingtai#567 by making TUI and portal i18n reject unsupported locales without corrupting global language state, and by adding English fallback for missing translations.

The old `SetLang` path set `lang` before attempting to load the locale. If the locale was unsupported or unloadable, `Lang()` could report the bogus code while translations still came from the previous locale. Missing translation keys also skipped English fallback and returned the raw key directly.

## Changes

- Change TUI and portal `SetLang` to return an error for unsupported/unloadable locales and leave the current language/map untouched on failure.
- Add active-locale → English → raw-key fallback in TUI and portal `T`.
- Cache TUI `TIn` locale maps instead of reparsing embedded JSON on every call, with unknown-locale and missing-key fallback behavior.
- Warn and continue for invalid persisted/config-derived TUI language values.
- Fail fast for an explicit invalid portal `--lang` value before portal startup side effects.
- Add focused TUI and portal i18n tests, including invalid locale state preservation, valid switching after failure, English/raw fallback, TUI `TIn` behavior, and shipped-locale key-set completeness.

## Non-goals

- No shared i18n package extraction.
- No portal `TIn`.
- No frontend fallback changes, config migrations, locale JSON content edits, or locale normalization changes.

## Validation

Parent verification:

- `git diff --check canonical/main...HEAD`
- `cd tui && go test ./i18n -count=1`
- `cd portal && go test ./i18n -count=1`
- `cd tui && go build ./...`
- `cd tui && go vet ./...`
- `cd portal/web && npm ci && npm run build`
- `cd portal && go build ./...`
- `cd portal && go vet ./...`
- `cd portal && go test ./... -count=1`
- `cd tui && go test ./i18n -run 'Test(SetLang|T|TIn|Locale)' -count=1`

Independent review validation also ran race-enabled i18n tests and focused overlap checks for adjacent PRs #581/#589. One reviewer hit an unrelated TUI headless test timeout during a broad full-suite run; focused i18n/TUI/portal validation passed, and this branch does not touch the headless/portal-timeout code.

Independent reviews: Codex, Claude Code, and GLM all approved with nonblocking nits and no blockers.
