### PR TITLE
docs: mention install.sh testing alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+> Testing alternative: run the Homebrew-free GitHub Release installer with `curl -fsSL https://lingtai.ai/install.sh | bash`.
+
 > New to LingTai? Start with the [Beginner work manual](docs/beginner-work-manual.zh.md) or the [single-file illustrated HTML guide](docs/beginner-work-manual-stick-figure.zh.html) to learn the workflow step by step.
 
 On first run LingTai creates `.lingtai/`, provisions its own runtime, walks you through model/preset setup, and starts one resident assistant for the project.


### PR DESCRIPTION
## Summary
- Add a README testing alternative line for the Homebrew-free `install.sh` path.
- Keep the existing Homebrew quick-start as the primary path; this only points testers at `curl -fsSL https://lingtai.ai/install.sh | bash`.

## Validation
- `git diff --check`

Taste check: used the installed `lingtai-taste` skill and kept this to the smallest additive README wording change, explicitly positioned as a testing alternative rather than replacing the main install path.