### PR TITLE
Bootstrap uv for installer runtime venv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ DOWNLOAD_BASE="https://github.com/${REPO_SLUG}/releases/download"
 RAW_INSTALL_URL="https://raw.githubusercontent.com/${REPO_SLUG}/main/install.sh"
 GO_DL_BASE="${LINGTAI_GO_DL_BASE:-https://go.dev/dl}"  # official Go toolchain downloads
 NODE_DL_BASE="${LINGTAI_NODE_DL_BASE:-https://nodejs.org/dist}"
+UV_INSTALLER_URL="${LINGTAI_UV_INSTALLER_URL:-https://astral.sh/uv/install.sh}"  # official uv bootstrap installer
 NODE_TOOLCHAIN_VERSION="${LINGTAI_NODE_VERSION:-22.12.0}"
 
 TMPDIR="${TMPDIR:-/tmp}"
@@ -443,6 +444,64 @@ find_uv() {
   return 1
 }
 
+# ensure_uv resolves an executable uv, bootstrapping it if necessary. uv can
+# download its own Python toolchain (uv venv --python 3.13), which is the only
+# reliable way to get Python 3.11+ on distros whose system packages are older
+# (e.g. Ubuntu jammy ships Python 3.10). If uv is already present it is reused;
+# otherwise the official installer is downloaded to a temp file and run with an
+# explicit UV_INSTALL_DIR so the result lands in a known location. On success it
+# echoes the uv path and returns 0; on failure it warns loudly and returns 1
+# without aborting the overall install.
+ensure_uv() {
+  local uv installer rc
+  uv="$(find_uv 2>/dev/null || true)"
+  if [[ -n "$uv" ]]; then
+    echo "$uv"
+    return 0
+  fi
+
+  if ! command -v curl &>/dev/null; then
+    warn "curl is required to bootstrap uv but was not found."
+    return 1
+  fi
+
+  local install_dir="${UV_INSTALL_DIR:-$HOME/.local/bin}"
+  say "Bootstrapping uv (for a self-contained Python runtime) ..."
+  mkdir -p "$install_dir"
+
+  installer="$BUILD_DIR/uv-install.sh"
+  mkdir -p "$BUILD_DIR"
+  # Download to a temp file first so the script is fetched (and can be inspected)
+  # before it is executed, rather than piping an unseen body straight into sh.
+  if ! curl -fsSL --retry 3 --max-time 120 -o "$installer" "$UV_INSTALLER_URL"; then
+    warn "failed to download the uv installer from $UV_INSTALLER_URL"
+    return 1
+  fi
+
+  # UV_INSTALL_DIR pins where the uv binary lands; UV_NO_MODIFY_PATH keeps the
+  # installer from editing shell rc files during a one-shot install.
+  UV_INSTALL_DIR="$install_dir" UV_NO_MODIFY_PATH=1 sh "$installer" >/dev/null 2>&1
+  rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    warn "the uv installer exited with status $rc"
+    return 1
+  fi
+
+  # The freshly-installed uv may not be on PATH yet; find_uv also probes
+  # ~/.local/bin, and we fold in an explicit install_dir check for custom dirs.
+  uv="$(find_uv 2>/dev/null || true)"
+  if [[ -z "$uv" && -x "$install_dir/uv" ]]; then
+    uv="$install_dir/uv"
+  fi
+  if [[ -z "$uv" || ! -x "$uv" ]]; then
+    warn "uv installer ran but no executable uv was found under $install_dir."
+    return 1
+  fi
+  say "Bootstrapped uv at $uv."
+  echo "$uv"
+  return 0
+}
+
 # python_ok reports whether a python3 with venv support and >=3.11 is present.
 python_ok() {
   command -v python3 &>/dev/null || return 1
@@ -451,21 +510,34 @@ python_ok() {
   return 0
 }
 
-# ensure_python makes a usable python3 available. On apt systems it can install
-# python3/python3-venv/python3-pip. uv can bootstrap its own Python, so uv alone
-# is also sufficient.
+# ensure_python makes a usable Python interpreter available for the runtime venv.
+# uv is preferred because it can download its own Python 3.13 toolchain, which is
+# the only reliable path on distros whose packages are too old (Ubuntu jammy ships
+# Python 3.10, so `apt install python3` does NOT yield a usable interpreter here).
+# Order of preference:
+#   1. an existing uv                       -> done (uv downloads Python itself)
+#   2. an already-adequate system python3   -> done
+#   3. bootstrap uv via the official installer (needs curl) -> done
+#   4. apt-install python3/venv/pip and re-check python_ok (for distros where it
+#      actually yields Python 3.11+, or where curl is unavailable for step 3)
 ensure_python() {
-  if [[ -n "$(find_uv)" ]] 2>/dev/null || find_uv >/dev/null 2>&1; then
+  if find_uv >/dev/null 2>&1; then
     return 0  # uv can download Python itself
   fi
   if python_ok; then
     return 0
   fi
+  # Try to bootstrap uv before falling back to system packages: on jammy the apt
+  # python3 is 3.10, so uv is the only way to reach Python 3.11+.
+  if ensure_uv >/dev/null; then
+    return 0
+  fi
   if command -v apt-get &>/dev/null; then
     apt_install "Python 3.11+ with venv/pip" python3 python3-venv python3-pip || return 1
     python_ok && return 0
+    warn "apt-installed python3 is still older than 3.11 (or lacks venv); uv bootstrap is required."
   fi
-  warn "Python 3.11+ (with venv and pip) is required for the runtime venv. Install it with:"
+  warn "Python 3.11+ (via uv or system packages) is required for the runtime venv. Install uv or Python 3.11+ with:"
   suggest_install python3
   return 1
 }

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -82,6 +82,131 @@ assert_eq '\u0001' "$(json_escape $'\001')" "json generic control-byte escaping"
 assert_eq "$tmp/prefix/bin" "$(bin_dir_for_prefix "$tmp/prefix")" "bin dir from prefix"
 assert_eq "$tmp/prefix/bin" "$(bin_dir_for_prefix "$tmp/prefix/")" "bin dir from slash-suffixed prefix"
 
+# --- uv bootstrap: no uv, system python3 too old (jammy scenario) -------------
+# Simulates Ubuntu jammy: python3 exists but reports 3.10 and there is no uv on
+# PATH. ensure_uv must download the official installer (via a fake curl) and run
+# it (a fake installer that drops a uv binary into UV_INSTALL_DIR), and
+# ensure_python must then succeed by resolving the bootstrapped uv.
+(
+  fakebin="$tmp/uv-fakebin"
+  fakehome="$tmp/uv-home"
+  mkdir -p "$fakebin" "$fakehome/.local/bin"
+
+  # Fake python3 reporting 3.10: sys.version_info check in python_ok fails.
+  cat > "$fakebin/python3" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"version_info >= (3, 11)"*) exit 1 ;;  # too old
+  *"import venv"*)             exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/python3"
+
+  # Fake curl: the -o argument names the file the uv installer is written to.
+  # Emit an installer that copies a real uv stub into UV_INSTALL_DIR.
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+out=""
+prev=""
+for a in "$@"; do
+  [[ "$prev" == "-o" ]] && out="$a"
+  prev="$a"
+done
+[[ -n "$out" ]] || { echo "fake curl: no -o target" >&2; exit 1; }
+cat > "$out" <<'INSTALLER'
+#!/usr/bin/env sh
+dir="${UV_INSTALL_DIR:?UV_INSTALL_DIR must be set}"
+mkdir -p "$dir"
+cat > "$dir/uv" <<'UVSTUB'
+#!/usr/bin/env bash
+echo "uv 0.0.0-fake"
+UVSTUB
+chmod +x "$dir/uv"
+INSTALLER
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+
+  # Isolate PATH so no real uv (typically under ~/.local/bin) is reachable; only
+  # the fake python3/curl plus system coreutils are visible.
+  export PATH="$fakebin:/usr/bin:/bin"
+  export HOME="$fakehome"
+  export UV_INSTALL_DIR="$fakehome/.local/bin"
+  BUILD_DIR="$tmp/uv-build"
+  UV_INSTALLER_URL="https://example.invalid/uv/install.sh"
+
+  # Preconditions: python_ok fails (too old), find_uv finds nothing yet.
+  if python_ok; then fail "fake python3 3.10 should make python_ok fail"; fi
+  if find_uv >/dev/null 2>&1; then fail "no uv should exist before bootstrap"; fi
+
+  ensure_uv >/dev/null || fail "ensure_uv should bootstrap uv via fake curl/installer"
+  bootstrapped="$(find_uv)" || fail "find_uv should locate bootstrapped uv"
+  assert_eq "$UV_INSTALL_DIR/uv" "$bootstrapped" "find_uv resolves bootstrapped uv path"
+  [[ -x "$bootstrapped" ]] || fail "bootstrapped uv should be executable"
+
+  ensure_python || fail "ensure_python should succeed once uv is bootstrapped"
+)
+
+# --- ensure_python drives the bootstrap itself from a clean state ------------
+# Same jammy scenario, but exercise ensure_python end-to-end (no prior ensure_uv
+# call): it must bootstrap uv and succeed without a usable system Python.
+(
+  fakebin="$tmp/uv-fakebin2"
+  fakehome="$tmp/uv-home2"
+  mkdir -p "$fakebin" "$fakehome/.local/bin"
+  cat > "$fakebin/python3" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"version_info >= (3, 11)"*) exit 1 ;;
+  *"import venv"*)             exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/python3"
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+out=""; prev=""
+for a in "$@"; do [[ "$prev" == "-o" ]] && out="$a"; prev="$a"; done
+[[ -n "$out" ]] || { echo "fake curl: no -o target" >&2; exit 1; }
+cat > "$out" <<'INSTALLER'
+#!/usr/bin/env sh
+dir="${UV_INSTALL_DIR:?}"; mkdir -p "$dir"
+printf '#!/usr/bin/env bash\necho uv-fake\n' > "$dir/uv"; chmod +x "$dir/uv"
+INSTALLER
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+  export PATH="$fakebin:/usr/bin:/bin"
+  export HOME="$fakehome"
+  export UV_INSTALL_DIR="$fakehome/.local/bin"
+  BUILD_DIR="$tmp/uv-build2"
+  UV_INSTALLER_URL="https://example.invalid/uv/install.sh"
+
+  ensure_python || fail "ensure_python should bootstrap uv end-to-end on jammy-like systems"
+  find_uv >/dev/null 2>&1 || fail "ensure_python should leave a resolvable uv behind"
+)
+
+# --- uv bootstrap idempotency: existing uv is reused, no download ------------
+(
+  fakebin="$tmp/uv-existing"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/uv" <<'SH'
+#!/usr/bin/env bash
+echo "uv 9.9.9-preinstalled"
+SH
+  chmod +x "$fakebin/uv"
+  # A curl that always fails: reuse path must not invoke it.
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+echo "fake curl should not be called when uv exists" >&2
+exit 22
+SH
+  chmod +x "$fakebin/curl"
+  export PATH="$fakebin:$PATH"
+  assert_eq "$fakebin/uv" "$(ensure_uv)" "ensure_uv reuses an existing uv without downloading"
+)
+
 REF=""
 VERSION=""
 UPDATE_MODE=0


### PR DESCRIPTION
## Summary
- bootstrap `uv` from `install.sh` when system Python is missing/too old/lacks venv support
- let the one-shot installer create the runtime venv via `uv venv --python 3.13` on Ubuntu/WSL jammy instead of depending on apt's Python 3.10
- add deterministic helper tests for uv bootstrap, existing-uv reuse, and the jammy-like Python 3.10 path

## Validation
- `bash -n install.sh`
- `bash -n scripts/test-install-sh.sh`
- `bash scripts/test-install-sh.sh`
- `git diff --check`

Jason explicitly authorized direct merge for this urgent live installer fix.
