### PR TITLE
feat: update TUI preset defaults

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -965,7 +965,7 @@ func zhipuPreset() Preset {
 		Description: PresetDescription{Summary: "Zhipu GLM Coding Plan — OpenAI-compatible"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				"provider": "zhipu", "model": "GLM-5.1",
+				"provider": "zhipu", "model": "GLM-5.2",
 				"api_key": nil, "api_key_env": "ZHIPU_API_KEY",
 				"base_url": ProviderRegionURLs["zhipu"][0].URL, "api_compat": "openai",
 			},
@@ -1014,8 +1014,8 @@ func deepseekPreset() Preset {
 	// `mcp-manual` skill (kernel `mcp` capability).
 	return openAICompatTextPreset(
 		"deepseek",
-		"DeepSeek V4 — OpenAI-compatible, 1M context window, tool calls",
-		"deepseek-v4-flash", "DEEPSEEK_API_KEY", "https://api.deepseek.com", "")
+		"DeepSeek V4 Pro — OpenAI-compatible, 1M context window, tool calls",
+		"deepseek-v4-pro", "DEEPSEEK_API_KEY", "https://api.deepseek.com", "")
 }
 
 func geminiPreset() Preset {
@@ -1104,11 +1104,11 @@ func codexPreset() Preset {
 		Description: PresetDescription{Summary: "ChatGPT account — vision + web search + tools"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				// Default to the latest frontier (gpt-5.5). It's only
-				// available via ChatGPT-OAuth — exactly the auth path
-				// codex uses — so it's the right "what do paid ChatGPT
-				// users actually want" pick. Model list is curated in
-				// preset_editor.go's providerModels; see SKILL.md there.
+				// Keep gpt-5.5 as the default even when newer GPT-5.x
+				// entries are selectable in the editor: current Codex +
+				// ChatGPT-account availability can lag public model names,
+				// and Jason explicitly asked that 5.5 remain default. The
+				// model list is curated in preset_editor.go's providerModels.
 				"provider": "codex", "model": "gpt-5.5",
 				"api_key": nil, "api_key_env": "",
 				"base_url": "https://chatgpt.com/backend-api/codex",
@@ -1141,7 +1141,7 @@ func codexPoolPreset() Preset {
 		Description: PresetDescription{Summary: "ChatGPT account pool — load-balances across your Codex accounts"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				// Same frontier default and endpoint as the single-account
+				// Same gpt-5.5 default and endpoint as the single-account
 				// codex preset; only the provider differs so the kernel routes
 				// through the pool. base_url stays the official Codex endpoint —
 				// the pool selects among token files, not endpoints.

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -482,6 +482,30 @@ func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 	})
 }
 
+func TestBuiltinPresetRequestedDefaultModels(t *testing.T) {
+	cases := []struct {
+		name      string
+		preset    Preset
+		wantModel string
+	}{
+		{"zhipu", zhipuPreset(), "GLM-5.2"},
+		{"deepseek", deepseekPreset(), "deepseek-v4-pro"},
+		{"codex", codexPreset(), "gpt-5.5"},
+		{"codex-pool", codexPoolPreset(), "gpt-5.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			llm, ok := tc.preset.Manifest["llm"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("%s manifest.llm missing or wrong type: %T", tc.name, tc.preset.Manifest["llm"])
+			}
+			if got, _ := llm["model"].(string); got != tc.wantModel {
+				t.Fatalf("%s default model = %q, want %q", tc.name, got, tc.wantModel)
+			}
+		})
+	}
+}
+
 func TestCodexPresetDefaultOmitsServiceTierAndSetsThinking(t *testing.T) {
 	p := codexPreset()
 	llm, ok := p.Manifest["llm"].(map[string]interface{})

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -130,7 +130,7 @@ var providerModels = map[string][]string{
 	},
 	"zhipu":    {"GLM-5.2", "GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air"},
 	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-flash"},
-	"deepseek": {"deepseek-v4-flash", "deepseek-v4-pro"},
+	"deepseek": {"deepseek-v4-pro", "deepseek-v4-flash"},
 	// NVIDIA NIM catalog IDs (build.nvidia.com) served on the free tier.
 	// Default flagship first; the rest are popular open-weight options.
 	// Users can also free-text any other catalog ID on this row.
@@ -145,15 +145,15 @@ var providerModels = map[string][]string{
 		"microsoft/phi-4-mini-instruct",
 	},
 	// Codex: ChatGPT-OAuth-only models served by chatgpt.com/backend-api/codex.
-	// gpt-5.5 is OAuth-exclusive (not available via API key); see SKILL.md
-	// next to this file for the canonical source list and why each one is
-	// included or excluded (e.g. gpt-5.5-pro is ChatGPT-Pro-only and not
-	// served on the codex endpoint, so we omit it to avoid 4xx breakage).
-	"codex": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
+	// Keep gpt-5.5 first because it remains the TUI default; newer entries
+	// such as gpt-5.6 are selectable for early testing when the endpoint/account
+	// enables them. See SKILL.md next to this file for the canonical source list
+	// and why each model is included or excluded (e.g. pro-only variants can 4xx).
+	"codex": {"gpt-5.5", "gpt-5.6", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
 	// codex-pool serves the same ChatGPT-OAuth models as codex — it only
 	// changes which token file each request routes through (the pool), not the
 	// model catalog. Keep the two lists identical.
-	"codex-pool": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
+	"codex-pool": {"gpt-5.5", "gpt-5.6", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
 	// Claude Agent SDK uses Claude Code CLI aliases, not dated API IDs.
 	// Keep opus first to match Jason's requested Opus 4.8 default;
 	// sonnet/haiku remain selectable for cheaper or faster runs.
@@ -200,12 +200,13 @@ var modelHasVision = map[string]bool{
 	"mimo-v2.5-pro": false,
 	"mimo-v2-flash": false,
 	// DeepSeek: text-only across the board.
-	"deepseek-v4-flash": false,
 	"deepseek-v4-pro":   false,
+	"deepseek-v4-flash": false,
 	// Codex (ChatGPT OAuth): all GPT-5.x family currently accepts images,
 	// including the *-codex tunes. Verify on each model's docs page when
 	// adding new entries; see SKILL.md.
 	"gpt-5.5":       true,
+	"gpt-5.6":       true,
 	"gpt-5.4":       true,
 	"gpt-5.4-mini":  true,
 	"gpt-5.3-codex": true,

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -72,6 +72,38 @@ func testCodexPresetEditorPresetWithThinking(serviceTier interface{}, thinking i
 	}
 }
 
+func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
+	if got := providerModels["zhipu"][0]; got != "GLM-5.2" {
+		t.Fatalf("zhipu default picker model = %q, want GLM-5.2", got)
+	}
+	if got := providerModels["deepseek"][0]; got != "deepseek-v4-pro" {
+		t.Fatalf("deepseek default picker model = %q, want deepseek-v4-pro", got)
+	}
+
+	for _, provider := range []string{"codex", "codex-pool"} {
+		models := providerModels[provider]
+		if len(models) == 0 {
+			t.Fatalf("%s provider model lineup is empty", provider)
+		}
+		if got := models[0]; got != "gpt-5.5" {
+			t.Fatalf("%s default picker model = %q, want gpt-5.5", provider, got)
+		}
+		found56 := false
+		for _, model := range models {
+			if model == "gpt-5.6" {
+				found56 = true
+				break
+			}
+		}
+		if !found56 {
+			t.Fatalf("%s model lineup should include gpt-5.6 while keeping gpt-5.5 first: %#v", provider, models)
+		}
+	}
+	if !modelHasVision["gpt-5.6"] {
+		t.Fatal("gpt-5.6 should be treated as vision-capable like the rest of the GPT-5.x Codex lineup")
+	}
+}
+
 func TestPresetEditorSmallHeightKeepsSaveVisible(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
 	var cmd tea.Cmd


### PR DESCRIPTION
## Summary
- add `gpt-5.6` to the TUI Codex / codex-pool model picker while keeping `gpt-5.5` first/default
- change the built-in DeepSeek template/default from `deepseek-v4-flash` to `deepseek-v4-pro`
- change the built-in Zhipu/GLM template/default from `GLM-5.1` to `GLM-5.2`
- add regression tests pinning the requested defaults and GPT-5.6 picker availability

## Notes
- `gpt-5.6` is selectable for early testing, but `gpt-5.5` intentionally remains the default because current Codex + ChatGPT-account availability can lag public model names.

## Validation
- `git diff --check`
- `cd tui && go test ./internal/preset ./internal/tui`
- `cd tui && go test ./...`
- `cd tui && make build`
