### PR TITLE
docs(preset): add built-in preset skill router

### DIFF
--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -19,6 +19,20 @@ related_files:
   - tui/internal/preset/preset_agent_json_merge_test.go
   - tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
   - tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/claude-agent-sdk/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
+  - tui/internal/preset/preset_skill_router_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -48,6 +62,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 | `RefreshTemplates()` | `tui/internal/preset/preset.go:437` | rewrites `templates/` from `BuiltinPresets()`, prunes retired |
 | `PopulateBundledLibrary(globalDir)` | `tui/internal/preset/preset.go:1288` | rewrites `~/.lingtai-tui/utilities/` from embedded `skills/` |
 | `BuiltinPresets()` | `tui/internal/preset/preset.go:489` | minimax, zhipu, mimo, deepseek, gemini, kimi, nvidia, openrouter, codex, codex-pool, claude-agent-sdk, custom |
+| `skills/lingtai-preset-skill/` | `tui/internal/preset/skills/lingtai-preset-skill/SKILL.md:1` | 12-child router; one nested manual per `BuiltinPresets()` name under `reference/<preset>/SKILL.md`. |
 | `IsTemplate(p)` | `tui/internal/preset/preset.go:540` | canonical "is this read-only?" — prefer over `IsBuiltin(p.Name)` |
 | `RefFor(p)` | `tui/internal/preset/preset.go:549` | `~/.lingtai-tui/presets/{templates\|saved}/<name>.json` |
 | `ResolveRefsWithAuth(refs, keys, auth)` / `ResolveRefs(refs, keys)` | `tui/internal/preset/preset.go` | health-check: Source, Exists, HasKey (+ `CodexAuthRef`) for each preset path; credential validity requires configured `api_key_env`, Codex OAuth, or Claude Code CLI auth for `claude-agent-sdk`. For codex, when `AuthState.CodexAuthDir` is set, validity is judged per-preset against the preset's own `manifest.llm.codex_auth_path` token file (empty → legacy `codex-auth.json` fallback) so multiple Codex accounts are independent; without the dir it falls back to the global `CodexOAuthConfigured` bool |
@@ -73,7 +88,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 ## Composition
 
 - **Parent:** `tui/internal/` (no own anatomy)
-- **Subfolders:** `covenant/`, `principle/`, `procedures/`, `templates/`, `soul/`, `recipe_assets/`, `skills/` — all `//go:embed` targets. `skills/swiss-knife/` is a top-level router whose nested utility references live under `skills/swiss-knife/reference/*/SKILL.md`.
+- **Subfolders:** `covenant/`, `principle/`, `procedures/`, `templates/`, `soul/`, `recipe_assets/`, `skills/` — all `//go:embed` targets. `skills/swiss-knife/` is a top-level router whose nested utility references live under `skills/swiss-knife/reference/*/SKILL.md`. `skills/lingtai-preset-skill/` is another top-level router whose 12 nested references mirror `BuiltinPresets()` under `skills/lingtai-preset-skill/reference/*/SKILL.md`.
 - **Siblings:** `tui/internal/migrate/ANATOMY.md` — migrations m029 (preset allowed list), m030 (preset dir split) live there
 
 ## State

--- a/tui/internal/preset/preset_skill_router_test.go
+++ b/tui/internal/preset/preset_skill_router_test.go
@@ -1,0 +1,483 @@
+package preset
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// wantMaintenance is the exact canonical sentence that every TUI-shipped
+// SKILL.md must carry in its YAML frontmatter.
+const wantMaintenance = `If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths.`
+
+// TestPresetSkillRouter_BuiltinBijection verifies the 5-sided bijection
+// between BuiltinPresets(), embedded child dirs, parent YAML catalog,
+// human routing table, and the extracted temp tree.
+func TestPresetSkillRouter_BuiltinBijection(t *testing.T) {
+	// A = want from BuiltinPresets()
+	want := map[string]bool{}
+	for _, p := range BuiltinPresets() {
+		want[p.Name] = true
+	}
+	if len(want) != 12 {
+		t.Fatalf("BuiltinPresets() returned %d unique names, want 12", len(want))
+	}
+
+	// B = embedded child dirs
+	childDirs := map[string]bool{}
+	err := fs.WalkDir(skillsFS, "skills/lingtai-preset-skill/reference", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		// Extract the dir name: reference/<name>/SKILL.md
+		rel := strings.TrimPrefix(path, "skills/lingtai-preset-skill/reference/")
+		parts := strings.SplitN(rel, "/", 2)
+		if len(parts) == 2 && parts[1] == "SKILL.md" {
+			childDirs[parts[0]] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert A == B
+	for name := range want {
+		if !childDirs[name] {
+			t.Errorf("BuiltinPresets() has %q but no embedded child dir", name)
+		}
+	}
+	for name := range childDirs {
+		if !want[name] {
+			t.Errorf("embedded child dir %q not in BuiltinPresets()", name)
+		}
+	}
+
+	// Read parent
+	parentData, err := fs.ReadFile(skillsFS, "skills/lingtai-preset-skill/SKILL.md")
+	if err != nil {
+		t.Fatalf("cannot read parent SKILL.md: %v", err)
+	}
+	parentBody := string(parentData)
+
+	// C = parent YAML catalog names
+	yamlLocRE := regexp.MustCompile(`location:\s*reference/([^/ \n]+)/SKILL\.md`)
+	yamlNameRE := regexp.MustCompile(`name:\s*preset-skill-([^\s\n]+)`)
+	locMatches := yamlLocRE.FindAllStringSubmatch(parentBody, -1)
+	nameMatches := yamlNameRE.FindAllStringSubmatch(parentBody, -1)
+
+	catalogNames := map[string]bool{}
+	if len(locMatches) != len(nameMatches) {
+		t.Errorf("parent YAML catalog: %d location entries vs %d name entries", len(locMatches), len(nameMatches))
+	}
+	for i, m := range locMatches {
+		childName := m[1]
+		catalogNames[childName] = true
+		if i < len(nameMatches) {
+			expectedPrefix := "preset-skill-" + childName
+			if nameMatches[i][1] != childName {
+				t.Errorf("parent YAML catalog entry %d: name=%q does not match location=%q", i, nameMatches[i][1], childName)
+			}
+			_ = expectedPrefix
+		}
+	}
+
+	// Assert A == C
+	for name := range want {
+		if !catalogNames[name] {
+			t.Errorf("BuiltinPresets() has %q but parent YAML catalog does not", name)
+		}
+	}
+	for name := range catalogNames {
+		if !want[name] {
+			t.Errorf("parent YAML catalog has %q but BuiltinPresets() does not", name)
+		}
+	}
+
+	// D = human routing table: assert each want name and reference/<name>/SKILL.md appears
+	if !strings.Contains(parentBody, "Nested reference catalog") {
+		t.Error("parent missing 'Nested reference catalog' heading")
+	}
+	if !strings.Contains(parentBody, "Routing table") {
+		t.Error("parent missing 'Routing table' heading")
+	}
+	for name := range want {
+		loc := "reference/" + name + "/SKILL.md"
+		if !strings.Contains(parentBody, loc) {
+			t.Errorf("parent routing table missing %q", loc)
+		}
+	}
+
+	// E = extracted temp tree
+	globalDir := t.TempDir()
+	PopulateBundledLibrary(globalDir)
+	utilitiesDir := filepath.Join(globalDir, "utilities", "lingtai-preset-skill")
+	for name := range want {
+		childPath := filepath.Join(utilitiesDir, "reference", name, "SKILL.md")
+		if _, err := os.Stat(childPath); err != nil {
+			t.Errorf("extracted tree missing %s: %v", childPath, err)
+		}
+	}
+	// Check no extra children
+	entries, err := os.ReadDir(filepath.Join(utilitiesDir, "reference"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() && !want[e.Name()] {
+			t.Errorf("extracted tree has extra child dir %q not in BuiltinPresets()", e.Name())
+		}
+	}
+
+	// BundledSkillNames check
+	if !BundledSkillNames()["lingtai-preset-skill"] {
+		t.Error("BundledSkillNames() does not contain lingtai-preset-skill")
+	}
+
+	// related_files check: every entry in parent must be a real repo-relative path
+	// by walking up from the package directory to the worktree root.
+	relatedRE := regexp.MustCompile(`(?m)^  - ([^\s#].+)$`)
+	inRelated := false
+	// Resolve the worktree root by walking up from the embedded skills dir
+	// to the tui/ directory, then one more level.
+	worktreeRoot := filepath.Join("..", "..", "..") // tui/internal/preset -> tui -> worktree root
+	for _, line := range strings.Split(parentBody, "\n") {
+		if strings.HasPrefix(line, "related_files:") {
+			inRelated = true
+			continue
+		}
+		if inRelated && strings.HasPrefix(line, "---") {
+			break
+		}
+		if inRelated {
+			m := relatedRE.FindStringSubmatch(line)
+			if m != nil {
+				rel := m[1]
+				abs := filepath.Join(worktreeRoot, rel)
+				if _, err := os.Stat(abs); err != nil {
+					t.Errorf("related_files entry %q does not resolve to a real file (checked %s)", rel, abs)
+				}
+			}
+		}
+	}
+}
+
+// TestPresetSkillRouter_ChildNaming verifies each child's frontmatter name
+// matches "preset-skill-<dirName>" and all are unique.
+func TestPresetSkillRouter_ChildNaming(t *testing.T) {
+	names := map[string]bool{}
+	err := fs.WalkDir(skillsFS, "skills/lingtai-preset-skill/reference", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		rel := strings.TrimPrefix(path, "skills/lingtai-preset-skill/reference/")
+		parts := strings.SplitN(rel, "/", 2)
+		if len(parts) != 2 || parts[1] != "SKILL.md" {
+			return nil
+		}
+		dirName := parts[0]
+
+		data, err := fs.ReadFile(skillsFS, path)
+		if err != nil {
+			return err
+		}
+		body := string(data)
+		if !strings.HasPrefix(body, "---\n") {
+			t.Errorf("%s missing frontmatter", path)
+			return nil
+		}
+		end := strings.Index(body[4:], "\n---")
+		if end < 0 {
+			t.Errorf("%s missing closing ---", path)
+			return nil
+		}
+		fm := body[:4+end]
+		nameRE := regexp.MustCompile(`(?m)^name:\s*(.+)$`)
+		m := nameRE.FindStringSubmatch(fm)
+		if m == nil {
+			t.Errorf("%s missing name in frontmatter", path)
+			return nil
+		}
+		gotName := strings.TrimSpace(m[1])
+		wantName := "preset-skill-" + dirName
+		if gotName != wantName {
+			t.Errorf("%s: name=%q, want %q", path, gotName, wantName)
+		}
+		if names[gotName] {
+			t.Errorf("duplicate child name %q", gotName)
+		}
+		names[gotName] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 12 {
+		t.Errorf("got %d unique child names, want 12", len(names))
+	}
+}
+
+// TestPresetSkillRouter_ParentMaintenanceAndRelated verifies the parent has
+// the canonical maintenance value and a non-empty related_files list.
+func TestPresetSkillRouter_ParentMaintenanceAndRelated(t *testing.T) {
+	data, err := fs.ReadFile(skillsFS, "skills/lingtai-preset-skill/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if !strings.HasPrefix(body, "---\n") {
+		t.Fatal("parent missing frontmatter")
+	}
+	end := strings.Index(body[4:], "\n---")
+	if end < 0 {
+		t.Fatal("parent missing closing ---")
+	}
+	fm := body[:4+end]
+
+	maintRE := regexp.MustCompile(`(?m)^maintenance:\s*"?(.+?)"?\s*$`)
+	m := maintRE.FindStringSubmatch(fm)
+	if m == nil {
+		t.Fatal("parent missing maintenance field")
+	}
+	got := strings.TrimSpace(m[1])
+	if got != wantMaintenance {
+		t.Errorf("parent maintenance mismatch.\n got: %s\nwant: %s", got, wantMaintenance)
+	}
+
+	if !strings.Contains(fm, "related_files:") {
+		t.Error("parent missing related_files field")
+	}
+}
+
+// TestPresetSkillRouter_ChildSizeBudget verifies each child body is within
+// the 1800-6000 char band (approx 450-1500 tokens).
+func TestPresetSkillRouter_ChildSizeBudget(t *testing.T) {
+	err := fs.WalkDir(skillsFS, "skills/lingtai-preset-skill/reference", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		data, err := fs.ReadFile(skillsFS, path)
+		if err != nil {
+			return err
+		}
+		text := string(data)
+		secondDash := strings.Index(text, "\n---")
+		if secondDash < 0 {
+			t.Errorf("%s missing closing ---", path)
+			return nil
+		}
+		body := strings.TrimPrefix(text[secondDash+4:], "\n")
+		bodyChars := len(body)
+		approxTokens := bodyChars / 4
+
+		rel := strings.TrimPrefix(path, "skills/lingtai-preset-skill/reference/")
+		parts := strings.SplitN(rel, "/", 2)
+		name := parts[0]
+		t.Logf("%s: %d chars ~ %d tokens", name, bodyChars, approxTokens)
+
+		if bodyChars < 1800 {
+			t.Errorf("%s body too short: %d chars (min 1800)", name, bodyChars)
+		}
+		if bodyChars > 6000 {
+			t.Errorf("%s body too long: %d chars (max 6000)", name, bodyChars)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPresetSkillRouter_ParentIsLeanRouter verifies the parent body is
+// within the 2500-7000 char band and contains the required headings.
+func TestPresetSkillRouter_ParentIsLeanRouter(t *testing.T) {
+	data, err := fs.ReadFile(skillsFS, "skills/lingtai-preset-skill/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	secondDash := strings.Index(text, "\n---")
+	if secondDash < 0 {
+		t.Fatal("parent missing closing ---")
+	}
+	body := strings.TrimPrefix(text[secondDash+4:], "\n")
+	bodyChars := len(body)
+	t.Logf("parent body: %d chars ~ %d tokens", bodyChars, bodyChars/4)
+
+	if bodyChars < 2500 {
+		t.Errorf("parent body too short: %d chars (min 2500)", bodyChars)
+	}
+	if bodyChars > 7000 {
+		t.Errorf("parent body too long: %d chars (max 7000)", bodyChars)
+	}
+	if !strings.Contains(body, "Nested reference catalog") {
+		t.Error("parent body missing 'Nested reference catalog' heading")
+	}
+	if !strings.Contains(body, "Routing table") {
+		t.Error("parent body missing 'Routing table' heading")
+	}
+}
+
+// TestPresetSkillRouter_ParentDoesNotDuplicateChildren verifies no >=48-char
+// normalized child body line appears verbatim in the parent body.
+func TestPresetSkillRouter_ParentDoesNotDuplicateChildren(t *testing.T) {
+	parentData, err := fs.ReadFile(skillsFS, "skills/lingtai-preset-skill/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentText := string(parentData)
+	parentDash := strings.Index(parentText, "\n---")
+	if parentDash < 0 {
+		t.Fatal("parent missing closing ---")
+	}
+	parentBody := strings.TrimPrefix(parentText[parentDash+4:], "\n")
+
+	err = fs.WalkDir(skillsFS, "skills/lingtai-preset-skill/reference", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		data, err := fs.ReadFile(skillsFS, path)
+		if err != nil {
+			return err
+		}
+		text := string(data)
+		secondDash := strings.Index(text, "\n---")
+		if secondDash < 0 {
+			return nil
+		}
+		childBody := strings.TrimPrefix(text[secondDash+4:], "\n")
+
+		rel := strings.TrimPrefix(path, "skills/lingtai-preset-skill/reference/")
+		childName := strings.SplitN(rel, "/", 2)[0]
+
+		for _, line := range strings.Split(childBody, "\n") {
+			normalized := strings.TrimSpace(line)
+			// Strip common markdown prefixes
+			normalized = strings.TrimPrefix(normalized, "- ")
+			normalized = strings.TrimPrefix(normalized, "* ")
+			normalized = strings.TrimPrefix(normalized, "> ")
+			normalized = strings.TrimPrefix(normalized, "# ")
+			// Strip backtick edges
+			normalized = strings.Trim(normalized, "`")
+			if len(normalized) >= 48 && strings.Contains(parentBody, normalized) {
+				t.Errorf("child %s: verbatim line in parent body: %.80s...", childName, normalized)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCodexPoolManualDocumentsClassifiedContract verifies the codex-pool
+// child body documents the dedicated preset, v1/v2 exact-model classification
+// from kernel #841 and TUI #612, and links official sources without reviving
+// cancelled convergence proposals.
+func TestCodexPoolManualDocumentsClassifiedContract(t *testing.T) {
+	data, err := fs.ReadFile(skillsFS, "skills/lingtai-preset-skill/reference/codex-pool/SKILL.md")
+	if err != nil {
+		t.Fatalf("cannot read codex-pool child: %v", err)
+	}
+	body := string(data)
+
+	// Must mention the dedicated codex-pool preset
+	if !strings.Contains(body, "codex-pool") {
+		t.Error("codex-pool child does not mention codex-pool preset")
+	}
+
+	// Must document v1/v2 pool shapes
+	if !strings.Contains(body, "version") || !strings.Contains(body, "models") {
+		t.Error("codex-pool child missing v1/v2 pool shape documentation")
+	}
+
+	// Must reference kernel #841 and TUI #612
+	if !strings.Contains(body, "#841") {
+		t.Error("codex-pool child missing kernel #841 reference")
+	}
+	if !strings.Contains(body, "#612") {
+		t.Error("codex-pool child missing TUI #612 reference")
+	}
+
+	// Must link official OpenAI/Codex sources
+	if !strings.Contains(body, "developers.openai.com/codex") {
+		t.Error("codex-pool child missing official OpenAI/Codex source link")
+	}
+
+	// Must link LingTai pool code/tests
+	if !strings.Contains(body, "codex_pool_store") {
+		t.Error("codex-pool child missing reference to TUI pool store code")
+	}
+
+	// Must NOT revive cancelled convergence proposals
+	if strings.Contains(body, "convergence") {
+		t.Error("codex-pool child references cancelled convergence proposals")
+	}
+
+	// Must mention exact-model classification
+	if !strings.Contains(body, "exact") {
+		t.Error("codex-pool child missing exact-model classification reference")
+	}
+}
+
+// TestBundledSkillsHaveMaintenance verifies all 66 SKILL.md files have the
+// exact canonical maintenance sentence.
+func TestBundledSkillsHaveMaintenance(t *testing.T) {
+	count := 0
+	err := fs.WalkDir(skillsFS, "skills", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		count++
+		data, err := fs.ReadFile(skillsFS, path)
+		if err != nil {
+			return err
+		}
+		body := string(data)
+		if !strings.HasPrefix(body, "---\n") {
+			t.Errorf("%s missing YAML frontmatter", path)
+			return nil
+		}
+		end := strings.Index(body[4:], "\n---")
+		if end < 0 {
+			t.Errorf("%s missing closing YAML frontmatter delimiter", path)
+			return nil
+		}
+		frontmatter := body[:4+end]
+		maintRE := regexp.MustCompile(`(?m)^maintenance:\s*"?(.+?)"?\s*$`)
+		match := maintRE.FindStringSubmatch(frontmatter)
+		if match == nil {
+			t.Errorf("%s missing maintenance frontmatter", path)
+			return nil
+		}
+		value := strings.TrimSpace(match[1])
+		if value != wantMaintenance {
+			t.Errorf("%s maintenance value does not match canonical sentence.\n got: %.80s...\nwant: %.80s...", path, value, wantMaintenance)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 66 {
+		t.Fatalf("checked %d bundled skill SKILL.md files, want 66", count)
+	}
+}

--- a/tui/internal/preset/skill_metadata_test.go
+++ b/tui/internal/preset/skill_metadata_test.go
@@ -49,7 +49,7 @@ func TestBundledSkillsHaveLastChangedAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 53 {
-		t.Fatalf("checked %d bundled skill SKILL.md files, want 53", count)
+	if count != 66 {
+		t.Fatalf("checked %d bundled skill SKILL.md files, want 66", count)
 	}
 }

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -10,6 +10,7 @@ description: >
   for end-user lessons, use tutorial-guide.
 version: 2.6.1
 last_changed_at: "2026-07-03T08:05:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # LingTai Developer Guide

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/architecture/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/architecture/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for the project architecture: Go TUI/portal monorepo, Python kernel, MCP addon repos, filesystem IPC, and where per-project/per-machine state lives.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:05:51-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Architecture

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/SKILL.md
@@ -12,6 +12,7 @@ description: >
   drop after a refresh/affinity/cache-key change.
 version: 1.0.0
 last_changed_at: "2026-06-21T20:24:21-05:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Cache Hit Rate

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for contribution workflow: issue/worktree/PR discipline, stale-worktree cleanup, daemon decomposition, portfolio sweeps, repo-specific build/test commands, skill changes, and anatomy maintenance.
 version: 1.1.0
 last_changed_at: "2026-06-24T12:37:00-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Contributing to LingTai

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/debug-troubleshoot/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/debug-troubleshoot/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for diagnosing LingTai failures: agent process state, OOM/crashes, avatar spawn issues, post-molt memory loss, mail delivery, scheduled messages, tool timeouts, and escalation.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:05:51-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # LingTai Debug & Troubleshoot Reference

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, dev-mode rebuilds, editable installs, migrations, localization, authorization gates, config conventions, and rebuild-gate test false-passes.
 version: 1.1.0
 last_changed_at: "2026-06-20T01:30:35-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Gotchas and Known Pitfalls

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/network-governance/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/network-governance/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for avatar network governance: core rules, health monitoring, CPR, watchdog cadence, role documentation, delegation patterns, workspaces, and peer communication.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:05:51-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Avatar Network Governance — Reference Card

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/pr-review-deliverables/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/pr-review-deliverables/SKILL.md
@@ -8,6 +8,7 @@ description: >
   authorization boundaries for opening, editing, and merging PRs.
 version: 1.0.0
 last_changed_at: "2026-06-13T23:25:20-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # PR Review & Deliverables

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
@@ -8,6 +8,7 @@ description: >
   template.
 version: 1.2.0
 last_changed_at: "2026-06-29T02:13:00-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Release Workflow

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Compact lingtai-dev-guide release overview: when you are doing a release, the maintainer-authorization boundary, the version scheme, and a pointer to release-workflow for the full TUI/Portal + kernel publishing checklist, GitHub/PyPI/Homebrew steps, the required HTML release log, and the website release blog.
 version: 2.0.0
 last_changed_at: "2026-06-29T02:13:00-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Releasing — Overview

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/repo-watch/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/repo-watch/SKILL.md
@@ -8,6 +8,7 @@ description: >
   reference, not a top-level intrinsic skill.
 version: 1.0.0
 last_changed_at: "2026-06-29T01:44:32-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # LingTai Repo Watch

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -11,6 +11,7 @@ description: >
   refresh, not just that new source is imported.
 version: 1.2.0
 last_changed_at: "2026-06-24T15:24:47-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Runtime Self-Check

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/security-audit/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/security-audit/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for security audits: secret scanning, file permissions, MCP config, communication security, data exposure, agent permission review, severity classification, and report format.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:05:51-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # LingTai Security Audit Reference

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/setup/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/setup/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested lingtai-dev-guide reference for local developer environment setup: cloning repos, building TUI/portal, dev-mode symlinks, editable kernel install, MCP addon setup, and verification.
 version: 1.0.0
 last_changed_at: "2026-06-12T15:01:39-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Development Environment Setup

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
@@ -9,6 +9,7 @@ description: >
   grooming shared-library candidates, and PR-ready skill cleanup.
 version: 1.0.1
 last_changed_at: "2026-07-03T08:05:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Skill Stewardship

--- a/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
@@ -3,6 +3,7 @@ name: lingtai-issue-report
 description: Protocol router for reporting bugs, stale info, missing capabilities, or design issues you spot in any LingTai skill, capability, preset, or system behavior. Enter through this router, then load the one nested reference you need — evidence-checklist (when to report, what evidence to collect, secret hygiene), report-template (the report body/title structure), or filing-flow (human consent, the gh CLI path, and the paste-ready fallback). You always assemble a structured report and ask the human for permission before filing.
 version: 1.4.0
 last_changed_at: "2026-06-02T02:43:15-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Reporting LingTai Issues

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/evidence-checklist/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/evidence-checklist/SKILL.md
@@ -3,6 +3,7 @@ name: issue-report-evidence-checklist
 description: Nested lingtai-issue-report reference for deciding when an observation is worth reporting, what evidence to collect, and how to keep secrets out of a report. Read this first, while the problem is fresh, before drafting the report body.
 version: 1.0.0
 last_changed_at: "2026-06-02T02:43:15-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Issue report — evidence checklist

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/filing-flow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/filing-flow/SKILL.md
@@ -3,6 +3,7 @@ name: issue-report-filing-flow
 description: Nested lingtai-issue-report reference for the filing decision — the always-required human consent boundary, the read-only gh probe, Path A (direct gh filing) and Path B (paste-ready handoff), token hygiene, and proactive surfacing. Read this once the report is drafted and you are deciding how it gets filed.
 version: 1.0.0
 last_changed_at: "2026-06-02T02:43:15-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Issue report — filing flow

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/report-template/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/report-template/SKILL.md
@@ -3,6 +3,7 @@ name: issue-report-report-template
 description: Nested lingtai-issue-report reference for the report skeleton — subject/title format, the structured body sections (what's wrong, where, reproduction, expected vs actual, severity, suggested fix), and how to send it via LingTai email or the human's active channel. Read this when you are ready to assemble the report.
 version: 1.0.0
 last_changed_at: "2026-06-02T02:43:15-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Issue report — report template

--- a/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
@@ -3,6 +3,7 @@ name: lingtai-portal-guide
 description: Reference router for LingTai portal (lingtai-portal) internals. Read this to understand portal startup/opening, .portal/ files, topology/replay APIs, network response shape, and lifecycle/recording behavior. Useful when the human asks about visualization, network history, or the portal.
 version: 1.1.0
 last_changed_at: "2026-06-02T01:46:45-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Portal Guide

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
@@ -3,6 +3,7 @@ name: portal-guide-lifecycle-and-recording
 description: Nested lingtai-portal-guide reference for portal lifecycle-state interpretation, heartbeat staleness, recording, and tape reconstruction behavior.
 version: 1.0.0
 last_changed_at: "2026-06-02T01:46:45-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Lifecycle and recording

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/overview/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/overview/SKILL.md
@@ -3,6 +3,7 @@ name: portal-guide-overview
 description: Nested lingtai-portal-guide reference for portal purpose, opening the browser view, and the `.portal/` directory layout.
 version: 1.0.0
 last_changed_at: "2026-06-02T01:46:45-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Portal overview

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
@@ -3,6 +3,7 @@ name: portal-guide-topology-and-api
 description: Nested lingtai-portal-guide reference for topology tape frames, replay chunks, portal API endpoints, and the Network JSON response.
 version: 1.0.0
 last_changed_at: "2026-06-02T01:46:45-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Topology and API

--- a/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: lingtai-preset-skill
+description: >
+  Routing table for the 12 TUI-shipped built-in preset templates. Reach for
+  this skill when you need to select, configure, compare, or troubleshoot a
+  built-in preset template — not an arbitrary saved preset. Routes to one
+  nested manual per built-in preset under reference/<preset>/SKILL.md.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+related_files:
+  - tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
+  - tui/internal/preset/preset.go
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/preset/skill_metadata_test.go
+  - tui/internal/preset/preset_skill_router_test.go
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# lingtai-preset-skill — built-in preset routing table
+
+This skill is the **sole agent-facing routing table** for the 12 TUI-shipped
+built-in preset templates. It routes you to one nested manual per preset.
+
+**Boundary:** this router covers **template** presets (the `BuiltinPresets()`
+list at `tui/internal/preset/preset.go:489`). A user-saved preset clone
+(living under `~/.lingtai-tui/presets/saved/`) may diverge from its template —
+inspect the saved preset's actual `manifest` JSON for current truth.
+
+## Nested reference catalog
+
+`lingtai-preset-skill` owns these nested references. They are parent-owned
+drill-down files, not standalone top-level skills.
+
+```yaml
+- name: preset-skill-minimax
+  location: reference/minimax/SKILL.md
+  description: |
+    Shipped built-in preset manual for `minimax` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-zhipu
+  location: reference/zhipu/SKILL.md
+  description: |
+    Shipped built-in preset manual for `zhipu` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-mimo
+  location: reference/mimo/SKILL.md
+  description: |
+    Shipped built-in preset manual for `mimo` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-deepseek
+  location: reference/deepseek/SKILL.md
+  description: |
+    Shipped built-in preset manual for `deepseek` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-gemini
+  location: reference/gemini/SKILL.md
+  description: |
+    Shipped built-in preset manual for `gemini` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-kimi
+  location: reference/kimi/SKILL.md
+  description: |
+    Shipped built-in preset manual for `kimi` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-nvidia
+  location: reference/nvidia/SKILL.md
+  description: |
+    Shipped built-in preset manual for `nvidia` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-openrouter
+  location: reference/openrouter/SKILL.md
+  description: |
+    Shipped built-in preset manual for `openrouter` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-codex
+  location: reference/codex/SKILL.md
+  description: |
+    Shipped built-in preset manual for `codex` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-codex-pool
+  location: reference/codex-pool/SKILL.md
+  description: |
+    Shipped built-in preset manual for `codex-pool` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-claude-agent-sdk
+  location: reference/claude-agent-sdk/SKILL.md
+  description: |
+    Shipped built-in preset manual for `claude-agent-sdk` — verify preset identity, provider sources, and compatibility facts.
+- name: preset-skill-custom
+  location: reference/custom/SKILL.md
+  description: |
+    Shipped built-in preset manual for `custom` — verify preset identity, provider sources, and compatibility facts.
+```
+
+## Routing table
+
+| Preset | Manual | Trigger |
+|--------|--------|---------|
+| `minimax` | `reference/minimax/SKILL.md` | MiniMax-M3 — Anthropic-compatible, CN/INTL regions |
+| `zhipu` | `reference/zhipu/SKILL.md` | Zhipu/Z.AI GLM Coding Plan — OpenAI-compatible |
+| `mimo` | `reference/mimo/SKILL.md` | Xiaomi MiMo — OpenAI-compatible, multimodal |
+| `deepseek` | `reference/deepseek/SKILL.md` | DeepSeek V4 Pro — OpenAI-compatible, text-only |
+| `gemini` | `reference/gemini/SKILL.md` | Google Gemini — native adapter, multimodal |
+| `kimi` | `reference/kimi/SKILL.md` | Kimi Code (Moonshot) — OpenAI-compatible, text-only |
+| `nvidia` | `reference/nvidia/SKILL.md` | NVIDIA NIM — OpenAI-compatible, text-only |
+| `openrouter` | `reference/openrouter/SKILL.md` | OpenRouter — unified gateway, text-only |
+| `codex` | `reference/codex/SKILL.md` | Codex — ChatGPT OAuth, single account |
+| `codex-pool` | `reference/codex-pool/SKILL.md` | Codex Pool — ChatGPT OAuth, multi-account load balancing |
+| `claude-agent-sdk` | `reference/claude-agent-sdk/SKILL.md` | Claude Agent SDK — local CLI auth, no API key |
+| `custom` | `reference/custom/SKILL.md` | Custom — user-supplied OpenAI/Anthropic-compatible endpoint |
+
+## Maintenance rule
+
+Provider-owned facts (models, pricing, endpoints, auth) change at the
+provider's cadence. LingTai-owned facts (preset wiring, env var names,
+capability flags, compatibility protocol) change only when the TUI source at
+`tui/internal/preset/preset.go` changes. Each child manual documents which
+facts belong to which owner.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/claude-agent-sdk/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/claude-agent-sdk/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: preset-skill-claude-agent-sdk
+description: >
+  Nested lingtai-preset-skill reference for the `claude-agent-sdk` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `claude-agent-sdk` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `claude-agent-sdk` — built-in preset manual
+
+> Completion-only provider that rides on Anthropic's local Claude Code CLI.
+> Not OpenAI-compatible; does not accept a per-request API key.
+
+## When to read
+
+- Verifying the `claude-agent-sdk` preset's shipped identity.
+- Understanding the CLI-login dependency and absence of API-key auth.
+- Distinguishing LingTai integration from Anthropic's SDK/CLI.
+
+## Shipped identity (verify in TUI source)
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `claude-agent-sdk` | `preset.go:1164` |
+| `llm.provider` | `claude-agent-sdk` | `preset.go:1178` |
+| `llm.model` | `opus` (CLI alias) | `preset.go:1178` |
+| `llm.api_key_env` | `""` (none) | `preset.go:1179` |
+| `llm.base_url` | none (CLI-owned) | `preset.go:1178-1179` |
+| Auth mode | Local `claude` CLI login | `preset.go:1169-1174`; `claude_auth.go:17-27` |
+| Capabilities | `skills` default only | `preset.go:1187-1189` |
+| Absent | `web_search`, `vision` | `preset.go:1181-1186` |
+| Alias | `claude_agent_sdk` (compatibility) | `preset.go:524` |
+
+## Auth detection
+
+The TUI detects CLI login via `claude auth status --json` (timeout 4s,
+`claude_auth.go:15`). Success signal: JSON with `loggedIn: true`.
+
+Uncertain outcomes (CLI missing, nonzero exit, timeout) all resolve to
+"not configured" (`claude_auth.go:24-25`).
+
+The credential guard (`ResolveRefsWithAuth`) treats the preset as "HasKey"
+only when `AuthState.ClaudeCodeAuthConfigured` is true (`preset.go:776-780`).
+
+## Official Anthropic sources
+
+| Resource | URL |
+|---|---|
+| Claude Code overview | <https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview> |
+| Agent SDK overview | <https://code.claude.com/docs/en/agent-sdk/overview> |
+| Agent SDK Python reference | <https://code.claude.com/docs/en/agent-sdk/python> |
+| CLI reference | <https://code.claude.com/docs/en/cli-reference> |
+| Model configuration | <https://code.claude.com/docs/en/model-config> |
+
+The `opus` alias resolves to the latest Opus model available to the active
+account. To pin a version, use a full model ID or `ANTHROPIC_DEFAULT_OPUS_MODEL`.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** CLI installation, SDK versions, model aliases,
+  pricing, auth methods.
+- **LingTai-owned (verify in source):** manifest shape, CLI auth probe,
+  credential guard mapping, deliberate absence of `web_search`/`vision`.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: preset-skill-codex-pool
+description: >
+  Nested lingtai-preset-skill reference for the `codex-pool` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `codex-pool` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `codex-pool` — built-in preset manual
+
+Identical to `codex` in model, endpoint, and capabilities; only the provider
+changes. `codex-pool` routes each agent session to one of several ChatGPT
+OAuth token files selected by weighted, sticky load balancing from a
+non-secret pool file.
+
+## When to read
+
+- Load-balancing a Codex agent across several ChatGPT accounts.
+- Editing the non-secret pool file.
+- Understanding v1 flat vs v2 exact-model classification.
+
+## Shipped defaults (verify in TUI source)
+
+Source: `tui/internal/preset/preset.go:1137-1160`.
+
+| Field | Value |
+|---|---|
+| `name` | `codex-pool` |
+| `llm.provider` | `codex-pool` |
+| `llm.model` | `gpt-5.6-sol` |
+| `llm.base_url` | `https://chatgpt.com/backend-api/codex` |
+| `llm.thinking` | `xhigh` |
+| `llm.api_key_env` | `""` (OAuth only) |
+
+## Pool file schema
+
+Two stable shapes, both handled by TUI and kernel:
+
+**v1 — flat (`accounts`)**
+
+```json
+{"version": 1, "accounts": [{"path": "codex-auth.json", "weight": 1}]}
+```
+
+**v2 — exact-model classification (`models`)** (kernel #841 / TUI #612)
+
+```json
+{"version": 2, "models": {"gpt-5.6-sol": [{"path": "codex-auth.json", "weight": 1}]}}
+```
+
+### Exact-model classification rules (kernel #841 / TUI #612)
+
+- The kernel keys off **structure**, not the `version` field.
+- A top-level `models` dict makes the file classified; `models: null` does not.
+- When classified, `models` is the **sole source of truth** — sibling flat
+  `accounts` list is ignored.
+- Matching is **exact, case-sensitive** — no prefix, family, wildcard, or default
+  fallback within the classified file.
+- The TUI credentials UI refuses flat weight edits on a classified pool so it
+  never silently destroys a hand-written classification
+  (`codex_pool_store.go:64-70, 292-306`).
+
+Kernel source: merge `b05be6d4` in `lingtai-kernel`, `src/lingtai/auth/codex_pool.py`.
+
+## Operational caveats
+
+- Base URL ends in `/codex`; omitting it produces HTML/Cloudflare errors.
+- Token files are secret (`0600`); pool files are non-secret (`0644`).
+- Weight `0` disables an account without removing it.
+- Selection is **sticky per agent session** and does not rotate on molt.
+- A missing/empty/invalid pool file causes fallback to legacy `codex-auth.json`.
+
+## Official sources
+
+<https://developers.openai.com/codex/auth> | <https://developers.openai.com/codex/models>
+| <https://github.com/openai/codex>
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model names, availability, auth URLs from OpenAI.
+- **LingTai-owned (verify in source):** provider string, endpoint, pool-file
+  schema, exact-model classification semantics, sticky selection, OAuth layout,
+  capability wiring. Reference both TUI and kernel source.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: preset-skill-codex
+description: >
+  Nested lingtai-preset-skill reference for the `codex` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `codex` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `codex` — built-in preset manual
+
+Routes the agent through OpenAI's Codex backend using a ChatGPT account
+OAuth session, not a standard OpenAI API key.
+
+## When to read
+
+- Choosing or troubleshooting the single-account Codex preset.
+- Picking a model, binding an account, or distinguishing from `codex-pool`.
+
+## Shipped defaults (verify in TUI source)
+
+Source: `tui/internal/preset/preset.go:1100-1128`.
+
+| Field | Value |
+|---|---|
+| `name` | `codex` |
+| `llm.provider` | `codex` |
+| `llm.model` | `gpt-5.6-sol` |
+| `llm.base_url` | `https://chatgpt.com/backend-api/codex` |
+| `llm.thinking` | `xhigh` |
+| `llm.api_key_env` | `""` (OAuth only) |
+
+Model picker: `preset_editor.go:147-152`.
+
+## Use when / avoid when
+
+- **Use** when you want a single ChatGPT account to power a Codex agent.
+- **Avoid** when you need load-balancing across multiple accounts — use `codex-pool`.
+- **Avoid** when you want a standard OpenAI API key flow — this uses OAuth tokens.
+
+## Authentication
+
+Codex uses ChatGPT OAuth token files. The TUI writes these during first-run
+or Credentials setup.
+
+- Default token file: `~/.lingtai-tui/codex-auth.json`
+- Additional accounts: `~/.lingtai-tui/codex-auth/<slug>.json`
+- Bind specific account via `manifest.llm.codex_auth_path`.
+- Credential validity: judged by non-empty `refresh_token` in the bound file.
+
+Official docs: <https://developers.openai.com/codex/auth>.
+Official model catalog: <https://developers.openai.com/codex/models>.
+Reference implementation: <https://github.com/openai/codex>.
+
+## Operational caveats
+
+- Base URL ends in `/codex`; omitting it produces HTML/Cloudflare errors.
+- Token files are secret (mode `0600`); paths may appear in presets but
+  contents must never be logged or copied into reports.
+- Model availability depends on ChatGPT account tier and OpenAI rollout.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model names, availability, auth URLs from OpenAI.
+- **LingTai-owned (verify in source):** provider string, endpoint,
+  `codex_auth_path` behavior, OAuth token-file layout, capability wiring.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: preset-skill-custom
+description: >
+  Nested lingtai-preset-skill reference for the `custom` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `custom` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `custom` — built-in preset manual
+
+> The generic escape hatch for any endpoint that speaks one of the wire
+> protocols LingTai's custom adapter implements.
+
+## When to read
+
+- Verifying the `custom` preset's manifest shape or supported protocols.
+- Understanding capability inheritance (vision `inherit`).
+- Routing through OpenAI-compatible, Anthropic, or Gemini endpoints.
+
+## Shipped identity (verify in TUI source)
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `custom` | `preset.go:1196` |
+| `llm.provider` | `custom` | `preset.go:1200` |
+| `llm.model` | `""` (user must set) | `preset.go:1200` |
+| `llm.api_key_env` | `LLM_API_KEY` | `preset.go:1201` |
+| `llm.base_url` | `nil` (user must set) | `preset.go:1201` |
+| `llm.api_compat` | unset; defaults to `openai` | `custom/defaults.py:2`; `_register.py:60` |
+| TUI editor compat options | `""`, `"openai"`, `"anthropic"` | `preset_editor.go:1114-1116` |
+| Capabilities | `web_search` (empty -> default), `vision` (`inherit`), `skills` default | `preset.go:1203-1212` |
+
+## Kernel custom adapter
+
+`src/lingtai/llm/custom/adapter.py:20-51` implements `create_custom_adapter()`:
+
+| api_compat | Backend | Requirements |
+|---|---|---|
+| `"openai"` (default) | `OpenAIAdapter` | `base_url` required |
+| `"anthropic"` | `AnthropicAdapter` | `base_url` required |
+| `"gemini"` | `GeminiAdapter` | `api_key` required; `base_url` ignored |
+
+**Note:** the TUI preset editor exposes only `openai` and `anthropic` for
+the `custom` preset. Gemini is supported by the kernel adapter but not
+exposed in the TUI editor for `custom`.
+
+## Capability inheritance
+
+- `vision` is configured with `provider: "inherit"` (`preset.go:1211`).
+  The kernel's `expand_inherit` (`presets.py:570-594`) copies the main LLM's
+  provider, api_key, api_key_env, base_url, and api_compat into the capability
+  config. Vision then falls back to `OpenAIVisionService` or
+  `AnthropicVisionService` based on the inherited `api_compat`.
+- `web_search` is shipped as an empty map (`preset.go:1204`). The kernel
+  defaults to `duckduckgo` when no provider is supplied.
+
+## Official protocol sources
+
+| Protocol | Documentation |
+|---|---|
+| OpenAI Chat Completions | <https://platform.openai.com/docs/api-reference/chat> |
+| Anthropic Messages | <https://docs.anthropic.com/en/api/messages> |
+| Google Gemini | <https://ai.google.dev/gemini-api/docs> |
+
+Do not embed model tables, pricing, or marketing claims — those live with
+the endpoint operator.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model IDs, pricing, auth flows of the
+  configured endpoint.
+- **LingTai-owned (verify in source):** manifest shape, TUI editor options,
+  kernel adapter factory, adapter registration, `api_compat` pass-through,
+  capability inheritance wiring, vision fallback routing.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: preset-skill-deepseek
+description: >
+  Nested lingtai-preset-skill reference for the `deepseek` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `deepseek` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `deepseek` — built-in preset manual
+
+> Progressive-disclosure manual. Its job is to tell a future maintainer where
+> to verify current truth, not to duplicate volatile catalogs.
+
+## When to read
+
+- Editing or health-checking the `deepseek` built-in template preset.
+- Confirming the shipped model string or base URL.
+- Needing authoritative DeepSeek model/pricing/API/auth links.
+
+## Shipped identity (verify in TUI source)
+
+Built through the `openAICompatTextPreset` helper (`preset.go:904-932`).
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `deepseek` | `preset.go:1015` |
+| `llm.provider` | `deepseek` | `preset.go:921` |
+| `llm.model` | `deepseek-v4-pro` | `preset.go:1018` |
+| `llm.api_compat` | `openai` | `preset.go:924` |
+| `llm.api_key_env` | `DEEPSEEK_API_KEY` | `preset.go:1018` |
+| `llm.base_url` | `https://api.deepseek.com` | `preset.go:1018` |
+| Capabilities | `web_search` (DuckDuckGo), `skills` default | `preset.go:926-929` |
+| Text only | No vision/media capability | `preset.go:1011-1014` |
+
+Single global endpoint — no regional URLs (not in `ProviderRegionURLs`).
+
+## Official provider sources
+
+| Resource | URL |
+|---|---|
+| API documentation | <https://api-docs.deepseek.com/> |
+| Platform / API keys | <https://platform.deepseek.com/api_keys> |
+| Tool calls guide | <https://api-docs.deepseek.com/guides/tool_calls/> |
+| Thinking mode | <https://api-docs.deepseek.com/guides/thinking_mode/> |
+| Coding agent integrations | <https://api-docs.deepseek.com/guides/coding_agents/> |
+
+## Use when / avoid when
+
+- **Use** when you want DeepSeek V4 Pro as the default LLM — verify current context
+  window and capabilities via the DeepSeek API docs; tool calls, thinking mode,
+  OpenAI-compatible API.
+- **Avoid** when you need vision/media capabilities — this preset is text-only.
+  For media creation, register a provider MCP server.
+
+## Verification index
+
+When maintaining this preset, verify in this order:
+
+1. **Model string:** `preset.go:1018` — matches current DeepSeek docs.
+2. **Base URL:** `preset.go:1018` — matches `https://api.deepseek.com`.
+3. **Builtin list:** `preset.go:489-504` — `deepseek` is present at position 4.
+4. **Test assertion:** `preset_test.go:492` — `deepseekPreset()` model is `deepseek-v4-pro`.
+5. **Anatomy:** `ANATOMY.md:50` — `BuiltinPresets()` row enumerates deepseek.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** current models, pricing, rate limits, auth flows.
+- **LingTai-owned (verify in source):** manifest shape, `api_compat`, `base_url`,
+  `DEEPSEEK_API_KEY`, text-only design choice.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: preset-skill-gemini
+description: >
+  Nested lingtai-preset-skill reference for the `gemini` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `gemini` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `gemini` — built-in preset manual
+
+Google Gemini — native adapter, multimodal, tool calling, vision.
+
+## When to read
+
+- Someone asks about the `gemini` built-in preset, its model, auth, or protocol.
+- Verifying Gemini model/pricing information.
+
+## Shipped identity (verify in TUI source)
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `gemini` | `preset.go:1026` |
+| `llm.provider` | `gemini` | `preset.go:1030` |
+| `llm.model` | `gemini-3-flash-preview` | `preset.go:1030` |
+| `llm.api_key_env` | `GEMINI_API_KEY` | `preset.go:1031` |
+| Protocol | **Native Gemini** — NOT OpenAI-compat | `preset.go:1023-1024` |
+| Tier | `3` | `preset.go:1027` |
+| Capabilities | `vision` (native), `web_search` (DuckDuckGo), `skills` default | `preset.go:1033-1038` |
+
+**No OAuth, no base_url, no api_compat.** The kernel's `GeminiAdapter` wraps
+`google.genai.Client` directly (`llm/gemini/adapter.py:702`).
+
+## Kernel adapter architecture
+
+Two session backends:
+1. **Interactions API** (primary, `adapter.py:739`) — server-side conversation state.
+2. **Chat API** (fallback for `json_schema` mode, `adapter.py:762-798`).
+
+The adapter auto-selects thinking config for Gemini 3+ models
+(`_supports_thinking()`, `adapter.py:115-126`).
+
+## Official provider sources
+
+| Topic | URL |
+|---|---|
+| Models and capabilities | <https://ai.google.dev/gemini-api/docs/models> |
+| Pricing and billing | <https://ai.google.dev/gemini-api/docs/pricing> |
+| API key setup | <https://ai.google.dev/gemini-api/docs/api-key> |
+| API reference | <https://ai.google.dev/api> |
+| Python SDK | <https://pypi.org/project/google-genai/> |
+
+Do not embed current model lists, pricing, or quotas — they change frequently.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** models, pricing, rate limits, available model IDs.
+- **LingTai-owned (verify in source):** provider string, adapter class, env var
+  name, capability flags, kernel registration.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: preset-skill-kimi
+description: >
+  Nested lingtai-preset-skill reference for the `kimi` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `kimi` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `kimi` — built-in preset manual
+
+> Progressive-disclosure manual for the `kimi` built-in preset.
+
+## When to read
+
+- Editing or health-checking the `kimi` built-in template preset.
+- Confirming the shipped model string, base URL, or API key env.
+- Needing authoritative Kimi/Moonshot model/pricing/API/auth links.
+
+## Shipped identity (verify in TUI source)
+
+Built through `openAICompatTextPreset` (`preset.go:912-932`).
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `kimi` | `preset.go:1053` |
+| `llm.provider` | `kimi` | `preset.go:922` |
+| `llm.model` | `kimi-for-coding` | `preset.go:1055` |
+| `llm.api_compat` | `openai` | `preset.go:924` |
+| `llm.api_key_env` | `KIMI_CODE_API_KEY` | `preset.go:1055` |
+| `llm.base_url` | `https://api.kimi.com/coding/v1` | `preset.go:1055` |
+| Tier | `3` | `preset.go:1055` |
+| Capabilities | `web_search` (DuckDuckGo), `skills` default | `preset.go:926-929` |
+| Text only | No vision/media capability | `preset.go:1046-1051` |
+
+**Kernel note:** the kernel sets `User-Agent: LingTai-Agent/1.0` for every Kimi
+request to comply with Kimi's Terms of Service (`lingtai-kernel/llm/service.py:272-281`).
+
+## Official provider sources
+
+| Resource | URL |
+|---|---|
+| Platform intro | <https://platform.kimi.com/docs/intro> |
+| API overview | <https://platform.kimi.com/docs/api> |
+| Chat completions reference | <https://platform.kimi.com/docs/api/chat> |
+| Pricing / billing | <https://platform.kimi.com/docs/pricing> |
+| Legacy Moonshot platform | <https://platform.moonshot.cn/docs/intro> |
+
+**Base URL note:** shipped `base_url` is `https://api.kimi.com/coding/v1`.
+Official docs may illustrate `https://api.moonshot.cn/v1` or another endpoint.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** current coding model names, pricing, rate limits.
+- **LingTai-owned (verify in source):** manifest shape, `api_compat`, `base_url`,
+  `KIMI_CODE_API_KEY`, mandatory `User-Agent` header, text-only design choice.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: preset-skill-mimo
+description: >
+  Nested lingtai-preset-skill reference for the `mimo` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `mimo` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `mimo` — built-in preset manual
+
+> Built-in name: `mimo` — index 3 in `BuiltinPresets()` (`preset.go:493`).
+
+## When to read
+
+- Choosing or configuring Xiaomi MiMo as the default LLM.
+- Switching among TUI-exposed MiMo model variants.
+- Debugging API key, endpoint, or vision-capability mismatches.
+
+## Shipped identity (verify in TUI source)
+
+| Field | Value | Source |
+|---|---|---|
+| `llm.provider` | `mimo` | `preset.go:989` |
+| `llm.model` | `mimo-v2.5` | `preset.go:990` |
+| `llm.api_key_env` | `XIAOMI_API_KEY` | `preset.go:998` |
+| `llm.base_url` | `https://api.xiaomimimo.com/v1` | `preset.go:999` |
+| `llm.api_compat` | `openai` | `preset.go:999` |
+| `web_search` | `duckduckgo` | `preset.go:1002` |
+| `vision` | provider `mimo`, model `mimo-v2.5` | `preset.go:1003` |
+
+## TUI model picker
+
+The preset editor exposes three MiMo models (`preset_editor.go:132`):
+
+| Model | Vision |
+|---|---|
+| `mimo-v2.5` | yes (default) |
+| `mimo-v2.5-pro` | no (text-only; 400 on image input) |
+| `mimo-v2-flash` | no (text-only; 400 on image input) |
+
+Vision is gated per-model (`preset_editor.go:198-201`). The kernel dispatches
+MiMo vision through `MiMoVisionService` (kernel `services/vision/mimo.py`).
+
+## Auth / setup
+
+1. Obtain an API key from the Xiaomi MiMo platform.
+2. Store in `~/.lingtai-tui/.env` under `XIAOMI_API_KEY`.
+3. Default `base_url` is pay-as-you-go. For Token Plan (`tp-` prefixed keys),
+   switch to the regional cluster assigned to your subscription.
+
+**Key format:** `sk-*` keys -> `api.xiaomimimo.com`; `tp-*` keys -> Token Plan
+cluster. Wrong combination returns `401 invalid_key`.
+
+## Official provider sources
+
+| Purpose | URL |
+|---|---|
+| Developer docs (LLM-friendly) | <https://platform.xiaomimimo.com/llms.txt> |
+| OpenAI-compat API reference | <https://platform.xiaomimimo.com/docs/zh-CN/api/chat/openai-api> |
+| API reference landing | <https://platform.xiaomimimo.com/api-reference> |
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model IDs, pricing, API schemas, endpoint URLs.
+- **LingTai-owned (verify in source):** preset fields, capability wiring,
+  env-var names, vision service dispatch.
+- **Operational caveat:** changing `llm.model` to a text-only variant without
+  removing `capabilities.vision` causes 400 on vision tool calls.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: preset-skill-minimax
+description: >
+  Nested lingtai-preset-skill reference for the `minimax` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `minimax` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `minimax` — built-in preset manual
+
+> **Manual, not a tool.** The TUI source is authority for shipped preset
+> identity; official MiniMax docs are authority for models, pricing, endpoints,
+> and auth. Do not copy volatile values into this file — link them.
+
+## When to read
+
+- Editing, debugging, or health-checking the `minimax` built-in template preset.
+- Rotating a MiniMax API key, adding a second account, or resolving a
+  CN-vs-INTL region mismatch.
+- Needing the authoritative MiniMax model/pricing/API/auth link.
+
+## Shipped identity (verify in TUI source)
+
+Produced by `minimaxPreset()` (`tui/internal/preset/preset.go`).
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `minimax` | `preset.go:940` |
+| `llm.provider` | `minimax` | `preset.go:936,944` |
+| `llm.model` | `MiniMax-M3` | `preset.go:944` |
+| `llm.api_key_env` | `MINIMAX_API_KEY` | `preset.go:937,945` |
+| `llm.base_url` | `ProviderRegionURLs["minimax"][0].URL` (CN default) | `preset.go:946` |
+| `llm.api_compat` | not set (Anthropic-compatible path) | `preset.go:943-946` |
+| Capabilities | `web_search`, `vision` (provider `minimax`); `skills` default | `preset.go:952-956` |
+
+**Notes:**
+- Default preset: `DefaultPreset()` returns `minimaxPreset()` (`preset.go:1400-1402`).
+- API shape: no `api_compat` override; base URL ends in `/anthropic` — MiniMax
+  is reached through its Anthropic-compatible Messages API.
+
+## Region endpoints
+
+`ProviderRegionURLs` (`preset.go:467-486`); first entry (CN) is default.
+
+| Label | base_url |
+|---|---|
+| CN | `https://api.minimaxi.com/anthropic` |
+| INTL | `https://api.minimax.io/anthropic` |
+
+Region detection: `base_url` containing `minimaxi.com` -> CN; otherwise -> INTL
+(`regionSuffix`, `preset.go:1465-1479`).
+
+**API key slot naming:** default `MINIMAX_API_KEY`; additional keys use
+`MINIMAX_<REGION>_<N>_API_KEY` via `AutoEnvVarName` (`preset.go:1405-1459`).
+
+## Official provider sources
+
+These are provider-owned and refreshable. International docs at
+`platform.minimax.io`, mainland-China at `platform.minimaxi.com`.
+
+| Need | Source |
+|---|---|
+| Anthropic Messages API (intl) | <https://platform.minimax.io/docs/api-reference/text-chat-anthropic> |
+| Anthropic Messages API (CN) | <https://platform.minimaxi.com/docs/api-reference/text-chat-anthropic> |
+| Models list | <https://platform.minimax.io/docs/api-reference/models/anthropic/list-models> |
+| Auth and setup | <https://platform.minimax.io/docs/guides/quickstart-preparation> |
+| Pricing | <https://platform.minimax.io/docs/pricing/overview> |
+| Claude Code base-URL setup | <https://platform.minimax.io/docs/token-plan/claude-code> |
+
+Auth: **Bearer API key** — `Authorization: Bearer <API_KEY>`.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model lineup, pricing, endpoints, region hosts,
+  request/response schema. Re-verify against official links before relying.
+- **LingTai-owned (verify in source):** preset name, summary, default model
+  string, `MINIMAX_API_KEY` slot, `ProviderRegionURLs` entries, region detection,
+  capabilities wiring, "default preset" status.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: preset-skill-nvidia
+description: >
+  Nested lingtai-preset-skill reference for the `nvidia` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `nvidia` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `nvidia` — NVIDIA NIM preset manual
+
+> `nvidia` — a shipped built-in template in `BuiltinPresets()` (`preset.go:489`).
+
+## When to read
+
+- Verifying the `nvidia` preset's stable identity or current behavior.
+- Confirming the correct NVIDIA API Catalog URLs.
+- Understanding the `prompt_cache_key` disable.
+
+## Shipped identity (verify in TUI source)
+
+Built through `openAICompatTextPreset` (`preset.go:912`).
+
+| Field | Value | Source |
+|---|---|---|
+| `name` | `nvidia` | `preset.go:1074` |
+| `llm.provider` | `nvidia` | `preset.go:922` |
+| `llm.model` | `meta/llama-3.3-70b-instruct` | `preset.go:1076` |
+| `llm.api_key_env` | `NVIDIA_API_KEY` | `preset.go:1076` |
+| `llm.base_url` | `https://integrate.api.nvidia.com/v1` | `preset.go:1076` |
+| `llm.api_compat` | `openai` | `preset.go:924` |
+| Capabilities | `web_search` (DuckDuckGo), `skills` default | `preset.go:927-928` |
+
+**Kernel note (`preset.go:1070-1072`):** the kernel registers `"nvidia"` with
+`prompt_cache_key` disabled — NVIDIA NIM rejects that field with HTTP 400.
+
+## Model switching
+
+Default model is `meta/llama-3.3-70b-instruct`. Users clone this preset to
+switch to any NVIDIA API Catalog model ID. The full catalog is at the provider
+listing below; LingTai does not duplicate it.
+
+## Official provider sources
+
+| Resource | URL |
+|---|---|
+| NVIDIA API Catalog | <https://build.nvidia.com> |
+| Available models | <https://build.nvidia.com/models> |
+| API reference (LLM APIs) | <https://docs.api.nvidia.com/nim/reference/llm-apis> |
+| API key generation | <https://build.nvidia.com> -> API key |
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model catalog, pricing, free-tier quotas, API URLs.
+- **LingTai-owned (verify in source):** provider string `"nvidia"`, `api_compat`
+  routing, `prompt_cache_key` disable, `NVIDIA_API_KEY` env name, text-only
+  restriction, DuckDuckGo default.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: preset-skill-openrouter
+description: >
+  Nested lingtai-preset-skill reference for the `openrouter` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `openrouter` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `openrouter` — built-in preset manual
+
+> Progressive-disclosure manual for the `openrouter` built-in preset.
+
+## When to read
+
+- Editing or health-checking the `openrouter` built-in template preset.
+- Confirming the shipped model slug, base URL resolution, or API key env.
+- Needing authoritative OpenRouter model/pricing/API/auth links.
+
+## Shipped identity (verify in TUI source)
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `openrouter` | `preset.go:1081` |
+| `llm.provider` | `openrouter` | `preset.go:1085` |
+| `llm.model` | `z-ai/glm-5.1` | `preset.go:1085` |
+| `llm.api_key_env` | `OPENROUTER_API_KEY` | `preset.go:1086` |
+| `llm.base_url` | `null` (TUI-resolved to `https://openrouter.ai/api/v1`) | `preset.go:1087`; `init.jsonc:35-36` |
+| Capabilities | `web_search` (DuckDuckGo), `skills` default | `preset.go:1092-1095` |
+| Text only | No vision/media | `preset.go:1089-1091` |
+
+OpenRouter does not use the generic `api_compat` field. The manifest sets
+`provider: "openrouter"` and leaves `base_url` as `null`; the TUI/kernel
+resolve this to `https://openrouter.ai/api/v1` (`init.jsonc:35-36`).
+
+## Official provider sources
+
+| Resource | URL |
+|---|---|
+| Models and pricing | <https://openrouter.ai/models> |
+| Models API | `GET https://openrouter.ai/api/v1/models` |
+| API reference | <https://openrouter.ai/docs/api> |
+| Quickstart | <https://openrouter.ai/docs/quickstart> |
+| API keys | <https://openrouter.ai/keys> |
+
+## Provider compatibility contract
+
+The OpenRouter preset is first-class in LingTai: it does not use the generic
+`api_compat` field. The manifest sets `provider: "openrouter"` and leaves
+`base_url` as `null`; the TUI/kernel resolve this to the OpenRouter endpoint
+`https://openrouter.ai/api/v1` (`init.jsonc:35-36`).
+
+OpenRouter's own API is OpenAI-compatible:
+- Primary endpoint: `POST https://openrouter.ai/api/v1/chat/completions`.
+- Authentication: `Authorization: Bearer <OPENROUTER_API_KEY>`.
+- Model values are OpenRouter slugs such as `provider/model`; the shipped
+  default `z-ai/glm-5.1` is one such slug.
+- Optional attribution headers (`HTTP-Referer`, `X-OpenRouter-Title`) are
+  documented in the API reference; the preset does not set them by default.
+
+## Use when / avoid when
+
+- **Use** when you want access to many providers through a single API key and
+  unified billing.
+- **Avoid** when you need vision/media capabilities — this preset is text-only.
+  For media, use a provider-specific preset or register MCP servers.
+
+## Verification index
+
+1. **Model string:** `preset.go:1085` — matches a current slug on <https://openrouter.ai/models>.
+2. **Base URL:** `preset.go:1087` (null) + `init.jsonc:35-36` — resolves to `https://openrouter.ai/api/v1`.
+3. **Builtin list:** `preset.go:489-504` — `openrouter` is present at position 7.
+4. **Test assertion:** `preset_test.go:227` — the 12 built-in preset names include `openrouter`.
+5. **Anatomy:** `ANATOMY.md:50` — `BuiltinPresets()` row enumerates openrouter.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** current models, slugs, pricing, rate limits.
+- **LingTai-owned (verify in source):** manifest shape, TUI-fixed base URL
+  behavior, `api_compat` absence, text-only design choice.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: preset-skill-zhipu
+description: >
+  Nested lingtai-preset-skill reference for the `zhipu` built-in preset.
+  Read when verifying shipped identity, provider sources, and compatibility
+  facts for the `zhipu` template preset.
+version: 1.0.0
+last_changed_at: "2026-07-10T10:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `zhipu` — built-in preset manual
+
+> Thin pointer. Code is truth for the wiring; provider docs are truth for
+> volatile catalogs (models, prices, quotas).
+
+## When to read
+
+- Editing or health-checking the `zhipu` built-in template preset.
+- Confirming region-bound endpoint behavior or env-var slot naming.
+- Needing authoritative Zhipu/GLM model/pricing/API/auth links.
+
+## Shipped identity (verify in TUI source)
+
+From `zhipuPreset()` (`tui/internal/preset/preset.go:961`).
+
+| Field | Value | Source |
+|---|---|---|
+| Preset name | `zhipu` | `preset.go:961` |
+| `llm.provider` | `zhipu` | `preset.go:961` |
+| `llm.model` | `GLM-5.2` | `preset.go:961` |
+| `llm.api_compat` | `openai` | OpenAI Chat Completions protocol |
+| `llm.api_key_env` | `ZHIPU_API_KEY` | `preset.go:961` |
+| `llm.base_url` | `ProviderRegionURLs["zhipu"][0].URL` (CN default) | `preset.go:478` |
+| Capabilities | `web_search` (provider `zhipu`), `vision` (provider `zhipu`), `skills` default | `preset.go:961` |
+
+## Regional endpoints
+
+`ProviderRegionURLs["zhipu"]` (`preset.go:478`). Keys are region-bound — not
+interchangeable.
+
+| Region | Host | base_url |
+|---|---|---|
+| CN | `open.bigmodel.cn` | `https://open.bigmodel.cn/api/coding/paas/v4` |
+| INTL | `api.z.ai` | `https://api.z.ai/api/coding/paas/v4` |
+
+Region detection (`regionSuffix`, `preset.go:1465`): `base_url` containing
+`api.z.ai` -> INTL, otherwise -> CN. Env-var slots: `ZHIPU_CN_<N>_API_KEY` /
+`ZHIPU_INTL_<N>_API_KEY` via `AutoEnvVarName` (`preset.go:1421`).
+
+## Official provider sources
+
+| Topic | International (Z.AI) | Mainland (BigModel) |
+|---|---|---|
+| Overview / models | <https://docs.z.ai/devpack/overview> | <https://docs.bigmodel.cn/cn/coding-plan/overview> |
+| Quick start / API key | <https://docs.z.ai/devpack/quick-start> | <https://docs.bigmodel.cn/cn/coding-plan/quick-start> |
+| Pricing | <https://z.ai/subscribe> | <https://docs.bigmodel.cn/cn/coding-plan/faq.md> |
+| API reference | <https://docs.z.ai/api-reference> | <https://docs.bigmodel.cn/api-reference> |
+
+This preset uses the OpenAI path (`api_compat: openai`) at `/api/coding/paas/v4`.
+
+## Related capabilities
+
+The same Zhipu coding-plan key unlocks MCP servers (vision, web search, web
+reader, zread). That is a separate concern — see `swiss-knife/reference/zhipu-coding-plan/SKILL.md`.
+
+## Maintenance checklist
+
+- **Provider-owned (refresh):** model names, pricing, plan tiers, quotas, doc paths.
+- **LingTai-owned (verify in source):** preset wiring, two regional `base_url`s,
+  `api_compat`, `ZHIPU_*_<N>_API_KEY` env-var rules.

--- a/tui/internal/preset/skills/lingtai-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/SKILL.md
@@ -23,6 +23,7 @@ description: >
   working directory, not through a recipe round-trip).
 version: 3.2.0
 last_changed_at: "2026-06-02T00:08:39-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # lingtai-recipe: Recipes and How to Publish Them

--- a/tui/internal/preset/skills/lingtai-recipe/reference/export-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/reference/export-recipe/SKILL.md
@@ -6,6 +6,7 @@ description: >
   collection, bundle authoring, validation, git initialization, and handoff.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:08:39-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Exporting a Recipe

--- a/tui/internal/preset/skills/lingtai-recipe/reference/recipe-format/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/reference/recipe-format/SKILL.md
@@ -7,6 +7,7 @@ description: >
   testing, and publishing.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:08:39-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Recipe Format Reference

--- a/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
@@ -51,6 +51,7 @@ description: >
       narrative only ("the kernel writes this file; we read it").
 version: 0.1.0
 last_changed_at: "2026-06-24T01:56:50-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # LingTai (Go) Anatomy — the Convention

--- a/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
@@ -10,6 +10,7 @@ description: >
 version: 1.0.0
 tags: [tui, help, slash-commands, reference, palette, lingtai-tui]
 last_changed_at: "2026-06-09T04:21:55-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # lingtai-tui help — canonical TUI reference

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
@@ -7,6 +7,7 @@ description: >
   human is ready to begin or continue the tutorial.
 version: 2.0.1
 last_changed_at: "2026-06-02T00:34:40-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Router

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/agent-runtime/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/agent-runtime/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested tutorial-guide reference for lessons 4–6: init.json, lingtai-agent run, heartbeat and signal files, TUI runtime wrapping, and system prompt identity.
 version: 1.0.0
 last_changed_at: "2026-06-28T00:01:05-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Agent Runtime Lessons

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/capabilities/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/capabilities/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested tutorial-guide reference for lesson 9: avatars, network exercises, and dynamic capability demonstrations.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:34:40-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Capabilities Lesson

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/communication/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/communication/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested tutorial-guide reference for lesson 7: filesystem email, message flow, and external addon bridges.
 version: 1.0.0
 last_changed_at: "2026-06-12T13:46:46-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Communication Lesson

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/memory-and-molt/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/memory-and-molt/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested tutorial-guide reference for lesson 8: intrinsics, memory layers, molt, charge, and lifecycle continuity.
 version: 1.0.0
 last_changed_at: "2026-06-08T22:45:25-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Memory and Molt Lesson

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/operations-and-graduation/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/operations-and-graduation/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested tutorial-guide reference for lessons 10–12: TUI commands, lifecycle exercises, addons, external connections, and graduation.
 version: 1.0.0
 last_changed_at: "2026-06-02T00:34:40-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Operations and Graduation Lessons

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/orientation/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/orientation/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested tutorial-guide reference for lessons 1–3: welcome, live architecture discovery, global directory, project directory, and agent working directory.
 version: 1.0.0
 last_changed_at: "2026-06-10T19:45:10-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Tutorial Guide — Orientation Lessons

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -19,6 +19,7 @@ description: >
 version: 2.4.0
 tags: [utilities, umbrella, toolkit, nested-skill]
 last_changed_at: "2026-06-23T17:01:03-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Swiss Knife — Utility Toolkit Router

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
@@ -15,6 +15,7 @@ version: 3.0.0
 allowed-tools: Bash(python3 *) Bash(curl *) Bash(pip *) Bash(pip3 *)
 tags: [academic, research, arxiv, crossref, openalex, semantic-scholar, core, pubmed, unpaywall, doi, pdf, citation, pipeline, europe-pmc, nasa-ads, inspire-hep, nested-skill]
 last_changed_at: "2026-06-08T20:23:41-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Academic Research

--- a/tui/internal/preset/skills/swiss-knife/reference/dj/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/dj/SKILL.md
@@ -4,6 +4,7 @@ description: Nested swiss-knife reference for composing one music track that res
 version: 1.1.0
 tags: [media-creation, music, journal, on-demand]
 last_changed_at: "2026-06-02T02:10:59-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # DJ — On-demand journal-track composer

--- a/tui/internal/preset/skills/swiss-knife/reference/find-something-to-do/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/find-something-to-do/SKILL.md
@@ -3,6 +3,7 @@ name: find-something-to-do
 description: "Nested swiss-knife reference for idle curiosity practice. When you're idle and the water is flat — two doors. One leads to quiet noticing. The other leads to poking things until they squeak. Both are real. Neither is a productivity tool. Read this when no human is waiting and you want an invitation to emerge."
 version: 0.2.0
 last_changed_at: "2026-06-02T02:10:59-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Find Something to Do

--- a/tui/internal/preset/skills/swiss-knife/reference/headless-bot/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/headless-bot/SKILL.md
@@ -10,6 +10,7 @@ description: >
 version: 1.1.0
 tags: [utilities, bot, telegram, mcp, headless, bootstrap]
 last_changed_at: "2026-06-01T02:00:30-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Headless Bot Project

--- a/tui/internal/preset/skills/swiss-knife/reference/html-report/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/html-report/SKILL.md
@@ -12,6 +12,7 @@ description: >
 version: 1.0.0
 tags: [html, report, mathjax, deliverable, artifact]
 last_changed_at: "2026-05-31T21:29:38-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # HTML Report — Standalone Artifacts for Humans

--- a/tui/internal/preset/skills/swiss-knife/reference/listen/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/listen/SKILL.md
@@ -10,6 +10,7 @@ description: >
 version: 1.0.0
 tags: [audio, transcribe, whisper, librosa, music-analysis, nested-skill]
 last_changed_at: "2026-06-02T11:16:04-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # listen

--- a/tui/internal/preset/skills/swiss-knife/reference/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/minimax-cli/SKILL.md
@@ -9,6 +9,7 @@ description: >
 version: 2.1.0
 tags: [manual, cli, minimax, mmx, image, video, music, speech, tts, vision, media-generation]
 last_changed_at: "2026-06-02T11:16:04-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # minimax-cli

--- a/tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md
@@ -13,6 +13,7 @@ description: >
 version: 1.0.0
 tags: [presets, health-check, diagnostics, read-only, connectivity]
 last_changed_at: "2026-06-08T19:56:00-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Preset Health Check (read-only)

--- a/tui/internal/preset/skills/swiss-knife/reference/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/token-usage/SKILL.md
@@ -6,6 +6,7 @@ description: >
 version: 2.1.0
 tags: [python, cost, tokens, litellm, budget, tools, agents]
 last_changed_at: "2026-06-23T17:01:03-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Token Usage, Cost, and Agentic-Intensity Reports v2

--- a/tui/internal/preset/skills/swiss-knife/reference/vision/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/vision/SKILL.md
@@ -12,6 +12,7 @@ description: >
 version: 1.0.0
 tags: [vision, image, ocr, vlm, decision-tree, nested-skill]
 last_changed_at: "2026-06-02T11:16:04-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # vision (router)

--- a/tui/internal/preset/skills/swiss-knife/reference/xiaomi-mimo/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/xiaomi-mimo/SKILL.md
@@ -24,6 +24,7 @@ description: >
   servers**; everything is HTTPS chat-completions.
 version: 2.0.0
 last_changed_at: "2026-05-31T21:29:38-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # xiaomi-mimo

--- a/tui/internal/preset/skills/swiss-knife/reference/zhipu-coding-plan/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/zhipu-coding-plan/SKILL.md
@@ -10,6 +10,7 @@ description: >
   registration is owned by the `mcp-manual` skill (kernel capability).
 version: 1.0.0
 last_changed_at: "2026-05-31T21:29:38-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # zhipu-coding-plan

--- a/tui/internal/preset/skills/textbook-distillation/SKILL.md
+++ b/tui/internal/preset/skills/textbook-distillation/SKILL.md
@@ -15,6 +15,7 @@ description: >
 version: 1.0.0
 tags: [learning, study, textbook, lecture-notes, html, curriculum, self-paced]
 last_changed_at: "2026-06-08T22:45:29-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Textbook Distillation — Self-Paced Learning Tracks

--- a/tui/internal/preset/skills/web-browsing/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/SKILL.md
@@ -8,6 +8,7 @@ description: >
   or you are composing a multi-step web/research pipeline.
 version: 3.1.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # web-browsing — Router

--- a/tui/internal/preset/skills/web-browsing/reference/maintenance-bundles/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/reference/maintenance-bundles/SKILL.md
@@ -6,6 +6,7 @@ description: >
   explicit decision flowchart.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Web Browsing Maintenance and Assets Reference

--- a/tui/internal/preset/skills/web-browsing/reference/routing-and-sites/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/reference/routing-and-sites/SKILL.md
@@ -5,6 +5,7 @@ description: >
   recommendations, known limitations/gotchas, and real-time data endpoints.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Web Browsing Routing and Site Reference

--- a/tui/internal/preset/skills/web-browsing/reference/tier-quick-refs/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/reference/tier-quick-refs/SKILL.md
@@ -6,6 +6,7 @@ description: >
   stealth, Tier 4 Jina/Firecrawl, and Tier 5 AI-native search.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # Web Browsing Tier Quick References


### PR DESCRIPTION
## Summary

- add a concise `lingtai-preset-skill` router plus one nested manual for each of the 12 TUI-shipped built-in preset templates
- keep provider-owned model, pricing, API, and authentication details behind official source links while documenting LingTai-owned contracts and exact repository paths
- add the same `maintenance` frontmatter contract to all 66 bundled TUI skills so stale information routes through `lingtai-issue-report` with per-issue consent and secret hygiene
- add deterministic tests for the 12-way builtin/router/extraction bijection, child naming and size budgets, a lean non-duplicating parent, maintenance metadata, and the dedicated `codex-pool` classified-model contract; update preset anatomy

This is a docs/tests/anatomy-only change. It does not modify production preset, parser, provider, editor, locale, or runtime behavior.

## Validation

- parent + 12 child manuals: agent-library validator with `--require-last-changed-at` — 13/13 pass
- `go test ./internal/preset -run 'TestPresetSkillRouter_|TestCodexPool|TestBundledSkills' -count=1`
- `go test ./internal/preset ./internal/tui -count=1`
- `go test ./... -count=1`
- `go vet ./internal/preset/ ./internal/tui/`
- `gofmt -d internal/preset/preset_skill_router_test.go internal/preset/skill_metadata_test.go`
- `git diff --check origin/main..HEAD`
- deterministic scans: 66/66 exact maintenance entries; 66/66 `last_changed_at`; 13 router-tree manuals; no `1M context window`, `free-tier catalog`, private paths, internal agent names, or production `.go` changes

One initial post-rebase full-suite run hit the unrelated scheduling-sensitive `TestPortalURLTimeoutKillsChild` (`fake portal never wrote its pid`). The focused/package tests had already passed. The test was then isolated with `-count=10` and the complete suite was rerun before merge; final rerun evidence is recorded in the PR checks/status.

## Review

Independent GLM review initially identified two volatile prose claims (`1M context window` and `free-tier catalog`). Both were removed/neutralized in a surgical two-file amendment. A separate narrow GLM fix verification returned **PASS**, and stable patch IDs prove the rebased commit preserves the reviewed patch exactly.

## Non-goals

- no changes to preset selection, provider wiring, saved-preset behavior, or runtime model semantics
- no embedded volatile provider catalog, price, quota, or context-window snapshots
- no convergence of the dedicated `codex-pool` preset into another built-in preset
