### PR TITLE
fix(release): align Homebrew formula license with Apache-2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
             desc "Terminal UI for the Lingtai AI agent framework"
             homepage "https://github.com/Lingtai-AI/lingtai"
             version "${VERSION}"
-            license "MIT"
+            license "Apache-2.0"
 
             url "https://github.com/Lingtai-AI/lingtai/archive/refs/tags/${TAG}.tar.gz"
             sha256 "${SHA}"


### PR DESCRIPTION
## Summary

- align the active release workflow's generated Homebrew formula license with the repository's Apache-2.0 `LICENSE`
- leave historical design/plan documents unchanged because they are not the shipping source of truth

## Why

The v0.10.6 release gate found that `.github/workflows/release.yml` would generate a formula declaring `MIT`, while the repository is Apache License 2.0. Tagging without this fix would publish incorrect package metadata to the Homebrew tap.

## Validation

- `git diff --check`
- parsed `.github/workflows/release.yml` with PyYAML
- asserted `LICENSE` begins with `Apache License`
- asserted the active formula template contains `license "Apache-2.0"`
- exact diff is one line in the active release template
- implementation delegated to and model-verified as `claude-opus-4-8`; reviewed against the `lingtai-taste` smallest-honest-scope/root-cause criteria

The generation-2 TUI/Portal gate had already passed its other 13 checks (tests, builds, cross-compilation, vet, asset/workflow/migration consistency). Full exact-candidate gates will be rerun after this PR is merged; this PR does not publish or merge anything by itself.
