### PR TITLE
fix(tui): detect Codex OAuth presets by provider

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -2030,12 +2030,10 @@ func codexOAuthConfigured(globalDir string) bool {
 }
 
 // validateCodexAuthForAgents scans all agent directories under projectDir for
-// init.json files whose active/default preset is codex, and validates the
-// SPECIFIC Codex account each such preset binds to (manifest.llm.codex_auth_path,
-// falling back to the legacy file). If any agent's bound account is missing or
-// invalid, returns a warning naming that agent. A different, validly-bound
-// account never suppresses (or triggers) the warning. Returns "" when all
-// codex-using agents have a usable bound account.
+// init.json files whose active/default preset declares a Codex provider. The
+// codex provider validates its bound account; codex-pool requires any valid
+// stored account. Returns a warning naming the first agent without usable
+// Codex credentials.
 func validateCodexAuthForAgents(globalDir, projectDir string) string {
 	entries, _ := os.ReadDir(projectDir)
 	for _, e := range entries {
@@ -2061,14 +2059,14 @@ func validateCodexAuthForAgents(globalDir, projectDir string) string {
 		}
 		for _, key := range []string{"default", "active"} {
 			presetRef, _ := presetBlock[key].(string)
-			if presetRef == "" || !strings.Contains(presetRef, "codex") {
+			if presetRef == "" {
 				continue
 			}
-			// Resolve the preset's bound account (#415) and validate just that
-			// file; warn (localized, #412) naming the agent only when its own
-			// bound account is missing — a different account staying invalid
-			// no longer condemns this agent.
-			if !codexPresetRefAuthValid(globalDir, presetRef) {
+			// Identify Codex presets by their declared provider, not their file
+			// name. Custom OpenAI-compatible presets may legitimately include
+			// "codex" in the name, while a true Codex preset may not.
+			usesCodex, authValid := codexPresetRefAuthStatus(globalDir, presetRef)
+			if usesCodex && !authValid {
 				return i18n.TF("codex.oauth_unverified_agent", e.Name())
 			}
 		}
@@ -2076,28 +2074,33 @@ func validateCodexAuthForAgents(globalDir, projectDir string) string {
 	return ""
 }
 
-// codexPresetRefAuthValid loads the preset file at presetRef and validates the
-// Codex OAuth account it binds to (manifest.llm.codex_auth_path, empty →
-// legacy fallback). When the preset file can't be read (e.g. a transient path),
-// it falls back to validating the legacy account so a missing preset file
-// doesn't spuriously fail an agent that may still resolve at launch.
-func codexPresetRefAuthValid(globalDir, presetRef string) bool {
+// codexPresetRefAuthStatus reports whether presetRef declares a Codex OAuth
+// provider and, when it does, whether its credentials are valid.
+func codexPresetRefAuthStatus(globalDir, presetRef string) (usesCodex, authValid bool) {
 	abs := presetRef
 	if strings.HasPrefix(abs, "~/") {
 		if home, err := os.UserHomeDir(); err == nil {
 			abs = filepath.Join(home, abs[2:])
 		}
 	}
-	ref := ""
-	if data, err := os.ReadFile(abs); err == nil {
-		var p map[string]interface{}
-		if json.Unmarshal(data, &p) == nil {
-			if manifest, ok := p["manifest"].(map[string]interface{}); ok {
-				if llm, ok := manifest["llm"].(map[string]interface{}); ok {
-					ref, _ = llm["codex_auth_path"].(string)
-				}
-			}
-		}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return false, true
 	}
-	return codexAuthPathValid(resolveCodexAuthPath(globalDir, ref))
+	var p map[string]interface{}
+	if json.Unmarshal(data, &p) != nil {
+		return false, true
+	}
+	manifest, _ := p["manifest"].(map[string]interface{})
+	llm, _ := manifest["llm"].(map[string]interface{})
+	provider, _ := llm["provider"].(string)
+	switch provider {
+	case "codex":
+		ref, _ := llm["codex_auth_path"].(string)
+		return true, codexAuthPathValid(resolveCodexAuthPath(globalDir, ref))
+	case "codex-pool", "codex_pool":
+		return true, hasAnyCodexAccount(globalDir)
+	default:
+		return false, true
+	}
 }

--- a/tui/internal/tui/app_test.go
+++ b/tui/internal/tui/app_test.go
@@ -1,10 +1,83 @@
 package tui
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 )
+
+func writeAgentPresetFixture(t *testing.T, projectDir, presetName, provider string) {
+	t.Helper()
+	presetDir := filepath.Join(projectDir, "presets")
+	if err := os.MkdirAll(presetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	presetPath := filepath.Join(presetDir, presetName+".json")
+	presetDoc := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"llm": map[string]interface{}{"provider": provider},
+		},
+	}
+	presetRaw, _ := json.Marshal(presetDoc)
+	if err := os.WriteFile(presetPath, presetRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agentDir := filepath.Join(projectDir, "test-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initDoc := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"preset": map[string]interface{}{
+				"active":  presetPath,
+				"default": presetPath,
+			},
+		},
+	}
+	initRaw, _ := json.Marshal(initDoc)
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), initRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateCodexAuthForAgentsIgnoresCustomPresetNamedCodex(t *testing.T) {
+	projectDir := t.TempDir()
+	writeAgentPresetFixture(t, projectDir, "codex-pro", "custom")
+
+	if got := validateCodexAuthForAgents(t.TempDir(), projectDir); got != "" {
+		t.Fatalf("custom preset named codex-pro produced OAuth warning: %q", got)
+	}
+}
+
+func TestValidateCodexAuthForAgentsChecksProviderNotPresetName(t *testing.T) {
+	projectDir := t.TempDir()
+	writeAgentPresetFixture(t, projectDir, "subscription", "codex")
+
+	got := validateCodexAuthForAgents(t.TempDir(), projectDir)
+	if !strings.Contains(got, "test-agent") {
+		t.Fatalf("true Codex provider with non-codex name warning = %q", got)
+	}
+}
+
+func TestValidateCodexAuthForAgentsAcceptsPoolWithAnyAccount(t *testing.T) {
+	globalDir := t.TempDir()
+	writeStubCodexToken(
+		t,
+		filepath.Join(globalDir, codexAuthSubdir, "work.json"),
+		"work@example.com",
+	)
+	projectDir := t.TempDir()
+	writeAgentPresetFixture(t, projectDir, "pool", "codex-pool")
+
+	if got := validateCodexAuthForAgents(globalDir, projectDir); got != "" {
+		t.Fatalf("Codex pool with a valid account produced OAuth warning: %q", got)
+	}
+}
 
 // runCmd executes a tea.Cmd and returns the message it produces (nil for a nil
 // cmd). Used to inspect what command an Update returned without running a full


### PR DESCRIPTION
## Summary

- detect Codex OAuth usage from `manifest.llm.provider` instead of the preset name or path
- avoid false `⚠ Codex OAuth 未验证` warnings for custom presets whose names contain `codex`
- validate `codex` and `codex-pool` credentials using their respective authentication rules

## Why

In v0.10.6, startup validation identifies Codex presets by checking whether the preset reference contains `codex`. This causes custom provider presets such as `codex-pro` to be incorrectly treated as Codex OAuth presets.

This is a standalone follow-up to the implementation previously included in PR #608 at commit [`512fe17d`](https://github.com/Lingtai-AI/lingtai/pull/608/changes/512fe17d3d5fef45725e58d2ea02fd7b536ffb9d).

The original implementation was reviewed against the current `main` branch. The updated version follows the current `codex-pool` behavior, where any valid stored Codex account satisfies pool authentication.

## Scope

This PR only changes startup Codex credential detection and adds focused regression coverage.

It does not change preset schemas, credential storage, setup flows, or runtime provider behavior.

## Validation

```text
cd tui
go test ./internal/tui -run '^TestValidateCodexAuthForAgents' -count=1
go test ./internal/tui ./internal/preset -count=1
git diff --check
```

Verified that:

- a custom provider preset named `codex-pro` does not trigger the warning
- a preset using the `codex` provider still requires valid credentials
- a `codex-pool` preset accepts a valid stored account