### PR TITLE
fix(tui): bound external disk refresh scans

### DIFF
--- a/tui/internal/fs/mail.go
+++ b/tui/internal/fs/mail.go
@@ -108,9 +108,19 @@ type MailCache struct {
 	inboxDir  string
 	sentDir   string
 	outboxDir string
+
+	// lastFullSentScan records the last time Refresh walked the entire sent/
+	// tree. Pending outbox messages still get exact sent/<id>/message.json checks
+	// every refresh, but historical sent mail is budgeted so the 1s TUI refresh
+	// loop does not repeatedly full-scan large external-disk mailboxes.
+	lastFullSentScan time.Time
 }
 
 // NewMailCache creates an empty cache for the given human directory.
+// mailCacheFullSentScanInterval budgets expensive full sent/ scans in
+// MailCache.Refresh. Tests override this package var.
+var mailCacheFullSentScanInterval = 10 * time.Second
+
 func NewMailCache(humanDir string) MailCache {
 	return MailCache{
 		seen:      make(map[string]int),
@@ -127,24 +137,33 @@ func NewMailCache(humanDir string) MailCache {
 // Delivered flag flipped from false to true in place (no duplicate entry).
 func (c MailCache) Refresh() MailCache {
 	out := MailCache{
-		seen:      make(map[string]int, len(c.seen)+16),
-		Messages:  make([]MailMessage, len(c.Messages)),
-		humanDir:  c.humanDir,
-		inboxDir:  c.inboxDir,
-		sentDir:   c.sentDir,
-		outboxDir: c.outboxDir,
+		seen:             make(map[string]int, len(c.seen)+16),
+		Messages:         make([]MailMessage, len(c.Messages)),
+		humanDir:         c.humanDir,
+		inboxDir:         c.inboxDir,
+		sentDir:          c.sentDir,
+		outboxDir:        c.outboxDir,
+		lastFullSentScan: c.lastFullSentScan,
 	}
 	copy(out.Messages, c.Messages)
 	for k, v := range c.seen {
 		out.seen[k] = v
 	}
 
-	// Order matters: scan outbox first so messages appear immediately after send.
-	// Then inbox and sent — for any mailbox id previously seen in outbox that now
-	// appears in sent, the scan flips Delivered to true in place.
+	// Order matters: scan outbox first so messages appear immediately after send,
+	// then inbox. Pending outbox messages get exact sent/<id>/message.json checks
+	// on every refresh so their Delivered flag flips promptly after pickup without
+	// forcing a full sent/ scan every second. Historical sent/ discovery is budgeted
+	// below because large external-disk sent folders can dominate the TUI loop.
 	out.scanFolder(out.outboxDir, false /* delivered */)
 	out.scanFolder(out.inboxDir, true)
-	out.scanFolder(out.sentDir, true)
+	out.markDeliveredFromSentIDs()
+
+	now := time.Now()
+	if out.lastFullSentScan.IsZero() || now.Sub(out.lastFullSentScan) >= mailCacheFullSentScanInterval {
+		out.scanFolder(out.sentDir, true)
+		out.lastFullSentScan = now
+	}
 
 	// Sort by ReceivedAt (RFC3339 strings sort lexicographically).
 	sort.Slice(out.Messages, func(i, j int) bool {
@@ -155,6 +174,7 @@ func (c MailCache) Refresh() MailCache {
 	// which could diverge from the directory name if a future kernel rewrote
 	// the JSON during pickup. MailboxID is set to the directory name at write
 	// time in WriteMail and never mutated.
+	out.seen = make(map[string]int, len(out.Messages))
 	for i, m := range out.Messages {
 		out.seen[m.MailboxID] = i
 	}
@@ -196,6 +216,27 @@ func (c *MailCache) scanFolder(folder string, delivered bool) {
 		msg.Delivered = delivered
 		c.seen[name] = len(c.Messages)
 		c.Messages = append(c.Messages, msg)
+	}
+}
+
+// markDeliveredFromSentIDs checks only the exact sent/<mailbox-id>/message.json
+// paths for messages already visible as pending/undelivered. This preserves the
+// immediate outbox→sent delivered-state transition without a full sent/ walk.
+func (c *MailCache) markDeliveredFromSentIDs() {
+	for i := range c.Messages {
+		if c.Messages[i].Delivered {
+			continue
+		}
+		mailboxID := c.Messages[i].MailboxID
+		if mailboxID == "" {
+			mailboxID = c.Messages[i].ID
+		}
+		if mailboxID == "" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(c.sentDir, mailboxID, "message.json")); err == nil {
+			c.Messages[i].Delivered = true
+		}
 	}
 }
 

--- a/tui/internal/fs/mail_test.go
+++ b/tui/internal/fs/mail_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // mailboxIDPattern matches the short mailbox id shape produced by
@@ -316,6 +317,94 @@ func TestMailCache_FlipsDeliveredOnOutboxToSentTransition(t *testing.T) {
 	}
 	if !cache.Messages[0].Delivered {
 		t.Errorf("after transition: Delivered = false, want true")
+	}
+}
+
+func TestMailCache_FlipsPendingSentIDWithoutFullSentScan(t *testing.T) {
+	humanDir := t.TempDir()
+	oldInterval := mailCacheFullSentScanInterval
+	mailCacheFullSentScanInterval = time.Hour
+	t.Cleanup(func() { mailCacheFullSentScanInterval = oldInterval })
+
+	outboxMsgDir := filepath.Join(humanDir, "mailbox", "outbox", "msg-transit-budgeted")
+	if err := os.MkdirAll(outboxMsgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	msg := MailMessage{
+		ID: "msg-transit-budgeted", MailboxID: "msg-transit-budgeted",
+		From: "human", To: []string{"alice"}, Subject: "in-transit", Message: "hi",
+		Type: "normal", ReceivedAt: "2026-04-21T10:00:00.000Z",
+	}
+	data, _ := json.Marshal(msg)
+	if err := os.WriteFile(filepath.Join(outboxMsgDir, "message.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewMailCache(humanDir).Refresh()
+	if len(cache.Messages) != 1 || cache.Messages[0].Delivered {
+		t.Fatalf("first refresh = %#v, want one pending outbox message", cache.Messages)
+	}
+
+	// Add unrelated sent history after the initial full scan. If the next refresh
+	// still full-scans sent/ despite the budget, this message would appear.
+	historyDir := filepath.Join(humanDir, "mailbox", "sent", "sent-history-after-scan")
+	if err := os.MkdirAll(historyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	history := MailMessage{ID: "sent-history-after-scan", MailboxID: "sent-history-after-scan", From: "human", To: []string{"bob"}, ReceivedAt: "2026-04-21T10:01:00.000Z"}
+	historyData, _ := json.Marshal(history)
+	if err := os.WriteFile(filepath.Join(historyDir, "message.json"), historyData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate recipient pickup of the pending outbox message.
+	transitSentDir := filepath.Join(humanDir, "mailbox", "sent", "msg-transit-budgeted")
+	if err := os.Rename(outboxMsgDir, transitSentDir); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	cache = cache.Refresh()
+	if len(cache.Messages) != 1 {
+		t.Fatalf("after budgeted refresh len = %d, want 1 (unrelated sent history should wait for full scan)", len(cache.Messages))
+	}
+	if !cache.Messages[0].Delivered {
+		t.Fatalf("pending sent-id exact check did not flip Delivered")
+	}
+}
+
+func TestMailCache_PeriodicFullSentScanDiscoversHistory(t *testing.T) {
+	humanDir := t.TempDir()
+	oldInterval := mailCacheFullSentScanInterval
+	mailCacheFullSentScanInterval = time.Hour
+	t.Cleanup(func() { mailCacheFullSentScanInterval = oldInterval })
+
+	cache := NewMailCache(humanDir).Refresh()
+	if len(cache.Messages) != 0 {
+		t.Fatalf("initial len = %d, want 0", len(cache.Messages))
+	}
+
+	sentDir := filepath.Join(humanDir, "mailbox", "sent", "sent-later")
+	if err := os.MkdirAll(sentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	msg := MailMessage{ID: "sent-later", MailboxID: "sent-later", From: "human", To: []string{"alice"}, ReceivedAt: "2026-04-21T09:30:00.000Z"}
+	data, _ := json.Marshal(msg)
+	if err := os.WriteFile(filepath.Join(sentDir, "message.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache = cache.Refresh()
+	if len(cache.Messages) != 0 {
+		t.Fatalf("budgeted refresh discovered sent history early: len = %d, want 0", len(cache.Messages))
+	}
+
+	cache.lastFullSentScan = time.Now().Add(-2 * time.Hour)
+	cache = cache.Refresh()
+	if len(cache.Messages) != 1 {
+		t.Fatalf("after interval len = %d, want 1", len(cache.Messages))
+	}
+	if !cache.Messages[0].Delivered {
+		t.Fatalf("sent history Delivered = false, want true")
 	}
 }
 

--- a/tui/internal/inventory/inventory.go
+++ b/tui/internal/inventory/inventory.go
@@ -25,6 +25,11 @@ const (
 	RoleUnknown Role = "?"
 )
 
+var (
+	inventorySlowThreshold = 500 * time.Millisecond
+	maxIMIdentityFiles     = 8
+)
+
 // Options controls inventory conversion. FilterDir is a project root, not a
 // .lingtai directory. SelfPID is excluded so list never reports itself when a
 // test or wrapper command happens to match the process pattern.
@@ -81,6 +86,7 @@ type Record struct {
 	AdminSummary   string
 	IMHandles      string
 	ReadError      string
+	SlowFields     []string
 
 	CreatedAt          string
 	MoltCount          int
@@ -223,33 +229,36 @@ func enrichRecord(r *Record) {
 	r.AgentName = fallback
 	r.AdminSummary = "unknown"
 
-	node, err := fs.ReadAgent(r.AgentDir)
+	start := time.Now()
+	node, raw, err := readAgentManifestOnce(r.AgentDir)
+	noteSlow(r, "agent_json", start)
 	if err == nil {
 		r.Address = firstNonEmpty(node.Address, fallback)
 		r.AgentName = firstNonEmpty(node.AgentName, fallback)
 		r.Nickname = node.Nickname
 		r.State = node.State
 		r.IsHuman = node.IsHuman
-	} else {
-		r.ReadError = err.Error()
-	}
-
-	raw, err := fs.ReadAgentRaw(r.AgentDir)
-	if err != nil {
-		if r.ReadError == "" {
-			r.ReadError = err.Error()
-		}
-	} else {
 		r.IsOrchestrator = fs.IsOrchestratorManifest(raw)
 		r.AdminSummary = SummarizeAdmin(raw["admin"])
 		if r.IsOrchestrator {
 			r.IsHuman = false
 		}
-		r.IMHandles = SummarizeIMIdentities(r.AgentDir)
+		start = time.Now()
+		var truncated bool
+		r.IMHandles, truncated = summarizeIMIdentities(r.AgentDir, maxIMIdentityFiles)
+		noteSlow(r, "mcp_identities", start)
+		if truncated {
+			appendSlowField(r, "mcp_identities_truncated")
+		}
 		r.CreatedAt = rawString(raw, "created_at")
 		r.MoltCount, r.MoltCountAvailable = rawInt(raw, "molt_count")
+	} else {
+		r.ReadError = err.Error()
 	}
+
+	start = time.Now()
 	status := fs.ReadStatus(r.AgentDir)
+	noteSlow(r, "status", start)
 	ctx := status.Tokens.Context
 	if ctx.WindowSize > 0 {
 		r.ContextTotalTokens = ctx.TotalTokens
@@ -258,8 +267,64 @@ func enrichRecord(r *Record) {
 		r.ContextAvailable = true
 	}
 	r.Role = RoleFor(*r)
+	start = time.Now()
 	r.Heartbeat = fs.ReadHeartbeat(r.AgentDir, fs.AgentAliveThresholdSec)
+	noteSlow(r, "heartbeat", start)
+	start = time.Now()
 	r.LockExists = fileExists(filepath.Join(r.AgentDir, ".agent.lock"))
+	noteSlow(r, "lock", start)
+}
+
+type inventoryAgentManifest struct {
+	AgentName    string           `json:"agent_name"`
+	Nickname     string           `json:"nickname"`
+	Address      string           `json:"address"`
+	State        string           `json:"state"`
+	Admin        *json.RawMessage `json:"admin,omitempty"`
+	Capabilities json.RawMessage  `json:"capabilities"`
+	Location     *fs.Location     `json:"location,omitempty"`
+}
+
+func readAgentManifestOnce(agentDir string) (fs.AgentNode, map[string]interface{}, error) {
+	data, err := os.ReadFile(filepath.Join(agentDir, ".agent.json"))
+	if err != nil {
+		return fs.AgentNode{}, nil, fmt.Errorf("read manifest: %w", err)
+	}
+	var manifest inventoryAgentManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fs.AgentNode{}, nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fs.AgentNode{}, nil, fmt.Errorf("parse manifest raw: %w", err)
+	}
+	isHuman := manifest.Admin == nil || string(*manifest.Admin) == "null"
+	node := fs.AgentNode{
+		Address:      manifest.Address,
+		AgentName:    manifest.AgentName,
+		Nickname:     manifest.Nickname,
+		State:        manifest.State,
+		IsHuman:      isHuman,
+		Capabilities: fs.ParseCapabilities(manifest.Capabilities),
+		Location:     manifest.Location,
+		WorkingDir:   agentDir,
+	}
+	return node, raw, nil
+}
+
+func noteSlow(r *Record, field string, start time.Time) {
+	elapsed := time.Since(start)
+	if elapsed < inventorySlowThreshold {
+		return
+	}
+	appendSlowField(r, fmt.Sprintf("%s:%dms", field, elapsed.Milliseconds()))
+}
+
+func appendSlowField(r *Record, field string) {
+	if strings.TrimSpace(field) == "" {
+		return
+	}
+	r.SlowFields = append(r.SlowFields, field)
 }
 
 func RoleFor(r Record) Role {
@@ -453,15 +518,27 @@ func fileExists(path string) bool {
 }
 
 func SummarizeIMIdentities(agentDir string) string {
+	summary, _ := summarizeIMIdentities(agentDir, maxIMIdentityFiles)
+	return summary
+}
+
+func summarizeIMIdentities(agentDir string, maxFiles int) (string, bool) {
 	identityDir := filepath.Join(agentDir, "system", "mcp_identities")
 	entries, err := os.ReadDir(identityDir)
 	if err != nil {
-		return ""
+		return "", false
 	}
 	var parts []string
+	jsonSeen := 0
+	truncated := false
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 			continue
+		}
+		jsonSeen++
+		if maxFiles > 0 && jsonSeen > maxFiles {
+			truncated = true
+			break
 		}
 		mcp := strings.TrimSuffix(entry.Name(), ".json")
 		data, err := os.ReadFile(filepath.Join(identityDir, entry.Name()))
@@ -494,7 +571,7 @@ func SummarizeIMIdentities(agentDir string) string {
 		}
 	}
 	sort.Strings(parts)
-	return strings.Join(parts, ";")
+	return strings.Join(parts, ";"), truncated
 }
 
 func publicHandle(account map[string]interface{}) string {

--- a/tui/internal/inventory/inventory_test.go
+++ b/tui/internal/inventory/inventory_test.go
@@ -241,3 +241,70 @@ func TestSnapshotJSONFixtureParity(t *testing.T) {
 		t.Fatalf("record JSON parity lost: %s", data)
 	}
 }
+
+func TestFromProcessesMarksSlowInventoryFields(t *testing.T) {
+	oldThreshold := inventorySlowThreshold
+	inventorySlowThreshold = 0
+	defer func() { inventorySlowThreshold = oldThreshold }()
+
+	agentDir := filepath.Join(t.TempDir(), "agent")
+	writeAgentJSON(t, agentDir, "agent", "IDLE", `{}`)
+
+	snap := FromProcesses([]processscan.AgentProcess{{PID: 7, AgentDir: agentDir}}, Options{})
+	if len(snap.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(snap.Records))
+	}
+	for _, prefix := range []string{"agent_json:", "status:", "heartbeat:", "lock:"} {
+		if !hasSlowPrefix(snap.Records[0].SlowFields, prefix) {
+			t.Fatalf("expected slow field prefix %q in %#v", prefix, snap.Records[0].SlowFields)
+		}
+	}
+}
+
+func TestFromProcessesMarksTruncatedIMIdentities(t *testing.T) {
+	oldMax := maxIMIdentityFiles
+	maxIMIdentityFiles = 1
+	defer func() { maxIMIdentityFiles = oldMax }()
+
+	agentDir := filepath.Join(t.TempDir(), "agent")
+	writeAgentJSON(t, agentDir, "agent", "IDLE", `{}`)
+	identityDir := filepath.Join(agentDir, "system", "mcp_identities")
+	if err := os.MkdirAll(identityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, handle := range map[string]string{"telegram": "bot_one", "wechat": "bot_two"} {
+		body := fmt.Sprintf(`{"mcp":%q,"accounts":[{"bot_username":%q}]}`, name, handle)
+		if err := os.WriteFile(filepath.Join(identityDir, name+".json"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snap := FromProcesses([]processscan.AgentProcess{{PID: 7, AgentDir: agentDir}}, Options{})
+	if len(snap.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(snap.Records))
+	}
+	if snap.Records[0].IMHandles == "" {
+		t.Fatalf("expected at least one identity handle")
+	}
+	if !hasSlowExact(snap.Records[0].SlowFields, "mcp_identities_truncated") {
+		t.Fatalf("expected truncated marker in %#v", snap.Records[0].SlowFields)
+	}
+}
+
+func hasSlowPrefix(fields []string, prefix string) bool {
+	for _, field := range fields {
+		if strings.HasPrefix(field, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSlowExact(fields []string, want string) bool {
+	for _, field := range fields {
+		if field == want {
+			return true
+		}
+	}
+	return false
+}

--- a/tui/internal/tui/auto_refresh.go
+++ b/tui/internal/tui/auto_refresh.go
@@ -48,16 +48,29 @@ func (a App) autoRefreshActiveView() (App, tea.Cmd) {
 	switch a.currentView {
 	case appViewProps:
 		// Keep the dashboard live, but do not interrupt the agent picker. The
-		// Ctrl+D detail layer is also live: refresh its derived breakdowns in
-		// place before scheduling the same outer dashboard reload Ctrl+R uses.
+		// Ctrl+D detail layer is also live, but both outer and detail reloads are
+		// guarded so slow external-disk scans do not stack overlapping commands.
 		if a.props.pickerOpen {
 			return a, nil
 		}
+		var cmds []tea.Cmd
 		if a.props.detailOpen {
-			a.props.loadDetail()
+			var detailCmd tea.Cmd
+			a.props, detailCmd = a.props.startDetailLoad()
 			a.props.syncViewportContent()
+			if detailCmd != nil {
+				cmds = append(cmds, detailCmd)
+			}
 		}
-		return a, a.props.AutoReloadCmd()
+		var reloadCmd tea.Cmd
+		a.props, reloadCmd = a.props.startLoadData()
+		if reloadCmd != nil {
+			cmds = append(cmds, reloadCmd)
+		}
+		if len(cmds) == 0 {
+			return a, nil
+		}
+		return a, tea.Batch(cmds...)
 	}
 	return a, nil
 }

--- a/tui/internal/tui/auto_refresh_test.go
+++ b/tui/internal/tui/auto_refresh_test.go
@@ -143,6 +143,19 @@ func TestAutoRefreshActiveViewOnlyReloadsKanban(t *testing.T) {
 	}
 }
 
+func TestAppAutoRefreshSkipsPropsLoadWhenInFlight(t *testing.T) {
+	dir := t.TempDir()
+	a := App{currentView: appViewProps, props: NewPropsModel(dir, dir, dir), tuiConfig: config.DefaultTUIConfig()}
+	a.props.loadInFlight = true
+	updated, cmd := a.autoRefreshActiveView()
+	if cmd != nil {
+		t.Fatal("auto-refresh should not queue overlapping props load while one is in flight")
+	}
+	if updated.props.loadSkippedTicks != 1 {
+		t.Fatalf("loadSkippedTicks = %d, want 1", updated.props.loadSkippedTicks)
+	}
+}
+
 func TestAppAutoRefreshTickDisabledDropsAndUnarms(t *testing.T) {
 	cfg := config.DefaultTUIConfig()
 	cfg.AutoRefreshOff = true

--- a/tui/internal/tui/ctrl_r_refresh_test.go
+++ b/tui/internal/tui/ctrl_r_refresh_test.go
@@ -22,6 +22,7 @@ import (
 // keypress is tea.KeyPressMsg{Code: 'r', Text: "r"} whose .String() is "r".
 
 func ctrlR() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl} }
+func ctrlD() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl} }
 func bareR() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'r', Text: "r"} }
 
 // --- Cmd-returning views: Ctrl+R must trigger a (re)load command. ---
@@ -31,6 +32,42 @@ func TestPropsCtrlRTriggersReload(t *testing.T) {
 	_, cmd := m.Update(ctrlR())
 	if cmd == nil {
 		t.Fatal("PropsModel ctrl+r returned nil cmd; expected a reload command")
+	}
+}
+
+func TestPropsCtrlRSkipsWhileLoadInFlight(t *testing.T) {
+	m := NewPropsModel(t.TempDir(), t.TempDir(), t.TempDir())
+	m.loadInFlight = true
+	updated, cmd := m.Update(ctrlR())
+	if cmd != nil {
+		t.Fatal("PropsModel ctrl+r should not queue overlapping reload while one is in flight")
+	}
+	if updated.loadSkippedTicks != 1 {
+		t.Fatalf("loadSkippedTicks = %d, want 1", updated.loadSkippedTicks)
+	}
+}
+
+func TestPropsCtrlDLoadsDetailAsynchronously(t *testing.T) {
+	dir := t.TempDir()
+	m := NewPropsModel(dir, dir, dir)
+	updated, cmd := m.Update(ctrlD())
+	if cmd == nil {
+		t.Fatal("PropsModel ctrl+d opening detail should return async detail load command")
+	}
+	if !updated.detailOpen {
+		t.Fatal("PropsModel ctrl+d should open detail view")
+	}
+	if !updated.detailInFlight {
+		t.Fatal("PropsModel ctrl+d should mark detail load in flight")
+	}
+	msg := cmd()
+	detailMsg, ok := msg.(propsDetailLoadMsg)
+	if !ok {
+		t.Fatalf("ctrl+d command returned %T, want propsDetailLoadMsg", msg)
+	}
+	updated, _ = updated.Update(detailMsg)
+	if updated.detailInFlight {
+		t.Fatal("detailInFlight should clear when propsDetailLoadMsg is applied")
 	}
 }
 

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -46,6 +46,18 @@ type PropsModel struct {
 	// hint.
 	AutoRefresh bool
 
+	// Reload state. Auto-refresh ticks can arrive faster than an external-disk
+	// network scan completes, so the props view keeps one load in flight and marks
+	// skipped ticks as stale instead of queuing overlapping scans.
+	loadInFlight        bool
+	loadSkippedTicks    int
+	loadLastDuration    time.Duration
+	loadLastCompleted   time.Time
+	detailInFlight      bool
+	detailSkippedTicks  int
+	detailLastDuration  time.Duration
+	detailLastCompleted time.Time
+
 	// Scrollable viewport for content
 	viewport viewport.Model
 	ready    bool // viewport initialized
@@ -82,6 +94,11 @@ type PropsModel struct {
 // Ctrl+D recent-call lane (main agent on the left, daemons on the right).
 const detailRecentCalls = 100
 
+// propsSlowLoadThreshold marks disk-backed props scans that are slow enough to
+// explain stale UI on external volumes. It is intentionally conservative: the
+// marker is informational and does not block future reloads.
+const propsSlowLoadThreshold = 500 * time.Millisecond
+
 func NewPropsModel(baseDir, orchDir, globalDir string) PropsModel {
 	return PropsModel{
 		baseDir:     baseDir,
@@ -99,9 +116,34 @@ type propsLoadMsg struct {
 	adminStart     string
 	agentDirs      []string
 	agentNodes     []fs.AgentNode
+	selectedDir    string
+	startedAt      time.Time
+	duration       time.Duration
+}
+
+type propsDetailLoadMsg struct {
+	selectedDir                   string
+	startedAt                     time.Time
+	duration                      time.Duration
+	detailByProvider              map[string]fs.TokenTotals
+	detailRecent                  []fs.LedgerEntry
+	detailDaemonRecent            []fs.DaemonLedgerEntry
+	detailCurrentSessionStats     fs.SessionTokenStats
+	detailLastSessionStats        fs.SessionTokenStats
+	detailCurrentSessionToolCalls int64
+	detailLastSessionToolCalls    int64
+	detailContextStats            fs.ContextStats
+	detailDaemonCounts            fs.DaemonCounts
+	detailMCPNames                []string
+	detailRebuilds                []time.Time
+	detailRefreshes               []time.Time
 }
 
 func (m PropsModel) loadData() tea.Msg {
+	return m.loadDataStarted(time.Now())
+}
+
+func (m PropsModel) loadDataStarted(startedAt time.Time) tea.Msg {
 	net, _ := fs.BuildNetwork(m.baseDir)
 
 	var dirs []string
@@ -136,10 +178,28 @@ func (m PropsModel) loadData() tea.Msg {
 		adminStart:     adminStart,
 		agentDirs:      allDirs,
 		agentNodes:     net.Nodes,
+		selectedDir:    m.selectedDir,
+		startedAt:      startedAt,
+		duration:       time.Since(startedAt),
 	}
 }
 
-func (m PropsModel) Init() tea.Cmd { return m.loadData }
+func (m PropsModel) loadDataCmd(startedAt time.Time) tea.Cmd {
+	return func() tea.Msg { return m.loadDataStarted(startedAt) }
+}
+
+func (m PropsModel) startLoadData() (PropsModel, tea.Cmd) {
+	if m.loadInFlight {
+		m.loadSkippedTicks++
+		return m, nil
+	}
+	m.loadInFlight = true
+	m.loadSkippedTicks = 0
+	startedAt := time.Now()
+	return m, m.loadDataCmd(startedAt)
+}
+
+func (m PropsModel) Init() tea.Cmd { return m.loadDataCmd(time.Now()) }
 
 // AutoReloadCmd implements autoReloadable: on the app-level 1s tick, reload the
 // kanban dashboard from disk so network/token/status data stays live without a
@@ -148,14 +208,13 @@ func (m PropsModel) Init() tea.Cmd { return m.loadData }
 // folder state.
 //
 // Returns nil — skipping this tick — while the agent picker is open (selectedDir
-// is mid-change). The Ctrl+D detail pane remains live: App.autoRefreshActiveView
-// refreshes the detail caches in place before this command reloads the outer
-// dashboard data.
+// is mid-change) or a previous load is still in flight. The App-level path uses
+// startLoadData so skipped ticks are counted and surfaced as a stale marker.
 func (m PropsModel) AutoReloadCmd() tea.Cmd {
-	if m.pickerOpen {
+	if m.pickerOpen || m.loadInFlight {
 		return nil
 	}
-	return m.loadData
+	return m.loadDataCmd(time.Now())
 }
 
 // propsHeaderLines is the number of lines used by the header (title + separator + optional callout).
@@ -186,13 +245,38 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 		m.syncViewportContent()
 
 	case propsLoadMsg:
+		m.loadInFlight = false
+		m.loadLastDuration = msg.duration
+		m.loadLastCompleted = msg.startedAt.Add(msg.duration)
 		m.network = msg.network
 		m.tokens = msg.tokens
-		m.selectedTokens = msg.selectedTokens
-		m.selectedStatus = msg.selectedStatus
+		if msg.selectedDir == m.selectedDir {
+			m.selectedTokens = msg.selectedTokens
+			m.selectedStatus = msg.selectedStatus
+		}
 		m.adminStart = msg.adminStart
 		m.agentDirs = msg.agentDirs
 		m.agentNodes = msg.agentNodes
+		m.syncViewportContent()
+
+	case propsDetailLoadMsg:
+		m.detailInFlight = false
+		m.detailLastDuration = msg.duration
+		m.detailLastCompleted = msg.startedAt.Add(msg.duration)
+		if msg.selectedDir == m.selectedDir {
+			m.detailByProvider = msg.detailByProvider
+			m.detailRecent = msg.detailRecent
+			m.detailDaemonRecent = msg.detailDaemonRecent
+			m.detailCurrentSessionStats = msg.detailCurrentSessionStats
+			m.detailLastSessionStats = msg.detailLastSessionStats
+			m.detailCurrentSessionToolCalls = msg.detailCurrentSessionToolCalls
+			m.detailLastSessionToolCalls = msg.detailLastSessionToolCalls
+			m.detailContextStats = msg.detailContextStats
+			m.detailDaemonCounts = msg.detailDaemonCounts
+			m.detailMCPNames = msg.detailMCPNames
+			m.detailRebuilds = msg.detailRebuilds
+			m.detailRefreshes = msg.detailRefreshes
+		}
 		m.syncViewportContent()
 
 	case tea.MouseWheelMsg:
@@ -217,7 +301,7 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 			return m, func() tea.Msg { return ViewChangeMsg{View: "mail"} }
 		case "ctrl+r":
 			// Reload the dashboard data (network, tokens, agent status) from disk.
-			return m, m.loadData
+			return m.startLoadData()
 		case "ctrl+t":
 			m.pickerOpen = true
 			for i, n := range m.agentNodes {
@@ -229,13 +313,16 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 			m.syncViewportContent()
 			return m, nil
 		case "ctrl+d":
-			// Toggle detail view. Reload the per-provider breakdown
-			// from disk on every open so the data is fresh — these
-			// reads are cheap (small local ledger, init, and daemon files).
+			// Toggle detail view. Reload the per-provider breakdown asynchronously on
+			// every open; external disks can make the detail reads expensive enough to
+			// block rendering if they run inline on the keypress path.
 			m.detailOpen = !m.detailOpen
 			if m.detailOpen {
-				m.loadDetail()
 				m.viewport.GotoTop()
+				var detailCmd tea.Cmd
+				m, detailCmd = m.startDetailLoad()
+				m.syncViewportContent()
+				return m, detailCmd
 			}
 			m.syncViewportContent()
 			return m, nil
@@ -246,6 +333,42 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m PropsModel) startDetailLoad() (PropsModel, tea.Cmd) {
+	if m.detailInFlight {
+		m.detailSkippedTicks++
+		return m, nil
+	}
+	m.detailInFlight = true
+	m.detailSkippedTicks = 0
+	startedAt := time.Now()
+	return m, m.loadDetailCmd(startedAt)
+}
+
+func (m PropsModel) loadDetailCmd(startedAt time.Time) tea.Cmd {
+	selectedDir := m.selectedDir
+	return func() tea.Msg {
+		scratch := PropsModel{selectedDir: selectedDir}
+		scratch.loadDetail()
+		return propsDetailLoadMsg{
+			selectedDir:                   selectedDir,
+			startedAt:                     startedAt,
+			duration:                      time.Since(startedAt),
+			detailByProvider:              scratch.detailByProvider,
+			detailRecent:                  scratch.detailRecent,
+			detailDaemonRecent:            scratch.detailDaemonRecent,
+			detailCurrentSessionStats:     scratch.detailCurrentSessionStats,
+			detailLastSessionStats:        scratch.detailLastSessionStats,
+			detailCurrentSessionToolCalls: scratch.detailCurrentSessionToolCalls,
+			detailLastSessionToolCalls:    scratch.detailLastSessionToolCalls,
+			detailContextStats:            scratch.detailContextStats,
+			detailDaemonCounts:            scratch.detailDaemonCounts,
+			detailMCPNames:                scratch.detailMCPNames,
+			detailRebuilds:                scratch.detailRebuilds,
+			detailRefreshes:               scratch.detailRefreshes,
+		}
+	}
 }
 
 // loadDetail populates the detail-view caches from disk for the
@@ -430,6 +553,9 @@ func (m PropsModel) View() string {
 	if m.AutoRefresh {
 		refreshHint = i18n.T("hints.auto_refresh_live") + " " + RuneBullet + " " + refreshHint
 	}
+	if status := m.reloadStatusHint(); status != "" {
+		refreshHint += " " + RuneBullet + " " + status
+	}
 
 	var footerLine string
 	if m.detailOpen {
@@ -445,6 +571,29 @@ func (m PropsModel) View() string {
 	footer := strings.Repeat("\u2500", m.width) + "\n" + StyleFaint.Render(footerLine)
 
 	return header + "\n" + PaintViewportBG(m.viewport.View(), m.width) + "\n" + footer
+}
+
+func (m PropsModel) reloadStatusHint() string {
+	var parts []string
+	if m.loadInFlight {
+		parts = append(parts, "loading")
+	}
+	if m.loadSkippedTicks > 0 {
+		parts = append(parts, fmt.Sprintf("stale:%d", m.loadSkippedTicks))
+	}
+	if m.loadLastDuration >= propsSlowLoadThreshold {
+		parts = append(parts, "slow:"+m.loadLastDuration.Round(time.Millisecond).String())
+	}
+	if m.detailOpen && m.detailInFlight {
+		parts = append(parts, "detail loading")
+	}
+	if m.detailSkippedTicks > 0 {
+		parts = append(parts, fmt.Sprintf("detail stale:%d", m.detailSkippedTicks))
+	}
+	if m.detailLastDuration >= propsSlowLoadThreshold {
+		parts = append(parts, "detail slow:"+m.detailLastDuration.Round(time.Millisecond).String())
+	}
+	return strings.Join(parts, " "+RuneBullet+" ")
 }
 
 func padToWidth(s string, w int) string {

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -13,6 +13,24 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+func TestPropsReloadStatusHintShowsStaleAndSlow(t *testing.T) {
+	m := PropsModel{
+		loadInFlight:       true,
+		loadSkippedTicks:   2,
+		loadLastDuration:   time.Second,
+		detailOpen:         true,
+		detailInFlight:     true,
+		detailSkippedTicks: 1,
+		detailLastDuration: time.Second,
+	}
+	hint := m.reloadStatusHint()
+	for _, want := range []string{"loading", "stale:2", "slow:1s", "detail loading", "detail stale:1", "detail slow:1s"} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("reloadStatusHint() missing %q in %q", want, hint)
+		}
+	}
+}
+
 func TestKanbanTimestampRendersLocalOffset(t *testing.T) {
 	origLocal := time.Local
 	t.Cleanup(func() { time.Local = origLocal })

--- a/tui/list_common.go
+++ b/tui/list_common.go
@@ -103,7 +103,7 @@ func printList(w io.Writer, records []inventory.Record, opts listOptions, showUp
 		imHandles := firstNonEmpty(r.IMHandles, "-")
 		name := firstNonEmpty(r.AgentName, r.Agent)
 		address := firstNonEmpty(r.Address, r.Agent)
-		state := firstNonEmpty(r.State, "unknown")
+		state := annotateSlowState(firstNonEmpty(r.State, "unknown"), r.SlowFields)
 		role := string(r.Role)
 		pid := fmt.Sprint(r.PID)
 		if opts.Admin {
@@ -178,6 +178,13 @@ func printListWarnings(w io.Writer, phantomDirs []string, filterDir string) {
 	} else {
 		fmt.Fprintln(w, "Run 'lingtai-tui purge <dir>' to kill phantoms in a specific directory.")
 	}
+}
+
+func annotateSlowState(state string, slowFields []string) string {
+	if len(slowFields) == 0 {
+		return state
+	}
+	return state + " [slow:" + strings.Join(slowFields, ",") + "]"
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
## Summary
- Budget `MailCache.Refresh()` sent-history scans while preserving immediate pending sent-ID delivery checks.
- Make inventory/list status scans more external-disk friendly: read `.agent.json` once, record `slow_fields`, and cap MCP identity scans with a truncation marker.
- Guard props/session/detail refresh paths so auto-refresh/Ctrl+R/Ctrl+D do not stack overlapping external-disk scans; detail loads asynchronously and the footer surfaces loading/stale/slow markers.
- Add focused tests for MailCache sent-scan throttling, inventory slow/truncated markers, and props in-flight/detail behavior.

## Context
This PR targets TUI lag observed on large `.lingtai` networks mounted on an external disk. It does not claim to eliminate every possible exFAT/external-volume slowdown, but it removes several every-second full-scan and synchronous-detail paths that matched the observed bottlenecks.

## Validation
- `git diff --check`
- `go test ./internal/fs ./internal/inventory -count=1`
- `go test ./internal/tui -run 'TestProps(CtrlR|CtrlD|ReloadStatusHint|AutoReloadCmd|LoadDetail)|TestAppAutoRefresh(SkipsPropsLoadWhenInFlight|TickKeepsKanbanDetailLive|TickReloadsAndRearms)|TestAutoRefreshActiveViewOnlyReloadsKanban' -count=1`
- `go test ./internal/tui -run '^$' -count=1` (compile-only)

## Not covered / follow-up
- Full `go test ./...` was intentionally not run because existing OAuth tests may open a real browser.
- No live external-disk Wenda validation was performed in this PR.
- No installed binary, hotpatch, release, installed wheel/venv, or Wenda runtime/mailbox/SCU/P0 state was changed.
