### PR TITLE
fix(tui): normalize daemon CLI cached input

### DIFF
--- a/tui/internal/fs/daemon_ledger.go
+++ b/tui/internal/fs/daemon_ledger.go
@@ -118,7 +118,10 @@ func DaemonLedgerSummary(agentDir string, recentN int) (map[string]TokenTotals, 
 		var fbInput, fbOutput, fbThinking, fbCached, fbCalls int64
 		if cli := card.CLITokens; cli != nil &&
 			(cli.Input+cli.Output+cli.Thinking+cli.Cached != 0 || cli.Calls != 0) {
-			fbInput = cli.Input
+			// cli_tokens keeps raw/non-cached input and cached input as
+			// disjoint counters. TokenTotals.Input is total input, so fold the
+			// cached subset into the canonical denominator at this boundary.
+			fbInput = cli.Input + cli.Cached
 			fbOutput = cli.Output
 			fbThinking = cli.Thinking
 			fbCached = cli.Cached

--- a/tui/internal/fs/daemon_ledger_test.go
+++ b/tui/internal/fs/daemon_ledger_test.go
@@ -297,6 +297,45 @@ func TestDaemonLedgerSummaryTwoCLIRunsSameBackendAggregateToOneBucket(t *testing
 	}
 }
 
+func TestDaemonLedgerSummaryCLITokensNormalizeDisjointCachedInput(t *testing.T) {
+	agentDir := t.TempDir()
+	const (
+		rawInput = int64(406_915)
+		cached   = int64(136_061_317)
+		total    = int64(136_468_232)
+	)
+	writeDaemonState(t, agentDir, "em-claude-cache", map[string]interface{}{
+		"backend": "claude-p",
+		"cli_tokens": map[string]interface{}{
+			"input": rawInput, "output": 1_063_675, "cached": cached, "calls": 53,
+		},
+	})
+
+	totals, recent := DaemonLedgerSummary(agentDir, 100)
+	claude, ok := totals["claude-p"]
+	if !ok {
+		t.Fatalf("expected claude-p bucket, got: %v", totals)
+	}
+	if claude.Input != total || claude.Cached != cached {
+		t.Fatalf("canonical input/cached = %d/%d, want %d/%d", claude.Input, claude.Cached, total, cached)
+	}
+	if claude.Cached > claude.Input {
+		t.Fatalf("cached input %d exceeds canonical input %d", claude.Cached, claude.Input)
+	}
+	if miss := claude.Input - claude.Cached; miss != rawInput {
+		t.Fatalf("cache miss = %d, want raw input %d", miss, rawInput)
+	}
+	if rate := 100 * float64(claude.Cached) / float64(claude.Input); rate < 99.6 || rate > 99.8 {
+		t.Fatalf("cache hit rate = %.3f%%, want about 99.7%%", rate)
+	}
+	if claude.Output != 1_063_675 || claude.APICalls != 53 {
+		t.Fatalf("output/calls changed during normalization: %+v", claude)
+	}
+	if len(recent) != 0 {
+		t.Fatalf("CLI snapshot should not create recent ledger rows, got %d", len(recent))
+	}
+}
+
 func TestDaemonLedgerSummaryPresetProviderPrecedence(t *testing.T) {
 	agentDir := t.TempDir()
 	// preset_provider is set; backend is also set but preset_provider wins.

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -534,6 +534,33 @@ func TestPropsRenderDetailShowsMainAndDaemonProviderSections(t *testing.T) {
 	}
 }
 
+func TestPropsRenderDetailDaemonCacheRateUsesCanonicalInput(t *testing.T) {
+	m := PropsModel{
+		detailDaemonByProvider: map[string]fs.TokenTotals{
+			"claude-p": {
+				Input: 136_468_232, Output: 1_063_675, Cached: 136_061_317, APICalls: 53,
+			},
+		},
+	}
+	out := ansi.Strip(m.renderDetail())
+	for _, want := range []string{
+		"input:    136,468,232",
+		"cached:    136,061,317",
+		"cache hit: 99.7%",
+		"miss:      406,915",
+		"input + output + thinking: 137,531,907",
+		"cache hit rate:            99.7%",
+		"api_calls:                 53",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("renderDetail missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "33437.3%") {
+		t.Fatalf("renderDetail leaked the pre-normalization impossible cache rate:\n%s", out)
+	}
+}
+
 func TestPropsRenderDetailEmptyDaemonProviderSection(t *testing.T) {
 	m := PropsModel{
 		detailByProvider: map[string]fs.TokenTotals{


### PR DESCRIPTION
## Summary

- normalize `daemon.json.cli_tokens` at the snapshot boundary so canonical `TokenTotals.Input` includes both raw/non-cached input and cached input
- keep per-call ledgers and legacy `tokens` semantics unchanged
- add production-scale source and renderer regressions for the impossible `33437.3%` cache-hit bug reported after #634

## Root cause

Claude Code persists external CLI usage as disjoint counters: `input` is raw/non-cached input, while `cached` is cache-read plus cache-creation input. The TUI snapshot fallback copied those counters into canonical totals without adding cached input to the `Input` denominator, then rendered `cached / input`.

For the reported values, the correct canonical totals are:

- raw miss: `406,915`
- cached: `136,061,317`
- total input: `136,468,232`
- cache hit: about `99.7%`

## Validation

- focused daemon snapshot + renderer regressions
- `go test ./...`
- `go vet ./...`
- `make build`
- `gofmt`
- `git diff --check`
- paired local TUI + portal candidate build from the same worktree
- maintainer live verification confirmed the corrected display before merge

Follow-up to #634.
