### PR TITLE
docs(readme): update Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Digital Scientist · lifelong agent · self-growing memory · durable knowledge 
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
 [![Kernel](https://img.shields.io/badge/kernel-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
 [![Site](https://img.shields.io/badge/site-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-join-%235865F2?logo=discord&logoColor=white)](https://discord.gg/cMchjXpg)
+[![Discord](https://img.shields.io/badge/discord-join-%235865F2?logo=discord&logoColor=white)](https://discord.gg/8KBGVYMS)
 
 </div>
 
@@ -147,7 +147,7 @@ See [`RELEASING.md`](RELEASING.md) for the release process. Areas that often nee
 
 - Website, tutorial, and release notes: <https://lingtai.ai>
 - Main repo: <https://github.com/Lingtai-AI/lingtai> · Kernel: <https://github.com/Lingtai-AI/lingtai-kernel>
-- Discord: <https://discord.gg/cMchjXpg>
+- Discord: <https://discord.gg/8KBGVYMS>
 - Issues: <https://github.com/Lingtai-AI/lingtai/issues> · Discussions: <https://github.com/Lingtai-AI/lingtai/discussions>
 
 For Chinese-language discussion and early testing, scan the WeChat QR below. Add the author on WeChat with the note `lingtai`; if the QR has expired, open an issue and we will refresh it.

--- a/README.wen.md
+++ b/README.wen.md
@@ -16,7 +16,7 @@
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
 [![Kernel](https://img.shields.io/badge/内核-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
 [![Site](https://img.shields.io/badge/site-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/cMchjXpg)
+[![Discord](https://img.shields.io/badge/discord-入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/8KBGVYMS)
 
 </div>
 
@@ -151,7 +151,7 @@ git diff --check && git status --short
 
 - 官网、教程与发布日志：<https://lingtai.ai>
 - 主仓：<https://github.com/Lingtai-AI/lingtai> · 内核：<https://github.com/Lingtai-AI/lingtai-kernel>
-- Discord：<https://discord.gg/cMchjXpg>
+- Discord：<https://discord.gg/8KBGVYMS>
 - Issues：<https://github.com/Lingtai-AI/lingtai/issues> · Discussions：<https://github.com/Lingtai-AI/lingtai/discussions>
 
 **微信同道群**：扫码加作者微信（备注 *lingtai*），引入测试群。此码按时更之，若已过期，请君提 issue 相告。

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,7 +11,7 @@
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
 [![Kernel](https://img.shields.io/badge/内核-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
 [![Site](https://img.shields.io/badge/site-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-加入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/cMchjXpg)
+[![Discord](https://img.shields.io/badge/discord-加入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/8KBGVYMS)
 
 </div>
 
@@ -146,7 +146,7 @@ git diff --check && git status --short
 
 - 官网、教程与发布日志：<https://lingtai.ai>
 - 主仓库：<https://github.com/Lingtai-AI/lingtai> · 内核：<https://github.com/Lingtai-AI/lingtai-kernel>
-- Discord：<https://discord.gg/cMchjXpg>
+- Discord：<https://discord.gg/8KBGVYMS>
 - Issues：<https://github.com/Lingtai-AI/lingtai/issues> · Discussions：<https://github.com/Lingtai-AI/lingtai/discussions>
 
 **微信交流群**：扫码加作者微信（备注 *lingtai*），拉入测试群。二维码会定期更新，若过期请提 issue。


### PR DESCRIPTION
## Summary

- replace the Discord invite with `https://discord.gg/8KBGVYMS`
- keep `README.md`, `README.zh.md`, and `README.wen.md` in sync
- prepare the current TUI/Portal release candidate without changing product behavior

## Validation

- new invite resolves with HTTP 200 to `https://discord.com/invite/8KBGVYMS`
- 6 new-link occurrences, 0 stale-link occurrences across the three READMEs
- `go test . -run '^TestArchitectureEntryLinks$' -count=1` from `tui/`\n- `git diff --check`\n\nRequested by the maintainer as part of the coordinated v0.10.7 / kernel v0.16.4 release.