### PR TITLE
TUI: establish direct-mail persistence contracts

### DIFF
--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -17,6 +17,10 @@ related_files:
   - tui/internal/fs/heartbeat_test.go
   - tui/internal/fs/mail.go
   - tui/internal/fs/mail_test.go
+  - tui/internal/fs/direct_mail.go
+  - tui/internal/fs/direct_mail_test.go
+  - tui/internal/fs/rail_unread.go
+  - tui/internal/fs/rail_unread_test.go
   - tui/internal/fs/network.go
   - tui/internal/fs/network_test.go
   - tui/internal/fs/session.go
@@ -24,6 +28,7 @@ related_files:
   - tui/internal/fs/session_rebuild_offsets_test.go
   - tui/internal/fs/session_tail_test.go
   - tui/internal/fs/session_window_test.go
+  - tui/internal/fs/session_persistence_role_test.go
   - tui/internal/sqlitelog/event.go
   - tui/internal/sqlitelog/query_test.go
   - tui/internal/fs/signal.go
@@ -48,7 +53,7 @@ maintenance: |
 
 ## What this is
 
-The TUI's filesystem window into an agent working directory (`<project>/.lingtai/<agent>/`). Agent state — manifest, heartbeat, mail, token ledger, location, network topology, chat history — is read through this package. The kernel owns agent state; the TUI's narrow writes are signal files, human outbox/location, and its derived human `logs/session.jsonl` replay cache.
+The TUI's filesystem window into an agent working directory (`<project>/.lingtai/<agent>/`). Agent state — manifest, heartbeat, mail, token ledger, location, network topology, chat history — is read through this package. The kernel owns agent state; the TUI's narrow writes are signal files, human outbox/location, its derived human `logs/session.jsonl` replay cache, and the TUI-owned direct-mail unread boundary file.
 
 ## Components
 
@@ -92,6 +97,11 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 | `MailCache` | `tui/internal/fs/mail.go:104` | incremental refresh cache: outbox + inbox + sent merged |
 | `NewMailCache(humanDir)` | `tui/internal/fs/mail.go:114` | creates cache; `Refresh()` returns updated copy (receiver not mutated) |
 | `WriteMail` | `tui/internal/fs/mail.go:254-316` | writes local mail to recipient inbox + sender sent (or human outbox for pseudo-agent); returns `ErrRemoteMailUnsupported` before mailbox allocation for remote addresses |
+| **direct_mail.go** | | |
+| `NormalizeMailEndpoints` / `IsDirectMail` | `tui/internal/fs/direct_mail.go:5-57` | normalizes the string-or-list `To` schema once and applies strict human-target direct membership without using CC |
+| **rail_unread.go** | | |
+| `OpenRailUnreadStore` / `SyncTargets` | `tui/internal/fs/rail_unread.go:53-115` | loads versioned per-project boundaries; missing/corrupt state and new/reused/address-changed target identities baseline to the supplied accepted snapshot |
+| `UnreadCount` / `MarkSeen` | `tui/internal/fs/rail_unread.go:117-169` | counts incoming direct mail beyond `(maximum timestamp, IDs at timestamp)` and atomically advances an exact accepted boundary |
 | **ledger.go** | | |
 | `ReadLedger(dir)` | `tui/internal/fs/ledger.go:17` | reads `delegates/ledger.jsonl` → `[]AvatarEdge` + child dirs |
 | **location.go** | | |
@@ -115,12 +125,12 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 | `CleanSignals(dir)` | `tui/internal/fs/signal.go:32` | remove all signal + refresh handshake files |
 | `SuspendAndWait` | `tui/internal/fs/signal.go:43` | touch `.suspend`, poll heartbeat until dead or timeout |
 | **session.go** | | |
-| `SessionCache` | `tui/internal/fs/session.go:123-162` | mutex-protected derived replay cache backed by human `logs/session.jsonl`; tracks parser-proven offsets plus full-history count metadata |
-| `NewSessionCache` | `tui/internal/fs/session.go:166-178` | pure in-memory construction; creates no file or directory |
-| `RebuildFromSources` / `RebuildFromSourcesInMemory` | `tui/internal/fs/session.go:184-201` | authoritative full ingest; write-through for accepted callers or detached/no-persist for generation-gated Mail work |
-| `RebuildFromSourcesWindowedInMemory` / `Complete` / `ExactHistoryStats` | `tui/internal/fs/session.go:208-220`, `tui/internal/fs/session.go:399-410` | bounded newest-content ingest plus a separately invoked exact metadata count for the captured canonical JSONL source/horizon; partial caches remain memory-only while complete caches may persist |
-| `Persist` / `append` | `tui/internal/fs/session.go:300-361` | writes only proven-complete accepted state; both snapshot persistence and incremental disk append decline while a bounded cache is partial |
-| `Refresh` | `tui/internal/fs/session.go:2228-2235` | incremental poll from each source's last complete consumed record; partial caches accept additions in memory without writing a misleading derived file |
+| `SessionPersistenceRole` / `SessionCache` | `tui/internal/fs/session.go:123-164` | separates the sole `MainAggregateWriter` from `NoPersist`, independently of mutex-protected replay-window completeness and offsets |
+| `NewSessionCache` | `tui/internal/fs/session.go:174-190` | pure in-memory construction with an explicit persistence role; creates no file or directory |
+| `RebuildFromSources` / `RebuildFromSourcesInMemory` | `tui/internal/fs/session.go:192-204` | authoritative full ingest; write-through requests still pass through the cache's persistence role |
+| `RebuildFromSourcesWindowedInMemory` / `Complete` / `ExactHistoryStats` | `tui/internal/fs/session.go:206-230`, `tui/internal/fs/session.go:417-428` | bounded newest-content ingest plus a separately invoked exact metadata count for the captured canonical JSONL source/horizon; completeness prevents partial-file truncation but does not grant write authority |
+| `Persist` / `rewriteFile` / `append` | `tui/internal/fs/session.go:311-378` | both write primitives enforce `MainAggregateWriter`; bounded caches independently remain memory-only until complete |
+| `Refresh` | `tui/internal/fs/session.go:2244-2252` | incremental poll from each source's last complete consumed record; `NoPersist` caches update memory without appending the shared aggregate |
 | **project_hash.go** | | |
 | `ProjectHash(projectPath)` | `tui/internal/fs/project_hash.go:9` | SHA-256 first 12 hex chars — used as the registry key for each project |
 | **contacts.go** | | |
@@ -138,7 +148,7 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 - **Called by `tui/internal/inventory/`** — running-agent inventory enriches process rows with `.agent.json`, heartbeat, status PID, lock, admin, IM identity, and orchestrator-role metadata.
 - **Reads from agent working directories** — `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/*/`, `logs/log.sqlite` (molt/session-boundary and diagnostic indexes, never canonical session replay authority), `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
 - **Writes signal files** (the only agent-owned files the TUI writes): `.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`, `.refresh`/`.refresh.taken`.
-- **Writes human-owned/derived state** — local `WriteMail` writes recipient inbox + sender sent, or `human/mailbox/outbox/<mailbox-id>/` for pseudo-agent sends; remote addresses fail before any mailbox write. Only complete accepted `SessionCache` persistence/appends write `human/logs/session.jsonl` (`tui/internal/fs/session.go:300-361`).
+- **Writes human-owned/derived state** — local `WriteMail` writes recipient inbox + sender sent, or `human/mailbox/outbox/<mailbox-id>/` for pseudo-agent sends; remote addresses fail before any mailbox write. Only complete accepted `SessionCache` persistence/appends write `human/logs/session.jsonl` (`tui/internal/fs/session.go:300-361`); `RailUnreadStore` atomically writes `.tui-asset/rail-last-seen.json` (`tui/internal/fs/rail_unread.go:192-205`).
 - **Calls `ipinfo.io`** — `ResolveLocation` makes an HTTP call; `UpdateHumanLocation` caches result in human's `.agent.json`.
 
 ## Composition
@@ -150,7 +160,7 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 ## State
 
 - **Reads**: `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/inbox/*`, `mailbox/sent/*`, `logs/log.sqlite` (additive index), `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
-- **Writes**: signal files (`.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`), human `mailbox/outbox/*`, human `.agent.json` location field, and the TUI-derived human `logs/session.jsonl` replay cache only on accepted persist/append paths.
+- **Writes**: signal files (`.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`), human `mailbox/outbox/*`, human `.agent.json` location field, `.tui-asset/rail-last-seen.json`, and the TUI-derived human `logs/session.jsonl` replay cache only from `MainAggregateWriter` persist/append paths.
 
 ## Notes
 
@@ -158,7 +168,9 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 - **Mailbox id shape.** `WriteMail` allocates short, human-scannable ids of the form `YYYYMMDDTHHMMSS-xxxx` (20 chars, UTC, 4 hex chars of UUID4 entropy) via `newMailboxID`. This matches the kernel's `_new_mailbox_id` in `lingtai-kernel/src/lingtai/kernel/intrinsics/email/primitives.py` and the portal's mirror in `portal/internal/fs/mail.go`, so directory names, `id`, and `_mailbox_id` look identical regardless of which side wrote the message. The directory name IS the id — `prepareMailDirs` uses `os.Mkdir` (not `MkdirAll`) on each leaf so collisions in any target folder surface as `fs.ErrExist` and trigger up to 8 regenerations without overwriting existing mail.
 - **`Delivered` is transient.** `MailMessage.Delivered` is `json:"-"` — set by `MailCache.Refresh()` based on which folder the message was found in. Outbox → false; inbox/sent → true.
 - **`MailCache` is copy-on-refresh.** `Refresh()` returns a new `MailCache`; the receiver is not mutated. Safe for goroutine use.
-- **Session cache reconstruction.** `RebuildFromSources` is idempotent — it re-ingests all mail + events + inquiries from offset 0, sorts by timestamp, and rewrites `session.jsonl`; `RebuildFromSourcesInMemory` performs the same read/merge without filesystem writes for detached generation-gated work. Canonical `logs/events.jsonl` owns session content and completeness: the additive SQLite log's source identity and endpoint offsets do not prove interior continuity, so they are not used to declare a replay complete. Every path retains the last complete-record boundary it actually consumed, so trailing partial records and concurrent appends are retried by `Refresh` rather than leaked, duplicated, or skipped.
+- **Direct projection and unread boundaries.** `NormalizeMailEndpoints` is the shared list-first parser for direct membership and topology counting; legacy mailbox label formatting remains separate. `RailUnreadStore` never scans mail or advances to wall clock: callers provide an accepted mailbox snapshot, and only incoming target→human direct mail contributes to each boundary/count. Canonical target directory plus address fingerprint makes nickname changes stable while address changes, disappearance, and directory reuse re-baseline.
+- **Session persistence role.** `MainAggregateWriter` is the only role authorized to mutate the compatibility aggregate `human/logs/session.jsonl`; `NoPersist` is enforced inside both rewrite and append primitives. `complete` describes whether the in-memory history window can safely replace/extend a complete derived file—it is not write authorization.
+- **Session cache reconstruction.** `RebuildFromSources` is idempotent — it re-ingests all mail + events + inquiries from offset 0, sorts by timestamp, and requests a role-gated `session.jsonl` rewrite (only `MainAggregateWriter` writes the file); `RebuildFromSourcesInMemory` performs the same read/merge without filesystem writes for detached generation-gated work. Canonical `logs/events.jsonl` owns session content and completeness: the additive SQLite log's source identity and endpoint offsets do not prove interior continuity, so they are not used to declare a replay complete. Every path retains the last complete-record boundary it actually consumed, so trailing partial records and concurrent appends are retried by `Refresh` rather than leaked, duplicated, or skipped.
 - **Windowed reconstruction and count metadata.** `RebuildFromSourcesWindowedInMemory` retains only the newest requested parser-produced session-event content window while loading mail/inquiries in full. `mail_page_size` directly owns that initial window and every later Ctrl+U increment. Empty/missing/wrong-type text rows do not spend content slots, while hidden `llm_call` and zero-token `llm_response` grouping carriers still do. The content path captures the canonical JSONL source/horizon but never runs a full-history aggregate. `ExactHistoryStats` is one async metadata task per activation/source/horizon: same-horizon Ctrl+U caches reuse it, while a genuinely newer horizon supersedes the old task. Accepted stats are cache/identity/generation/current-horizon-gated, reused by older-page caches, and incremented for parser-proven EOF refresh rows. JSONL content is read backward from EOF; top-level count/window metadata uses a structural fixed-buffer fast path across arbitrarily long string/nested payloads, enforces the same 10,000-container limit as `encoding/json`, and falls back to canonical one-record decoding whenever a bounded key/type/number lexeme or parser edge is declined. A cut legacy group retains only its nearest hidden `llm_response` marker. Increasing windows rescan the same canonical horizon, include every session row regardless of SQLite sparsity, and become complete only after reaching byte offset zero; parser-proven offsets, stable sort, and the shared completeness gate on both persistence and incremental disk append keep that convergence honest.
 - **`parseEvent` event-type allow-list.** Only certain `events.jsonl` / `log.sqlite` types become `SessionEntry`s: `thinking`, `diary`, `text_input`, `text_output`, `tool_call`, `tool_result`, `insight`, `soul_flow`, `notification`, `aed`, and `apriori_summary`. Four kernel-side rename/promotion rules at ingest: `consultation_fire → soul_flow` (carries `fire_id` for voice-index inflation against `logs/soul_flow.jsonl`); `notification_pair_injected → notification` (carries `sources []string` and prefers the kernel-logged `summary` string for body, **plus an optional `meta *NotificationMeta`** with `current_time`, `context.{system_tokens,history_tokens,usage}`, and `injection_seq` — the kernel's `build_meta` snapshot at injection time, rendered as a faint footer line by `mail.go`; nil for events written before issue #40); `aed_attempt`/`aed_exhausted`/`aed_timeout → aed` (subtype written to `Source`, body recovered from raw `type` plus per-subtype fields — `attempt`/`error`, `attempts`/`error`, `seconds`); and `apriori_summary_generated`/`apriori_summary_cap_refused`/`apriori_summary_failed`/`apriori_summary_empty`/`apriori_summary_no_summarizer → apriori_summary` (summary metadata and generated text preserved for Ctrl+O rendering). To surface a new event type in the chat replay: extend the rename map (if needed), the allow-list in `parseEventMap` (the `switch eventType` in `tui/internal/fs/session.go`) and the `sqlitelog` session-event filter (`sessionEventFilterSQL` in `tui/internal/sqlitelog/event.go`), `extractSessionEventText`, and the renderer in `tui/internal/tui/mail.go`.
 - **Provider derivation.** `DeriveLedgerProvider` uses endpoint host substring matching first, then model prefix fallback. Unknown endpoints surface the hostname so the UI still shows a breakdown.

--- a/tui/internal/fs/direct_mail.go
+++ b/tui/internal/fs/direct_mail.go
@@ -1,0 +1,67 @@
+package fs
+
+import "strings"
+
+// NormalizeMailEndpoints converts the mailbox schema's string-or-list endpoint
+// value into one deduplicated list. CC is deliberately not part of this input.
+func NormalizeMailEndpoints(value interface{}) []string {
+	var raw []string
+	switch endpoints := value.(type) {
+	case string:
+		raw = []string{endpoints}
+	case []string:
+		raw = endpoints
+	case []interface{}:
+		raw = make([]string, 0, len(endpoints))
+		for _, endpoint := range endpoints {
+			if text, ok := endpoint.(string); ok {
+				raw = append(raw, text)
+			}
+		}
+	default:
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(raw))
+	result := make([]string, 0, len(raw))
+	for _, endpoint := range raw {
+		endpoint = strings.TrimSpace(endpoint)
+		if endpoint == "" {
+			continue
+		}
+		if _, exists := seen[endpoint]; exists {
+			continue
+		}
+		seen[endpoint] = struct{}{}
+		result = append(result, endpoint)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// IsDirectMail reports whether msg belongs to the strict human-target thread.
+// Only From and To participate; CC never creates membership.
+func IsDirectMail(msg MailMessage, humanAddress, targetAddress string) bool {
+	humanAddress = strings.TrimSpace(humanAddress)
+	targetAddress = strings.TrimSpace(targetAddress)
+	from := strings.TrimSpace(msg.From)
+	if humanAddress == "" || targetAddress == "" {
+		return false
+	}
+	to := NormalizeMailEndpoints(msg.To)
+	if from == humanAddress {
+		return endpointListContains(to, targetAddress)
+	}
+	return from == targetAddress && endpointListContains(to, humanAddress)
+}
+
+func endpointListContains(endpoints []string, address string) bool {
+	for _, endpoint := range endpoints {
+		if endpoint == address {
+			return true
+		}
+	}
+	return false
+}

--- a/tui/internal/fs/direct_mail_test.go
+++ b/tui/internal/fs/direct_mail_test.go
@@ -1,0 +1,55 @@
+package fs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeMailEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		to   interface{}
+		want []string
+	}{
+		{name: "string", to: "agent-a", want: []string{"agent-a"}},
+		{name: "typed list", to: []string{"agent-a", "agent-b"}, want: []string{"agent-a", "agent-b"}},
+		{name: "decoded list", to: []interface{}{"agent-a", 7, "agent-b"}, want: []string{"agent-a", "agent-b"}},
+		{name: "trim empty and duplicates", to: []interface{}{" agent-a ", "", "agent-a"}, want: []string{"agent-a"}},
+		{name: "unsupported", to: map[string]string{"to": "agent-a"}, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeMailEndpoints(tt.to); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("NormalizeMailEndpoints(%#v) = %#v, want %#v", tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDirectMail(t *testing.T) {
+	const human = "project/human"
+	const main = "project/main"
+	const agentB = "project/agent-b"
+	tests := []struct {
+		name   string
+		msg    MailMessage
+		target string
+		want   bool
+	}{
+		{name: "human to scalar target", msg: MailMessage{From: human, To: main}, target: main, want: true},
+		{name: "human multi-to belongs to main", msg: MailMessage{From: human, To: []interface{}{main, agentB}}, target: main, want: true},
+		{name: "human multi-to belongs to b", msg: MailMessage{From: human, To: []string{main, agentB}}, target: agentB, want: true},
+		{name: "b multi-to belongs to b", msg: MailMessage{From: agentB, To: []interface{}{human, main}}, target: agentB, want: true},
+		{name: "b multi-to does not belong to main", msg: MailMessage{From: agentB, To: []interface{}{human, main}}, target: main, want: false},
+		{name: "cc does not create main membership", msg: MailMessage{From: agentB, To: human, CC: []string{main}}, target: main, want: false},
+		{name: "cc leaves b membership direct", msg: MailMessage{From: agentB, To: human, CC: []string{main}}, target: agentB, want: true},
+		{name: "human cc only is not direct", msg: MailMessage{From: human, To: agentB, CC: []string{main}}, target: main, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDirectMail(tt.msg, human, tt.target); got != tt.want {
+				t.Fatalf("IsDirectMail(%#v, %q, %q) = %v, want %v", tt.msg, human, tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/tui/internal/fs/network.go
+++ b/tui/internal/fs/network.go
@@ -76,7 +76,7 @@ func buildMailEdges(nodes []AgentNode, baseDir string) []MailEdge {
 		inbox, _ := ReadInbox(n.WorkingDir)
 		for _, msg := range inbox {
 			from := RelativizeAddress(ResolveAddress(msg.From, baseDir), baseDir)
-			recipients := resolveRecipients(msg.To)
+			recipients := NormalizeMailEndpoints(msg.To)
 			for _, r := range recipients {
 				counts[edgeKey{from, RelativizeAddress(ResolveAddress(r, baseDir), baseDir)}]++
 			}
@@ -92,22 +92,6 @@ func buildMailEdges(nodes []AgentNode, baseDir string) []MailEdge {
 		})
 	}
 	return edges
-}
-
-func resolveRecipients(to interface{}) []string {
-	switch v := to.(type) {
-	case string:
-		return []string{v}
-	case []interface{}:
-		var result []string
-		for _, item := range v {
-			if s, ok := item.(string); ok {
-				result = append(result, s)
-			}
-		}
-		return result
-	}
-	return nil
 }
 
 func computeStats(nodes []AgentNode, mailEdges []MailEdge) NetworkStats {

--- a/tui/internal/fs/rail_unread.go
+++ b/tui/internal/fs/rail_unread.go
@@ -1,0 +1,268 @@
+package fs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const RailUnreadStateVersion = 1
+
+type DirectTarget struct {
+	Directory string
+	Address   string
+}
+
+type unreadBoundary struct {
+	Timestamp string   `json:"timestamp,omitempty"`
+	IDs       []string `json:"ids,omitempty"`
+}
+
+type unreadTargetState struct {
+	AddressFingerprint string         `json:"address_fingerprint"`
+	LastSeen           unreadBoundary `json:"last_seen"`
+}
+
+type railUnreadState struct {
+	Version int                          `json:"version"`
+	Targets map[string]unreadTargetState `json:"targets"`
+}
+
+// RailUnreadStore owns the TUI's durable per-project direct-mail boundaries.
+// It is intentionally not a mailbox scanner; callers supply accepted snapshots.
+type RailUnreadStore struct {
+	path  string
+	state railUnreadState
+}
+
+func RailUnreadStatePath(projectDir string) string {
+	return filepath.Join(projectDir, ".tui-asset", "rail-last-seen.json")
+}
+
+func AddressFingerprint(address string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(address)))
+	return hex.EncodeToString(sum[:])
+}
+
+// OpenRailUnreadStore loads the versioned state. Missing, malformed, or
+// unsupported state is replaced with an all-read baseline at snapshot.
+func OpenRailUnreadStore(projectDir string, targets []DirectTarget, snapshot []MailMessage, humanAddress string) (*RailUnreadStore, error) {
+	store := &RailUnreadStore{
+		path: RailUnreadStatePath(projectDir),
+		state: railUnreadState{
+			Version: RailUnreadStateVersion,
+			Targets: make(map[string]unreadTargetState),
+		},
+	}
+	data, err := os.ReadFile(store.path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read rail unread state: %w", err)
+	}
+	valid := err == nil && json.Unmarshal(data, &store.state) == nil &&
+		store.state.Version == RailUnreadStateVersion && store.state.Targets != nil
+	if !valid {
+		store.state = railUnreadState{Version: RailUnreadStateVersion, Targets: make(map[string]unreadTargetState)}
+		store.baselineTargets(targets, snapshot, humanAddress)
+		if err := store.write(); err != nil {
+			return nil, err
+		}
+		return store, nil
+	}
+	if err := store.SyncTargets(targets, snapshot, humanAddress); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// SyncTargets drops disappeared directories and baselines new or address-changed
+// identities. Existing matching identities retain their last-seen boundary.
+func (s *RailUnreadStore) SyncTargets(targets []DirectTarget, snapshot []MailMessage, humanAddress string) error {
+	current := make(map[string]DirectTarget, len(targets))
+	for _, target := range targets {
+		key := canonicalTargetDirectory(target.Directory)
+		if key != "" {
+			current[key] = target
+		}
+	}
+	changed := false
+	for key := range s.state.Targets {
+		if _, exists := current[key]; !exists {
+			delete(s.state.Targets, key)
+			changed = true
+		}
+	}
+	for key, target := range current {
+		fingerprint := AddressFingerprint(target.Address)
+		state, exists := s.state.Targets[key]
+		if !exists || state.AddressFingerprint != fingerprint {
+			s.state.Targets[key] = unreadTargetState{
+				AddressFingerprint: fingerprint,
+				LastSeen:           incomingBoundary(snapshot, humanAddress, target.Address),
+			}
+			changed = true
+		}
+	}
+	if changed {
+		return s.write()
+	}
+	return nil
+}
+
+func (s *RailUnreadStore) UnreadCount(target DirectTarget, snapshot []MailMessage, humanAddress string) int {
+	state, ok := s.targetState(target)
+	if !ok {
+		return 0
+	}
+	boundaryTime := parseMailTime(state.LastSeen.Timestamp)
+	seenAtBoundary := make(map[string]struct{}, len(state.LastSeen.IDs))
+	for _, id := range state.LastSeen.IDs {
+		seenAtBoundary[id] = struct{}{}
+	}
+	count := 0
+	for _, msg := range snapshot {
+		if !isIncomingDirectMail(msg, humanAddress, target.Address) {
+			continue
+		}
+		messageTime := parseMailTime(msg.ReceivedAt)
+		if messageTime.IsZero() {
+			continue
+		}
+		if boundaryTime.IsZero() || messageTime.After(boundaryTime) {
+			count++
+			continue
+		}
+		if messageTime.Equal(boundaryTime) {
+			if _, seen := seenAtBoundary[mailBoundaryID(msg)]; !seen {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// MarkSeen advances exactly to the supplied accepted snapshot boundary. The
+// target must already match the identity accepted by the latest SyncTargets.
+func (s *RailUnreadStore) MarkSeen(target DirectTarget, snapshot []MailMessage, humanAddress string) error {
+	key := canonicalTargetDirectory(target.Directory)
+	if key == "" {
+		return fmt.Errorf("direct target directory is empty")
+	}
+	fingerprint := AddressFingerprint(target.Address)
+	state, exists := s.state.Targets[key]
+	if !exists {
+		return fmt.Errorf("direct target is not synchronized")
+	}
+	if state.AddressFingerprint != fingerprint {
+		return fmt.Errorf("direct target identity changed; synchronize targets before marking seen")
+	}
+	s.state.Targets[key] = unreadTargetState{
+		AddressFingerprint: fingerprint,
+		LastSeen:           incomingBoundary(snapshot, humanAddress, target.Address),
+	}
+	return s.write()
+}
+
+func (s *RailUnreadStore) targetState(target DirectTarget) (unreadTargetState, bool) {
+	state, ok := s.state.Targets[canonicalTargetDirectory(target.Directory)]
+	if !ok || state.AddressFingerprint != AddressFingerprint(target.Address) {
+		return unreadTargetState{}, false
+	}
+	return state, true
+}
+
+func (s *RailUnreadStore) baselineTargets(targets []DirectTarget, snapshot []MailMessage, humanAddress string) {
+	for _, target := range targets {
+		key := canonicalTargetDirectory(target.Directory)
+		if key == "" {
+			continue
+		}
+		s.state.Targets[key] = unreadTargetState{
+			AddressFingerprint: AddressFingerprint(target.Address),
+			LastSeen:           incomingBoundary(snapshot, humanAddress, target.Address),
+		}
+	}
+}
+
+func (s *RailUnreadStore) write() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("create rail unread directory: %w", err)
+	}
+	data, err := json.MarshalIndent(s.state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal rail unread state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := writeJSONAtomic(s.path, data); err != nil {
+		return fmt.Errorf("write rail unread state: %w", err)
+	}
+	return nil
+}
+
+func incomingBoundary(snapshot []MailMessage, humanAddress, targetAddress string) unreadBoundary {
+	var maximum time.Time
+	ids := make(map[string]struct{})
+	timestamp := ""
+	for _, msg := range snapshot {
+		if !isIncomingDirectMail(msg, humanAddress, targetAddress) {
+			continue
+		}
+		messageTime := parseMailTime(msg.ReceivedAt)
+		if messageTime.IsZero() {
+			continue
+		}
+		switch {
+		case maximum.IsZero() || messageTime.After(maximum):
+			maximum = messageTime
+			timestamp = msg.ReceivedAt
+			ids = map[string]struct{}{mailBoundaryID(msg): {}}
+		case messageTime.Equal(maximum):
+			ids[mailBoundaryID(msg)] = struct{}{}
+		}
+	}
+	result := unreadBoundary{Timestamp: timestamp}
+	for id := range ids {
+		if id != "" {
+			result.IDs = append(result.IDs, id)
+		}
+	}
+	sort.Strings(result.IDs)
+	return result
+}
+
+func isIncomingDirectMail(msg MailMessage, humanAddress, targetAddress string) bool {
+	return strings.TrimSpace(msg.From) == strings.TrimSpace(targetAddress) &&
+		IsDirectMail(msg, humanAddress, targetAddress)
+}
+
+func mailBoundaryID(msg MailMessage) string {
+	if msg.MailboxID != "" {
+		return msg.MailboxID
+	}
+	return msg.ID
+}
+
+func parseMailTime(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func canonicalTargetDirectory(directory string) string {
+	directory = strings.TrimSpace(directory)
+	if directory == "" {
+		return ""
+	}
+	absolute, err := filepath.Abs(directory)
+	if err != nil {
+		return filepath.Clean(directory)
+	}
+	return filepath.Clean(absolute)
+}

--- a/tui/internal/fs/rail_unread_test.go
+++ b/tui/internal/fs/rail_unread_test.go
@@ -1,0 +1,238 @@
+package fs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func incomingMail(id, from, human, ts string) MailMessage {
+	return MailMessage{ID: id, MailboxID: id, From: from, To: human, ReceivedAt: ts}
+}
+
+func TestRailUnreadSameTimestampLateIDAndRestart(t *testing.T) {
+	projectDir := t.TempDir()
+	human := "project/human"
+	target := DirectTarget{Directory: filepath.Join(projectDir, ".lingtai", "agent-b"), Address: "project/agent-b"}
+	first := incomingMail("id-1", target.Address, human, "2026-07-13T10:00:00Z")
+	store, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, []MailMessage{first}, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(target, []MailMessage{first}, human); got != 0 {
+		t.Fatalf("startup unread = %d, want 0", got)
+	}
+
+	late := incomingMail("id-2", target.Address, human, first.ReceivedAt)
+	snapshot := []MailMessage{first, late}
+	if got := store.UnreadCount(target, snapshot, human); got != 1 {
+		t.Fatalf("same-timestamp late-ID unread = %d, want 1", got)
+	}
+	if err := store.MarkSeen(target, snapshot, human); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, snapshot, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := restarted.UnreadCount(target, snapshot, human); got != 0 {
+		t.Fatalf("restart unread = %d, want 0", got)
+	}
+}
+
+func TestRailUnreadMissingAndCorruptStateBaselineCurrentSnapshot(t *testing.T) {
+	projectDir := t.TempDir()
+	human := "project/human"
+	target := DirectTarget{Directory: filepath.Join(projectDir, ".lingtai", "agent-b"), Address: "project/agent-b"}
+	history := []MailMessage{incomingMail("old", target.Address, human, "2026-07-13T09:00:00Z")}
+
+	store, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, history, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(target, history, human); got != 0 {
+		t.Fatalf("missing-state baseline unread = %d, want 0", got)
+	}
+	path := RailUnreadStatePath(projectDir)
+	if err := os.WriteFile(path, []byte("not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err = OpenRailUnreadStore(projectDir, []DirectTarget{target}, history, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(target, history, human); got != 0 {
+		t.Fatalf("corrupt-state baseline unread = %d, want 0", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(data, &persisted); err != nil || persisted.Version != RailUnreadStateVersion {
+		t.Fatalf("recovered state = version %d, err %v", persisted.Version, err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("atomic write left temp path; stat err = %v", err)
+	}
+}
+
+func TestRailUnreadIdentityChangesRebaselineAndOutgoingDoesNotCount(t *testing.T) {
+	projectDir := t.TempDir()
+	human := "project/human"
+	dir := filepath.Join(projectDir, ".lingtai", "agent-b")
+	target := DirectTarget{Directory: dir, Address: "project/agent-b"}
+	store, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, nil, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outgoing := MailMessage{ID: "out", MailboxID: "out", From: human, To: target.Address, ReceivedAt: "2026-07-13T10:00:00Z"}
+	if got := store.UnreadCount(target, []MailMessage{outgoing}, human); got != 0 {
+		t.Fatalf("outgoing unread = %d, want 0", got)
+	}
+	incoming := incomingMail("in", target.Address, human, "2026-07-13T10:01:00Z")
+	if got := store.UnreadCount(target, []MailMessage{outgoing, incoming}, human); got != 1 {
+		t.Fatalf("incoming unread = %d, want 1", got)
+	}
+
+	changed := DirectTarget{Directory: dir, Address: "project/agent-b-v2"}
+	changedHistory := []MailMessage{incomingMail("new-address-history", changed.Address, human, "2026-07-13T10:02:00Z")}
+	if err := store.SyncTargets([]DirectTarget{changed}, changedHistory, human); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(changed, changedHistory, human); got != 0 {
+		t.Fatalf("address-change unread = %d, want re-baselined 0", got)
+	}
+
+	if err := store.SyncTargets(nil, changedHistory, human); err != nil {
+		t.Fatal(err)
+	}
+	reusedHistory := append(changedHistory, incomingMail("reused", changed.Address, human, "2026-07-13T10:03:00Z"))
+	if err := store.SyncTargets([]DirectTarget{changed}, reusedHistory, human); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(changed, reusedHistory, human); got != 0 {
+		t.Fatalf("directory-reuse unread = %d, want re-baselined 0", got)
+	}
+}
+
+func TestRailUnreadUnsupportedVersionBaselinesCurrentSnapshot(t *testing.T) {
+	projectDir := t.TempDir()
+	human := "project/human"
+	target := DirectTarget{Directory: filepath.Join(projectDir, ".lingtai", "agent-b"), Address: "project/agent-b"}
+	history := []MailMessage{incomingMail("old", target.Address, human, "2026-07-13T09:00:00Z")}
+	path := RailUnreadStatePath(projectDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":999,"targets":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, history, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(target, history, human); got != 0 {
+		t.Fatalf("unsupported-version baseline unread = %d, want 0", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted railUnreadState
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Version != RailUnreadStateVersion {
+		t.Fatalf("recovered version = %d, want %d", persisted.Version, RailUnreadStateVersion)
+	}
+}
+
+func TestRailUnreadReadErrorIsNotTreatedAsMissingOrCorrupt(t *testing.T) {
+	projectDir := t.TempDir()
+	path := RailUnreadStatePath(projectDir)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := OpenRailUnreadStore(projectDir, nil, nil, "project/human")
+	if err == nil {
+		t.Fatal("OpenRailUnreadStore succeeded when the state path was unreadable")
+	}
+	if !strings.Contains(err.Error(), "read rail unread state") {
+		t.Fatalf("error = %q, want read failure context", err)
+	}
+}
+
+func TestRailUnreadNicknameRenameRetainsBoundary(t *testing.T) {
+	projectDir := t.TempDir()
+	human := "project/human"
+	before := AgentNode{
+		WorkingDir: filepath.Join(projectDir, ".lingtai", "agent-b"),
+		Address:    "project/agent-b",
+		Nickname:   "Before",
+	}
+	directTarget := func(node AgentNode) DirectTarget {
+		return DirectTarget{Directory: node.WorkingDir, Address: node.Address}
+	}
+	target := directTarget(before)
+	store, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, nil, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+	incoming := incomingMail("in", target.Address, human, "2026-07-13T10:00:00Z")
+	snapshot := []MailMessage{incoming}
+	if got := store.UnreadCount(target, snapshot, human); got != 1 {
+		t.Fatalf("pre-rename unread = %d, want 1", got)
+	}
+
+	after := before
+	after.Nickname = "After"
+	renamedTarget := directTarget(after)
+	if err := store.SyncTargets([]DirectTarget{renamedTarget}, snapshot, human); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.UnreadCount(renamedTarget, snapshot, human); got != 1 {
+		t.Fatalf("nickname-only rename unread = %d, want retained 1", got)
+	}
+}
+
+func TestRailUnreadMarkSeenRequiresSyncedIdentity(t *testing.T) {
+	projectDir := t.TempDir()
+	human := "project/human"
+	target := DirectTarget{Directory: filepath.Join(projectDir, ".lingtai", "agent-b"), Address: "project/agent-b"}
+	store, err := OpenRailUnreadStore(projectDir, []DirectTarget{target}, nil, human)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changed := DirectTarget{Directory: target.Directory, Address: "project/agent-b-v2"}
+	if err := store.MarkSeen(changed, nil, human); err == nil {
+		t.Fatal("MarkSeen accepted an address identity that had not been synchronized")
+	}
+	if err := store.SyncTargets([]DirectTarget{changed}, nil, human); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkSeen(changed, nil, human); err != nil {
+		t.Fatalf("MarkSeen rejected synchronized identity: %v", err)
+	}
+
+	unsynced := DirectTarget{Directory: filepath.Join(projectDir, ".lingtai", "agent-c"), Address: "project/agent-c"}
+	if err := store.MarkSeen(unsynced, nil, human); err == nil {
+		t.Fatal("MarkSeen accepted a target that had not been synchronized")
+	}
+}
+
+func TestRailUnreadNicknameIndependentAddressFingerprint(t *testing.T) {
+	if AddressFingerprint(" project/agent-b ") != AddressFingerprint("project/agent-b") {
+		t.Fatal("address fingerprint should normalize surrounding whitespace")
+	}
+	if AddressFingerprint("project/agent-b") == AddressFingerprint("project/agent-c") {
+		t.Fatal("different addresses must have different fingerprints")
+	}
+}

--- a/tui/internal/fs/session.go
+++ b/tui/internal/fs/session.go
@@ -120,6 +120,15 @@ type sessionHistoryCountPlan struct {
 	upper    int64
 }
 
+// SessionPersistenceRole separates history completeness from permission to
+// write the shared human/logs/session.jsonl aggregate.
+type SessionPersistenceRole uint8
+
+const (
+	NoPersist SessionPersistenceRole = iota
+	MainAggregateWriter
+)
+
 // SessionCache is an append-only cache backed by session.jsonl.
 // It incrementally tails three data sources and appends new entries.
 //
@@ -145,6 +154,7 @@ type SessionCache struct {
 	rebuilding         bool                    // true during RebuildFromSources — suppress file writes
 	complete           bool                    // true when the cache holds the full history; false after a windowed rebuild truncated older events
 	afterRebuildIngest func()                  // optional deterministic test hook after authoritative reads
+	persistenceRole    SessionPersistenceRole  // only MainAggregateWriter may change session.jsonl
 
 	// soulVoices indexes voices by fire_id, populated by tailing
 	// soul_flow.jsonl. Used to inflate soul_flow SessionEntry bodies that
@@ -163,24 +173,25 @@ type soulVoiceRecord struct {
 
 // NewSessionCache constructs an in-memory cache without touching the filesystem.
 // Parent directories are created only by accepted persistence/append writes.
-func NewSessionCache(humanDir string, projectPath string) *SessionCache {
+func NewSessionCache(humanDir string, projectPath string, persistenceRole SessionPersistenceRole) *SessionCache {
 	return &SessionCache{
-		path:        filepath.Join(humanDir, "logs", "session.jsonl"),
-		projectPath: projectPath,
-		soulVoices:  make(map[string][]soulVoiceRecord),
+		path:            filepath.Join(humanDir, "logs", "session.jsonl"),
+		projectPath:     projectPath,
+		soulVoices:      make(map[string][]soulVoiceRecord),
+		persistenceRole: persistenceRole,
 		// Complete-from-zero: a fresh cache holds nothing, which trivially IS the
-		// full (empty) history. A plain NewSessionCache + full Refresh + Persist
-		// (no windowed rebuild) therefore still writes session.jsonl, matching the
-		// pre-windowing Persist contract. Only a windowed rebuild that PROVES it
-		// truncated older events flips this false; the JSONL fallback and every
-		// full rebuild keep it true.
+		// full (empty) history. A MainAggregateWriter cache followed by full Refresh
+		// + Persist (no windowed rebuild) may therefore still write session.jsonl,
+		// matching the pre-windowing completeness contract. NoPersist remains
+		// memory-only regardless. Only a windowed rebuild that PROVES it truncated
+		// older events flips this false; full rebuilds keep it true.
 		complete: true,
 	}
 }
 
 // RebuildFromSources reads all data sources from scratch, merges and sorts them
-// chronologically, writes session.jsonl, and retains each source's last complete
-// consumed-record boundary for subsequent Refresh calls.
+// chronologically, requests a rewrite through the role-enforcing primitive, and
+// retains each source's last complete consumed-record boundary for Refresh.
 func (sc *SessionCache) RebuildFromSources(cache MailCache, humanAddr, orchDir, orchName string) {
 	sc.rebuildFromSources(cache, humanAddr, orchDir, orchName, true, 0)
 }
@@ -297,11 +308,10 @@ func (sc *SessionCache) rebuildFromSources(cache MailCache, humanAddr, orchDir, 
 	}
 }
 
-// Persist writes the accepted in-memory snapshot to session.jsonl — but ONLY
-// when the cache is proven complete. A partial (windowed) cache holds just the
-// newest slice of history; rewriting session.jsonl from it would truncate the
-// operator's complete derived replay file. In that case Persist is a no-op and
-// the existing complete session.jsonl (if any) is left untouched.
+// Persist requests that the accepted in-memory snapshot replace session.jsonl.
+// Completeness is a truncation-safety guard, not authorization: rewriteFile
+// separately permits only MainAggregateWriter. A partial cache is a no-op so it
+// cannot replace the operator's complete derived replay file.
 func (sc *SessionCache) Persist() {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
@@ -314,6 +324,9 @@ func (sc *SessionCache) Persist() {
 // rewriteFile overwrites session.jsonl with the current in-memory entries.
 // The caller must hold sc.mu.
 func (sc *SessionCache) rewriteFile() {
+	if sc.persistenceRole != MainAggregateWriter {
+		return
+	}
 	if err := os.MkdirAll(filepath.Dir(sc.path), 0o755); err != nil {
 		return
 	}
@@ -340,6 +353,9 @@ func (sc *SessionCache) append(entries ...SessionEntry) {
 	// cache is intentionally incomplete, so its incremental EOF additions must
 	// remain memory-only rather than create or extend a misleading session.jsonl.
 	if sc.rebuilding || !sc.complete {
+		return
+	}
+	if sc.persistenceRole != MainAggregateWriter {
 		return
 	}
 

--- a/tui/internal/fs/session_persistence_role_test.go
+++ b/tui/internal/fs/session_persistence_role_test.go
@@ -1,0 +1,115 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetachedSessionCacheSteadyRefreshRemainsMemoryOnly(t *testing.T) {
+	root := t.TempDir()
+	humanDir := filepath.Join(root, ".lingtai", "human")
+	sessionPath := filepath.Join(humanDir, "logs", "session.jsonl")
+	cache := MailCache{Messages: []MailMessage{{
+		ID:         "first",
+		MailboxID:  "first",
+		From:       "human",
+		To:         "agent-b",
+		Message:    "first",
+		ReceivedAt: "2026-07-13T10:00:00Z",
+	}}}
+
+	sc := NewSessionCache(humanDir, root, NoPersist)
+	sc.RebuildFromSourcesInMemory(cache, "human", "", "agent-b")
+	cache.Messages = append(cache.Messages, MailMessage{
+		ID:         "second",
+		MailboxID:  "second",
+		From:       "agent-b",
+		To:         "human",
+		Message:    "second",
+		ReceivedAt: "2026-07-13T10:01:00Z",
+	})
+	sc.Refresh(cache, "human", "", "agent-b")
+
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Fatalf("memory-only cache steady refresh wrote %s; stat err = %v", sessionPath, err)
+	}
+	if got := sc.Len(); got != 2 {
+		t.Fatalf("memory-only cache length = %d, want 2", got)
+	}
+}
+
+func TestNoPersistSessionCacheNeverChangesAggregateFile(t *testing.T) {
+	root := t.TempDir()
+	humanDir := filepath.Join(root, ".lingtai", "human")
+	sessionPath := filepath.Join(humanDir, "logs", "session.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const original = "existing-main-aggregate\n"
+	if err := os.WriteFile(sessionPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cache := MailCache{Messages: []MailMessage{{
+		ID: "only", MailboxID: "only", From: "agent-b", To: "human",
+		Message: "short complete history", ReceivedAt: "2026-07-13T10:00:00Z",
+	}}}
+
+	sc := NewSessionCache(humanDir, root, NoPersist)
+	sc.RebuildFromSources(cache, "human", "", "agent-b")
+	if !sc.Complete() {
+		t.Fatal("short full rebuild should be complete")
+	}
+	sc.Persist()
+	cache.Messages = append(cache.Messages, MailMessage{
+		ID: "next", MailboxID: "next", From: "agent-b", To: "human",
+		Message: "steady append", ReceivedAt: "2026-07-13T10:01:00Z",
+	})
+	sc.Refresh(cache, "human", "", "agent-b")
+
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != original {
+		t.Fatalf("noPersist changed aggregate file: %q", data)
+	}
+}
+
+func TestMainAggregateWriterRebuildAndRefreshPersist(t *testing.T) {
+	root := t.TempDir()
+	humanDir := filepath.Join(root, ".lingtai", "human")
+	sessionPath := filepath.Join(humanDir, "logs", "session.jsonl")
+	cache := MailCache{Messages: []MailMessage{{
+		ID: "first", MailboxID: "first", From: "human", To: "main",
+		Message: "first", ReceivedAt: "2026-07-13T10:00:00Z",
+	}}}
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
+	sc.RebuildFromSources(cache, "human", "", "main")
+	cache.Messages = append(cache.Messages, MailMessage{
+		ID: "second", MailboxID: "second", From: "main", To: "human",
+		Message: "second", ReceivedAt: "2026-07-13T10:01:00Z",
+	})
+	sc.Refresh(cache, "human", "", "main")
+
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(sc.Entries()); got != 2 {
+		t.Fatalf("writer entries = %d, want 2", got)
+	}
+	if string(data) == "" || !containsAll(string(data), "first", "second") {
+		t.Fatalf("writer aggregate file missing rebuild/append entries: %q", data)
+	}
+}
+
+func containsAll(s string, values ...string) bool {
+	for _, value := range values {
+		if !strings.Contains(s, value) {
+			return false
+		}
+	}
+	return true
+}

--- a/tui/internal/fs/session_race_test.go
+++ b/tui/internal/fs/session_race_test.go
@@ -42,7 +42,7 @@ func TestSessionCacheConcurrentRebuildAndRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sc := NewSessionCache(humanDir, tmp)
+	sc := NewSessionCache(humanDir, tmp, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 
 	var wg sync.WaitGroup

--- a/tui/internal/fs/session_rebuild_offsets_test.go
+++ b/tui/internal/fs/session_rebuild_offsets_test.go
@@ -13,7 +13,7 @@ func TestSessionCacheConstructionAndDetachedRebuildAreFilesystemPure(t *testing.
 	orchDir := filepath.Join(root, "orch")
 	writeSessionTestFile(t, filepath.Join(orchDir, "logs", "events.jsonl"), `{"ts":1781300001,"type":"text_output","text":"detached"}`+"\n")
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	if _, err := os.Stat(humanDir); !os.IsNotExist(err) {
 		t.Fatalf("constructor touched human directory: stat error = %v", err)
 	}
@@ -36,7 +36,7 @@ func TestRebuildPreservesTrailingPartialJSONLRecords(t *testing.T) {
 			`{"ts":1781300001,"type":"text_output","text":"first"}`+"\n"+
 				`{"ts":1781300002,"type":"text_output","text":"sec`)
 
-		sc := NewSessionCache(humanDir, root)
+		sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 		cache := NewMailCache(humanDir).Refresh()
 		sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 		appendSessionTestFile(t, path, `ond"}`+"\n")
@@ -51,7 +51,7 @@ func TestRebuildPreservesTrailingPartialJSONLRecords(t *testing.T) {
 			`{"ts":"2026-06-12T21:33:21Z","source":"human","voice":"first"}`+"\n"+
 				`{"ts":"2026-06-12T21:33:22Z","source":"insight","voice":"sec`)
 
-		sc := NewSessionCache(humanDir, root)
+		sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 		cache := NewMailCache(humanDir).Refresh()
 		sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 		appendSessionTestFile(t, path, `ond"}`+"\n")
@@ -66,7 +66,7 @@ func TestRebuildPreservesTrailingPartialJSONLRecords(t *testing.T) {
 		path := filepath.Join(orchDir, "logs", "soul_flow.jsonl")
 		writeSessionTestFile(t, path, `{"kind":"voice","fire_id":"fire-partial","source":"insights","voice":"partial`)
 
-		sc := NewSessionCache(humanDir, root)
+		sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 		cache := NewMailCache(humanDir).Refresh()
 		sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 		appendSessionTestFile(t, path, ` voice"}`+"\n")
@@ -86,7 +86,7 @@ func TestRebuildPreservesAppendsThatLandAfterAuthoritativeReads(t *testing.T) {
 	writeSessionTestFile(t, inquiryPath, `{"ts":"2026-06-12T21:33:21Z","source":"human","voice":"before inquiry"}`+"\n")
 	writeSessionTestFile(t, soulPath, "")
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.afterRebuildIngest = func() {
 		appendSessionTestFile(t, eventsPath, `{"ts":1781300003,"type":"text_output","text":"during event"}`+"\n")
 		appendSessionTestFile(t, inquiryPath, `{"ts":"2026-06-12T21:33:23Z","source":"insight","voice":"during inquiry"}`+"\n")

--- a/tui/internal/fs/session_rebuild_test.go
+++ b/tui/internal/fs/session_rebuild_test.go
@@ -45,7 +45,7 @@ func TestRebuildDeduplicatesMailAcrossRestart(t *testing.T) {
 	}
 
 	// First rebuild (simulates fresh launch)
-	sc1 := NewSessionCache(humanDir, tmp)
+	sc1 := NewSessionCache(humanDir, tmp, MainAggregateWriter)
 	cache1 := NewMailCache(humanDir).Refresh()
 	sc1.RebuildFromSources(cache1, "human", orchDir, "xiake")
 	firstLen := sc1.Len()
@@ -54,7 +54,7 @@ func TestRebuildDeduplicatesMailAcrossRestart(t *testing.T) {
 	}
 
 	// Second rebuild (simulates relaunch — the bug scenario)
-	sc2 := NewSessionCache(humanDir, tmp)
+	sc2 := NewSessionCache(humanDir, tmp, MainAggregateWriter)
 	cache2 := NewMailCache(humanDir).Refresh()
 	sc2.RebuildFromSources(cache2, "human", orchDir, "xiake")
 	secondLen := sc2.Len()
@@ -88,7 +88,7 @@ func TestIngestMailWatermarkSkipsOldMail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sc := NewSessionCache(humanDir, tmp)
+	sc := NewSessionCache(humanDir, tmp, MainAggregateWriter)
 	sc.lastMailTs = "2026-04-10T00:00:00Z" // simulate post-rebuild watermark
 
 	cache := MailCache{
@@ -126,7 +126,7 @@ func TestRefreshDoesNotReingestSQLiteHistory(t *testing.T) {
 		sessionSQLiteInsert(1.0, "text_input", "hello from sqlite", rootSource, 0, "agent_events", "agent"),
 	)
 
-	sc := NewSessionCache(humanDir, tmp)
+	sc := NewSessionCache(humanDir, tmp, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.afterRebuildIngest = func() {
 		appendSessionTestFile(t, eventsPath,
@@ -157,7 +157,7 @@ func TestCanonicalJSONLRebuildIgnoresForeignSQLiteRows(t *testing.T) {
 				sessionSQLiteInsert(1.5, "text_output", "daemon leaked", daemonSource, int64(len(firstLine+tailLine)+100), "daemon_events", "daemon"),
 		)
 
-		sc := NewSessionCache(humanDir, root)
+		sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 		cache := NewMailCache(humanDir).Refresh()
 		sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 		assertSessionBodiesExactly(t, sc.Entries(), "root indexed", "root tail")
@@ -180,7 +180,7 @@ func TestCanonicalJSONLRebuildIgnoresForeignSQLiteRows(t *testing.T) {
 				sessionSQLiteInsert(1.5, "text_output", "foreign leaked", foreignSource, foreignOffset, "agent_events", "agent"),
 		)
 
-		sc := NewSessionCache(humanDir, root)
+		sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 		cache := NewMailCache(humanDir).Refresh()
 		sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 		assertSessionBodiesExactly(t, sc.Entries(), "root indexed", "root must not be skipped")
@@ -202,7 +202,7 @@ func TestCanonicalJSONLRebuildIncludesRowsMissingFromSQLite(t *testing.T) {
 		sessionSQLiteInsert(1.0, "text_input", "covered before query", rootSource, 0, "agent_events", "agent"),
 	)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 	assertSessionBodiesExactly(t, sc.Entries(), "covered before query", "missing from sqlite")
@@ -223,7 +223,7 @@ func TestSQLiteReplayRejectsInvalidNoNewlineBoundary(t *testing.T) {
 		sessionSQLiteInsert(1.0, "text_input", "complete only after newline", rootSource, 0, "agent_events", "agent"),
 	)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 	assertSessionBodiesExactly(t, sc.Entries())
@@ -255,7 +255,7 @@ func TestSQLiteReplayFallsBackWhenRootIdentityCannotBeProven(t *testing.T) {
 	`
 	runSessionSQLiteSQL(t, sqliteBin, orchDir, oldSchema)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesInMemory(cache, "human", orchDir, "orch")
 	sc.Refresh(cache, "human", orchDir, "orch")

--- a/tui/internal/fs/session_window_test.go
+++ b/tui/internal/fs/session_window_test.go
@@ -156,7 +156,7 @@ func TestWindowedRebuildTailIndexReachesJSONLPrefixOnOlderLoad(t *testing.T) {
 	cache := NewMailCache(humanDir).Refresh()
 
 	// (1) Initial newest window of 3 → newest 3 events (e9,e10,e11), partial.
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 3)
 	assertSessionMarkersExactly(t, sc.Entries(), "e9", "e10", "e11")
 	if sc.Complete() {
@@ -166,14 +166,14 @@ func TestWindowedRebuildTailIndexReachesJSONLPrefixOnOlderLoad(t *testing.T) {
 	// (2) A larger explicit older request (window 8) exhausts the 4 indexed tail
 	// rows and must reach the un-indexed JSONL prefix — no duplicates, no order
 	// break. Newest 8 events are e4..e11.
-	sc2 := NewSessionCache(humanDir, root)
+	sc2 := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc2.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 8)
 	assertSessionMarkersExactly(t, sc2.Entries(),
 		"e4", "e5", "e6", "e7", "e8", "e9", "e10", "e11")
 
 	// (3) A window >= whole history (12) reaches the whole prefix → complete and
 	// persistable.
-	sc3 := NewSessionCache(humanDir, root)
+	sc3 := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc3.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 12)
 	assertSessionMarkersExactly(t, sc3.Entries(),
 		"e0", "e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10", "e11")
@@ -197,7 +197,7 @@ func TestWindowedExactEqualWindowIsComplete(t *testing.T) {
 	cache := NewMailCache(humanDir).Refresh()
 
 	// Window exactly equal to history reaches byte offset zero and is complete.
-	scEqual := NewSessionCache(humanDir, root)
+	scEqual := NewSessionCache(humanDir, root, MainAggregateWriter)
 	scEqual.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 4)
 	assertSessionBodiesExactly(t, scEqual.Entries(), "e0", "e1", "e2", "e3")
 	if !scEqual.Complete() {
@@ -205,7 +205,7 @@ func TestWindowedExactEqualWindowIsComplete(t *testing.T) {
 	}
 
 	// A larger request remains complete and stable.
-	scNext := NewSessionCache(humanDir, root)
+	scNext := NewSessionCache(humanDir, root, MainAggregateWriter)
 	scNext.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 8)
 	assertSessionBodiesExactly(t, scNext.Entries(), "e0", "e1", "e2", "e3")
 	if !scNext.Complete() {
@@ -222,7 +222,7 @@ func TestWindowedRebuildKeepsOnlyNewestEventsButFullEOFOffset(t *testing.T) {
 	root, humanDir, orchDir := newSessionTestDirs(t)
 	buildWindowSQLiteEvents(t, sqliteBin, orchDir, 10)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 3)
 
@@ -251,7 +251,7 @@ func TestWindowedRebuildWithoutSQLitePreservesLegacyGroupBoundary(t *testing.T) 
 		`{"type":"tool_result","ts":5,"tool_name":"grep","status":"ok"}` + "\n"
 	writeSessionTestFile(t, eventsPath, content)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(NewMailCache(humanDir).Refresh(), "human", orchDir, "orch", 3)
 	entries := sc.Entries()
 	if len(entries) != 4 || entries[0].Type != "llm_response" {
@@ -275,7 +275,7 @@ func TestWindowedRebuildWithoutSQLiteRetainsOnlyNewestContentAndCountsAll(t *tes
 	writeSessionTestFile(t, eventsPath, content)
 	cache := NewMailCache(humanDir).Refresh()
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 3)
 	assertSessionBodiesExactly(t, sc.Entries(), "e7", "e8", "e9")
 	if sc.Complete() {
@@ -299,7 +299,7 @@ func TestWindowedRebuildWithoutSQLiteRetainsOnlyNewestContentAndCountsAll(t *tes
 		t.Fatalf("stats after tail refresh = %+v, want Detailed=11", stats)
 	}
 
-	complete := NewSessionCache(humanDir, root)
+	complete := NewSessionCache(humanDir, root, MainAggregateWriter)
 	complete.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 20)
 	if !complete.Complete() || complete.Len() != 11 {
 		t.Fatalf("larger no-index window = complete %v len %d, want true/11", complete.Complete(), complete.Len())
@@ -316,7 +316,7 @@ func TestJSONLWindowSkipsHugeOlderBodyAndCountsItFromBoundedMetadata(t *testing.
 		sessionEventJSONL(4, "text_output", "e3")
 	writeSessionTestFile(t, eventsPath, content)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(NewMailCache(humanDir).Refresh(), "human", orchDir, "orch", 2)
 	assertSessionBodiesExactly(t, sc.Entries(), "e2", "e3")
 	stats, _, err := sc.ExactHistoryStats()
@@ -351,7 +351,7 @@ func TestWindowedRebuildSparseInteriorIndexUsesCanonicalJSONL(t *testing.T) {
 	createSessionSQLite(t, sqliteBin, orchDir, inserts)
 	cache := NewMailCache(humanDir).Refresh()
 
-	newest := NewSessionCache(humanDir, root)
+	newest := NewSessionCache(humanDir, root, MainAggregateWriter)
 	newest.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 3)
 	assertSessionBodiesExactly(t, newest.Entries(), "e7", "e8", "e9")
 	if newest.Complete() {
@@ -362,14 +362,14 @@ func TestWindowedRebuildSparseInteriorIndexUsesCanonicalJSONL(t *testing.T) {
 		t.Fatalf("canonical sparse-index stats = %+v err=%v, want 10 detailed", stats, err)
 	}
 
-	older := NewSessionCache(humanDir, root)
+	older := NewSessionCache(humanDir, root, MainAggregateWriter)
 	older.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 6)
 	assertSessionBodiesExactly(t, older.Entries(), "e4", "e5", "e6", "e7", "e8", "e9")
 	if older.Complete() {
 		t.Fatal("interior holes are incorporated, but older canonical history still remains")
 	}
 
-	all := NewSessionCache(humanDir, root)
+	all := NewSessionCache(humanDir, root, MainAggregateWriter)
 	all.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 10)
 	assertSessionBodiesExactly(t, all.Entries(), "e0", "e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9")
 	if !all.Complete() {
@@ -386,7 +386,7 @@ func TestSessionMetadataStructuralLateKeysAndNestedDecoys(t *testing.T) {
 		`{"nested":{"type":"text_output","text":"nested only","input_tokens":5},"padding":"` + huge + `","type":"not_session","ts":3}` + "\n"
 	writeSessionTestFile(t, eventsPath, content)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(NewMailCache(humanDir).Refresh(), "human", orchDir, "orch", 10)
 	entries := sc.Entries()
 	if len(entries) != 2 || entries[0].Type != "text_output" || entries[0].Body != "late text" || entries[1].Type != "llm_response" {
@@ -418,7 +418,7 @@ func TestWindowedRebuildSkipsNonRenderableTextMetadata(t *testing.T) {
 	}, "\n") + "\n"
 	writeSessionTestFile(t, eventsPath, content)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(NewMailCache(humanDir).Refresh(), "human", orchDir, "orch", 5)
 	entries := sc.Entries()
 	wantTypes := []string{"llm_call", "text_output", "llm_response", "insight", "text_output"}
@@ -476,7 +476,7 @@ func TestSessionMetadataCanonicalNumericFallback(t *testing.T) {
 		})
 	}
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(NewMailCache(humanDir).Refresh(), "human", orchDir, "orch", 10)
 	entries := sc.Entries()
 	if len(entries) != 2 || entries[0].Body != "finite ignored number" || entries[1].Type != "llm_response" {
@@ -521,7 +521,7 @@ func TestSessionMetadataCanonicalDepthLimit(t *testing.T) {
 		t.Fatalf("over-depth metadata unexpectedly accepted: %+v", got)
 	}
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	sc.RebuildFromSourcesWindowedInMemory(NewMailCache(humanDir).Refresh(), "human", orchDir, "orch", 10)
 	entries := sc.Entries()
 	if len(entries) != 1 || entries[0].Body != "root plus 9999 arrays" {
@@ -541,7 +541,7 @@ func TestWindowedRebuildLargerThanHistoryIsComplete(t *testing.T) {
 	root, humanDir, orchDir := newSessionTestDirs(t)
 	buildWindowSQLiteEvents(t, sqliteBin, orchDir, 4)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 2000)
 
@@ -560,7 +560,7 @@ func TestPersistRefusesPartialWindowedCache(t *testing.T) {
 
 	sessionPath := filepath.Join(humanDir, "logs", "session.jsonl")
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 3)
 	sc.Persist()
@@ -581,7 +581,7 @@ func TestPartialWindowRefreshDoesNotAppendSessionFile(t *testing.T) {
 	cache := NewMailCache(humanDir).Refresh()
 	sessionPath := filepath.Join(humanDir, "logs", "session.jsonl")
 
-	partial := NewSessionCache(humanDir, root)
+	partial := NewSessionCache(humanDir, root, MainAggregateWriter)
 	partial.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 2)
 	if partial.Complete() {
 		t.Fatal("two-entry window over four events must be partial")
@@ -603,7 +603,7 @@ func TestPartialWindowRefreshDoesNotAppendSessionFile(t *testing.T) {
 		t.Fatalf("partial EOF refresh must leave session.jsonl absent; stat err = %v", err)
 	}
 
-	complete := NewSessionCache(humanDir, root)
+	complete := NewSessionCache(humanDir, root, MainAggregateWriter)
 	complete.Refresh(cache, "human", orchDir, "orch")
 	complete.Persist()
 	if data, err := os.ReadFile(sessionPath); err != nil || len(data) == 0 {
@@ -623,7 +623,7 @@ func TestFreshCacheRefreshPersistsAsComplete(t *testing.T) {
 	writeSessionTestFile(t, eventsPath,
 		`{"ts":1781300001,"type":"text_output","text":"only"}`+"\n")
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	// A plain Refresh reads the whole file from offset 0 — a full, complete load.
 	sc.Refresh(cache, "human", orchDir, "orch")
@@ -649,7 +649,7 @@ func TestWindowedRebuildUnboundedMatchesLegacy(t *testing.T) {
 	root, humanDir, orchDir := newSessionTestDirs(t)
 	buildWindowSQLiteEvents(t, sqliteBin, orchDir, 5)
 
-	sc := NewSessionCache(humanDir, root)
+	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
 	cache := NewMailCache(humanDir).Refresh()
 	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 0)
 

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -261,7 +261,7 @@ func NewMailModel(humanDir, humanAddr, baseDir, orchDir, orchName string, pageSi
 		insightsEnabled:   insights,
 		toolCallTruncate:  toolCallTruncate,
 		dismissedInsights: make(map[string]bool),
-		sessionCache:      fs.NewSessionCache(humanDir, filepath.Dir(baseDir)),
+		sessionCache:      fs.NewSessionCache(humanDir, filepath.Dir(baseDir), fs.MainAggregateWriter),
 		// The authoritative session rebuild is deferred to initialRebuild() (see
 		// below), so the first frames render before history is loaded. Show a
 		// loading banner at the top of the stream until that rebuild's refresh
@@ -299,7 +299,7 @@ func (m MailModel) initialRebuild() tea.Msg {
 	// mail_page_size directly owns both the initial newest content window and the
 	// visible/reveal batch. Exact full-history metadata is launched separately
 	// after this bounded content result is accepted.
-	sessionCache := fs.NewSessionCache(m.humanDir, filepath.Dir(m.baseDir))
+	sessionCache := fs.NewSessionCache(m.humanDir, filepath.Dir(m.baseDir), fs.MainAggregateWriter)
 	sessionCache.RebuildFromSourcesWindowedInMemory(cache, m.humanAddr, m.orchestrator, m.orchDisplayName(), m.pageSize)
 	m.cache = cache
 	// Tag the resulting refresh as the initial one so the handler can clear the
@@ -341,7 +341,7 @@ func (m MailModel) requestOlderPage() (MailModel, tea.Cmd) {
 // accepts this generation.
 func (m MailModel) olderPageCmd(window int, generation uint64) tea.Msg {
 	cache := m.cache.Refresh()
-	sessionCache := fs.NewSessionCache(m.humanDir, filepath.Dir(m.baseDir))
+	sessionCache := fs.NewSessionCache(m.humanDir, filepath.Dir(m.baseDir), fs.MainAggregateWriter)
 	sessionCache.RebuildFromSourcesWindowedInMemory(cache, m.humanAddr, m.orchestrator, m.orchDisplayName(), window)
 	return mailOlderPageMsg{
 		generation:   generation,


### PR DESCRIPTION
## Summary

- add one list-first endpoint normalizer and strict human↔Agent direct-mail predicate for scalar, list, multi-`To`, and CC cases
- add a versioned, atomic per-project unread-boundary store keyed by canonical Agent directory plus address fingerprint
- make `SessionCache` disk ownership explicit with zero-safe `NoPersist` and sole-writer `MainAggregateWriter` roles enforced inside both write primitives
- remove the superseded topology recipient parser, update all current Main cache construction sites, and document the ownership contracts in package anatomy

Part of #645 (the first independent root PR in the issue's implementation DAG). This is a behavior-preserving semantic foundation: it does **not** add the Agent rail, switch the Main viewport to strict direct mail, wire ordinary Agent threads, change the kernel mail schema, or alter legacy mailbox labels.

## Behavior and scope

### Direct-mail semantics

`NormalizeMailEndpoints` produces one trimmed, order-preserving, deduplicated endpoint list from scalar strings, `[]string`, and JSON-decoded lists. `IsDirectMail` accepts only these two relationships:

- human → target, with the target in `To`
- target → human, with the human in `To`

CC never establishes direct-thread membership. The topology builder reuses only the shared normalizer, eliminating its duplicate parser without coupling display behavior to the direct-thread predicate. Literal duplicate `To` entries now normalize to one endpoint rather than double-counting the same topology edge.

### Durable unread boundary

The new version-1 store lives at `.tui-asset/rail-last-seen.json` and records the maximum accepted timestamp plus all IDs observed at that same timestamp. It:

- uses canonical Agent directory plus address fingerprint for identity
- writes atomically through the existing filesystem primitive
- treats missing, corrupt, and unsupported-version state as an all-read baseline at the accepted snapshot
- preserves boundaries across nickname-only changes
- re-baselines on address change, disappearance, or directory reuse
- counts only incoming direct Agent→human mail
- requires `SyncTargets` to accept the current identity before `MarkSeen`
- surfaces non-missing state-read failures instead of treating them as missing state

This PR exposes the foundation API only; later rail/lifecycle work owns accepted-snapshot wiring.

### Session persistence ownership

`SessionPersistenceRole` has a fail-closed zero value, `NoPersist`, and an explicit `MainAggregateWriter` role. Authorization is checked inside both `rewriteFile` and `append`, so rebuild, explicit persist, rewrite, and steady refresh cannot bypass it. A short history with `complete=true` is still never authorized to write.

All current `MailModel` cache construction sites explicitly use `MainAggregateWriter`, so the existing aggregate `human/logs/session.jsonl` behavior and visible Main chat remain unchanged in this PR.

## Test-first evidence

The original contract test was written and run against base `d0167c35d696654899678e5a5498df04ebab6492` before implementation:

```sh
go test ./internal/fs -run '^TestDetachedSessionCacheSteadyRefreshRemainsMemoryOnly$' -count=1
```

It exited `1` after compiling and exercising the real steady-refresh path because the memory-only cache created `human/logs/session.jsonl`. This was the intended missing-authorization failure, not a syntax, import, dependency, environment, or unrelated flaky-test failure. The contemporaneous RED record has SHA-256 `78aab5ba00a5084309aff12e81d52cf2727d69159cc4938f839ab356c170b79b`.

Parent review then added edge-contract tests before the corresponding production correction:

```sh
go test ./internal/fs -run 'TestRailUnread(UnsupportedVersion|ReadError|NicknameRename|MarkSeen)' -count=1
```

That run exited `1` with the two intended failures: non-missing read errors lacked read context, and `MarkSeen` accepted an identity that had not been synchronized. Its RED record has SHA-256 `ed41b8b14a8b4f985b6fcf17515bde07a5040bf99cdf0fc0b59d3f28c21c12af`.

## Validation

Exact candidate: `05e73f17477f830b93af2033046ee19902dd3fcb`

```sh
# focused PR1 contracts
go test ./internal/fs -run 'Test(NormalizeMailEndpoints|IsDirectMail|RailUnread|DetachedSessionCache|NoPersistSessionCache|MainAggregateWriter)' -count=1

# complete changed package and TUI module
go test ./internal/fs -count=1
go test ./... -count=1

# static and patch gates
go vet ./...
git diff --check

# complete race-enabled module except one proven pre-existing timing flake
go test -race ./... -skip '^TestPortalURLTimeoutKillsChild$'
```

All listed commands passed. The repository-wide anatomy checker also passed with `447` citations and `0` missing or out-of-range targets; changed citations were inspected semantically.

The unfiltered race suite passed every package changed by this PR and failed only untouched `TestPortalURLTimeoutKillsChild`, whose fake child has a 400 ms startup deadline. The same assertion reproduced on a clean detached canonical base 5 times in 50 race-stressed runs; the candidate reproduced it 2 times in 10. No portal code or test is changed here.

Independent review of this exact final HEAD:

- Claude: **PASS**, no blockers; independently verified the RED chronology and ran focused/full tests, build, vet, formatting/diff, anatomy, and bounded race checks
- Codex (`gpt-5.6-sol`, high reasoning): **PASS**, no code or contract blockers; its read-only sandbox could not create Go temporary compilation directories, a limitation stated in its report and covered by the exact parent and Claude executable validation above

A prior old-HEAD Codex review caught one inaccurate anatomy sentence about unconditional rewrite behavior. The sentence was corrected to describe the role-gated rewrite, the full parent gates were rerun, the commit was amended, and both final reviewers freshly reviewed the new exact HEAD; no old-HEAD verdict was carried forward.

## Cleanup and bridge ledger

- duplicate `resolveRecipients` parsing is removed
- every `NewSessionCache` call supplies an explicit persistence role
- both disk primitives enforce the role; `complete` remains only a window/completeness fact
- legacy label-formatting paths remain intentionally unchanged
- no duplicate writer, store adapter, compatibility branch, or ownerless TODO remains
- bridge ledger: empty

## Risks and non-goals

The unread store consumes accepted snapshots supplied by its future owner; it intentionally performs no mailbox scan and owns no timer in this PR. Later lifecycle work must call `SyncTargets` with the accepted project target set and must not install rejected or wrong-project snapshots.

No visible rail, target switching, strict-Main projection, or ordinary-thread cache is introduced here.

## Rollback

Before downstream consumers exist, reverting this commit removes the foundation as one unit and restores the former implicit persistence behavior. Do not roll back `NoPersist` alone after ordinary Agent thread caches begin depending on it.
