### PR TITLE
fix(mcp): use bundled curated module paths

### DIFF
--- a/examples/init.jsonc
+++ b/examples/init.jsonc
@@ -173,10 +173,9 @@
   // =============================================================
   // Addons — curated MCP server integrations
   // =============================================================
-  // As of v0.7.3, addons are MCP servers that ship as separate PyPI
-  // packages (lingtai-imap, lingtai-telegram, lingtai-feishu, lingtai-wechat),
-  // installed alongside the kernel by `pip install lingtai`. The TUI
-  // wires them up in two halves:
+  // Curated addons are MCP servers bundled in the `lingtai` wheel under
+  // `lingtai.mcp_servers.*`. The TUI installs that wheel in its local runtime
+  // venv and wires the selected addons up in two halves:
   //
   // 1. The `addons:` list below — names of curated MCPs the agent
   //    should "register" on boot. The kernel's `mcp` capability looks
@@ -191,16 +190,17 @@
   //
   // Default for new agents (auto-populated by the TUI wizard):
   //
-  //   "addons": ["imap", "telegram", "feishu", "wechat"],
+  //   "addons": ["imap", "telegram", "feishu", "wechat", "whatsapp"],
   //   "mcp": {
   //     "imap":     { "type": "stdio", "command": "<venv>/bin/python",
-  //                   "args": ["-m", "lingtai_imap"],
+  //                   "args": ["-m", "lingtai.mcp_servers.imap"],
   //                   "env": { "LINGTAI_IMAP_CONFIG": ".secrets/imap.json" } },
-  //     "telegram": { ... }, "feishu": { ... }, "wechat": { ... }
+  //     "telegram": { ... }, "feishu": { ... }, "wechat": { ... },
+  //     "whatsapp": { ... }
   //   }
   //
-  // The `command` always points at the local venv Python where pip
-  // installed the MCP packages — no remote fetch at runtime.
+  // The `command` always points at the local venv Python where the `lingtai`
+  // wheel installed its bundled MCP modules — no remote fetch at runtime.
   //
   // Per-MCP secrets live in <agent>/.secrets/<name>.json — plaintext JSON
   // (no *_env indirection in the new MCP shape). Each MCP's README

--- a/portal/internal/migrate/m028_addons_to_mcp.go
+++ b/portal/internal/migrate/m028_addons_to_mcp.go
@@ -26,7 +26,7 @@ import (
 //	    "imap": {
 //	      "type": "stdio",
 //	      "command": "/Users/.../runtime/venv/bin/python",
-//	      "args": ["-m", "lingtai_imap"],
+//	      "args": ["-m", "lingtai.mcp_servers.imap"],
 //	      "env": {"LINGTAI_IMAP_CONFIG": ".secrets/imap.json"}
 //	    }
 //	  }
@@ -85,11 +85,11 @@ type addonSpec struct {
 }
 
 var addonSpecs = map[string]addonSpec{
-	"imap":     {module: "lingtai_imap", envVarName: "LINGTAI_IMAP_CONFIG", defaultRel: ".secrets/imap.json"},
-	"telegram": {module: "lingtai_telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
-	"feishu":   {module: "lingtai_feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
-	"wechat":   {module: "lingtai_wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
-	"whatsapp": {module: "lingtai_whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
+	"imap":     {module: "lingtai.mcp_servers.imap", envVarName: "LINGTAI_IMAP_CONFIG", defaultRel: ".secrets/imap.json"},
+	"telegram": {module: "lingtai.mcp_servers.telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
+	"feishu":   {module: "lingtai.mcp_servers.feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
+	"wechat":   {module: "lingtai.mcp_servers.wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
+	"whatsapp": {module: "lingtai.mcp_servers.whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
 }
 
 // convertAddonsInInitFile is the per-init.json workhorse. A returned error

--- a/portal/internal/migrate/m028_addons_to_mcp_test.go
+++ b/portal/internal/migrate/m028_addons_to_mcp_test.go
@@ -1,0 +1,27 @@
+package migrate
+
+import "testing"
+
+func TestM028AddonSpecsUseBundledModules(t *testing.T) {
+	want := map[string]addonSpec{
+		"imap":     {module: "lingtai.mcp_servers.imap", envVarName: "LINGTAI_IMAP_CONFIG", defaultRel: ".secrets/imap.json"},
+		"telegram": {module: "lingtai.mcp_servers.telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
+		"feishu":   {module: "lingtai.mcp_servers.feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
+		"wechat":   {module: "lingtai.mcp_servers.wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
+		"whatsapp": {module: "lingtai.mcp_servers.whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
+	}
+
+	if len(addonSpecs) != len(want) {
+		t.Fatalf("addonSpecs has %d entries, want %d: %#v", len(addonSpecs), len(want), addonSpecs)
+	}
+	for name, wantSpec := range want {
+		got, ok := addonSpecs[name]
+		if !ok {
+			t.Errorf("addonSpecs missing %q", name)
+			continue
+		}
+		if got != wantSpec {
+			t.Errorf("addonSpecs[%q] = %#v, want %#v", name, got, wantSpec)
+		}
+	}
+}

--- a/tui/internal/migrate/m028_addons_to_mcp.go
+++ b/tui/internal/migrate/m028_addons_to_mcp.go
@@ -31,7 +31,7 @@ import (
 //	    "imap": {
 //	      "type": "stdio",
 //	      "command": "/Users/.../runtime/venv/bin/python",
-//	      "args": ["-m", "lingtai_imap"],
+//	      "args": ["-m", "lingtai.mcp_servers.imap"],
 //	      "env": {"LINGTAI_IMAP_CONFIG": ".secrets/imap.json"}
 //	    }
 //	  }
@@ -41,7 +41,7 @@ import (
 //  1. addons becomes a list of names (the kernel mcp capability decompresses
 //     each name from mcp_catalog.json into the per-agent registry).
 //  2. mcp gets a sibling activation entry per addon, pointing at the MCP
-//     subprocess (python -m lingtai_<name>) with the corresponding env var
+//     subprocess (python -m lingtai.mcp_servers.<name>) with the corresponding env var
 //     pointing at the addon's config file.
 //
 // The migration also resolves *_env indirection inside the addon's config
@@ -103,11 +103,11 @@ type addonSpec struct {
 }
 
 var addonSpecs = map[string]addonSpec{
-	"imap":     {module: "lingtai_imap", envVarName: "LINGTAI_IMAP_CONFIG", defaultRel: ".secrets/imap.json"},
-	"telegram": {module: "lingtai_telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
-	"feishu":   {module: "lingtai_feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
-	"wechat":   {module: "lingtai_wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
-	"whatsapp": {module: "lingtai_whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
+	"imap":     {module: "lingtai.mcp_servers.imap", envVarName: "LINGTAI_IMAP_CONFIG", defaultRel: ".secrets/imap.json"},
+	"telegram": {module: "lingtai.mcp_servers.telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
+	"feishu":   {module: "lingtai.mcp_servers.feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
+	"wechat":   {module: "lingtai.mcp_servers.wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
+	"whatsapp": {module: "lingtai.mcp_servers.whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
 }
 
 // convertAddonsInInitFile is the per-init.json workhorse. Atomic write,

--- a/tui/internal/migrate/m028_addons_to_mcp_test.go
+++ b/tui/internal/migrate/m028_addons_to_mcp_test.go
@@ -100,8 +100,8 @@ func TestM028ConvertsImapWithConfigRef(t *testing.T) {
 		t.Errorf("mcp.imap.type = %v, want stdio", imap["type"])
 	}
 	args, _ := imap["args"].([]interface{})
-	if len(args) != 2 || args[0] != "-m" || args[1] != "lingtai_imap" {
-		t.Errorf("mcp.imap.args = %v, want [\"-m\", \"lingtai_imap\"]", args)
+	if len(args) != 2 || args[0] != "-m" || args[1] != "lingtai.mcp_servers.imap" {
+		t.Errorf("mcp.imap.args = %v, want [\"-m\", \"lingtai.mcp_servers.imap\"]", args)
 	}
 	env, _ := imap["env"].(map[string]interface{})
 	if env["LINGTAI_IMAP_CONFIG"] != ".secrets/imap.json" {
@@ -364,8 +364,8 @@ func TestM028WechatPointsAtConfigJSON(t *testing.T) {
 		t.Errorf("env.LINGTAI_WECHAT_CONFIG = %v, want %s", env["LINGTAI_WECHAT_CONFIG"], want)
 	}
 	args, _ := wc["args"].([]interface{})
-	if len(args) != 2 || args[1] != "lingtai_wechat" {
-		t.Errorf("wechat args = %v, want [\"-m\", \"lingtai_wechat\"]", args)
+	if len(args) != 2 || args[0] != "-m" || args[1] != "lingtai.mcp_servers.wechat" {
+		t.Errorf("wechat args = %v, want [\"-m\", \"lingtai.mcp_servers.wechat\"]", args)
 	}
 }
 
@@ -376,13 +376,24 @@ func TestM028WechatPointsAtConfigJSON(t *testing.T) {
 func TestM028HandlesMultipleAddons(t *testing.T) {
 	tmp := t.TempDir()
 	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	wantSpecs := map[string]struct {
+		module string
+		envVar string
+		config string
+	}{
+		"imap":     {"lingtai.mcp_servers.imap", "LINGTAI_IMAP_CONFIG", ".secrets/imap.json"},
+		"telegram": {"lingtai.mcp_servers.telegram", "LINGTAI_TELEGRAM_CONFIG", ".secrets/telegram.json"},
+		"feishu":   {"lingtai.mcp_servers.feishu", "LINGTAI_FEISHU_CONFIG", ".secrets/feishu.json"},
+		"wechat":   {"lingtai.mcp_servers.wechat", "LINGTAI_WECHAT_CONFIG", ".secrets/wechat/config.json"},
+		"whatsapp": {"lingtai.mcp_servers.whatsapp", "LINGTAI_WHATSAPP_CONFIG", ".secrets/whatsapp.json"},
+	}
+	legacyAddons := map[string]interface{}{}
+	for name, want := range wantSpecs {
+		legacyAddons[name] = map[string]interface{}{"config": want.config}
+	}
 	initPath := writeM028Init(t, lingtaiDir, "alice", map[string]interface{}{
 		"manifest": map[string]interface{}{"agent_name": "alice"},
-		"addons": map[string]interface{}{
-			"imap":     map[string]interface{}{"config": ".secrets/imap.json"},
-			"telegram": map[string]interface{}{"config": ".secrets/telegram.json"},
-			"feishu":   map[string]interface{}{"config": ".secrets/feishu.json"},
-		},
+		"addons":   legacyAddons,
 	})
 
 	if err := migrateAddonsToMCP(lingtaiDir); err != nil {
@@ -390,21 +401,45 @@ func TestM028HandlesMultipleAddons(t *testing.T) {
 	}
 
 	got := readM028Init(t, initPath)
-	addons, _ := got["addons"].([]interface{})
+	addons, ok := got["addons"].([]interface{})
+	if !ok {
+		t.Fatalf("addons not a list: %T", got["addons"])
+	}
 	names := map[string]bool{}
 	for _, a := range addons {
-		names[a.(string)] = true
+		name, ok := a.(string)
+		if !ok {
+			t.Errorf("addon entry has type %T, want string", a)
+			continue
+		}
+		names[name] = true
 	}
-	for _, want := range []string{"imap", "telegram", "feishu"} {
-		if !names[want] {
-			t.Errorf("missing addon %s in addons list (got %v)", want, addons)
+	if len(names) != len(wantSpecs) {
+		t.Errorf("addons list = %v, want exactly %d curated addons", addons, len(wantSpecs))
+	}
+	for name := range wantSpecs {
+		if !names[name] {
+			t.Errorf("missing addon %s in addons list (got %v)", name, addons)
 		}
 	}
 
-	mcp, _ := got["mcp"].(map[string]interface{})
-	for _, want := range []string{"imap", "telegram", "feishu"} {
-		if _, ok := mcp[want]; !ok {
-			t.Errorf("missing mcp.%s entry", want)
+	mcp, ok := got["mcp"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcp not a map: %T", got["mcp"])
+	}
+	for name, want := range wantSpecs {
+		entry, ok := mcp[name].(map[string]interface{})
+		if !ok {
+			t.Errorf("mcp.%s missing or wrong type: %T", name, mcp[name])
+			continue
+		}
+		args, _ := entry["args"].([]interface{})
+		if len(args) != 2 || args[0] != "-m" || args[1] != want.module {
+			t.Errorf("mcp.%s.args = %v, want [-m %s]", name, args, want.module)
+		}
+		env, _ := entry["env"].(map[string]interface{})
+		if env[want.envVar] != want.config {
+			t.Errorf("mcp.%s.env[%s] = %v, want %q", name, want.envVar, env[want.envVar], want.config)
 		}
 	}
 }

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1384,15 +1384,15 @@ func AddonSecretsPathFromAgent(addon string) string {
 func defaultMCPSpec(name string) (module, envVar, configRel string, supported bool) {
 	switch name {
 	case "imap":
-		return "lingtai_imap", "LINGTAI_IMAP_CONFIG", filepath.Join(".secrets", "imap.json"), true
+		return "lingtai.mcp_servers.imap", "LINGTAI_IMAP_CONFIG", filepath.Join(".secrets", "imap.json"), true
 	case "telegram":
-		return "lingtai_telegram", "LINGTAI_TELEGRAM_CONFIG", filepath.Join(".secrets", "telegram.json"), true
+		return "lingtai.mcp_servers.telegram", "LINGTAI_TELEGRAM_CONFIG", filepath.Join(".secrets", "telegram.json"), true
 	case "feishu":
-		return "lingtai_feishu", "LINGTAI_FEISHU_CONFIG", filepath.Join(".secrets", "feishu.json"), true
+		return "lingtai.mcp_servers.feishu", "LINGTAI_FEISHU_CONFIG", filepath.Join(".secrets", "feishu.json"), true
 	case "wechat":
-		return "lingtai_wechat", "LINGTAI_WECHAT_CONFIG", filepath.Join(".secrets", "wechat", "config.json"), true
+		return "lingtai.mcp_servers.wechat", "LINGTAI_WECHAT_CONFIG", filepath.Join(".secrets", "wechat", "config.json"), true
 	case "whatsapp":
-		return "lingtai_whatsapp", "LINGTAI_WHATSAPP_CONFIG", filepath.Join(".secrets", "whatsapp.json"), true
+		return "lingtai.mcp_servers.whatsapp", "LINGTAI_WHATSAPP_CONFIG", filepath.Join(".secrets", "whatsapp.json"), true
 	}
 	return "", "", "", false
 }

--- a/tui/internal/preset/preset_addons_default_test.go
+++ b/tui/internal/preset/preset_addons_default_test.go
@@ -1,11 +1,11 @@
 // Verifies that GenerateInitJSONWithOpts writes the new list-shape addons +
 // matching mcp activation entries pointing at the local venv Python.
 //
-// This is the wire that satisfies "default include four addons; activation
+// This is the wire that satisfies "default include five addons; activation
 // points to local installation, not remote". When this test passes, brand-new
 // agents created by the TUI wizard (or rehydrated from setup mode) ship with
-// all four curated MCPs registered + activated against the local venv where
-// `pip install lingtai` placed lingtai_imap / lingtai_telegram / etc.
+// all five curated MCPs registered + activated against the local venv where
+// `pip install lingtai` placed the curated lingtai.mcp_servers modules.
 package preset
 
 import (
@@ -64,12 +64,25 @@ func TestGenerateInitJSONWritesNewShapeWithLocalVenv(t *testing.T) {
 		t.Errorf("missing addon names: %v", wantNames)
 	}
 
-	// mcp section must exist with one entry per addon.
+	// mcp section must exist with one entry per addon and exact module/env
+	// wiring. In particular, generated args must never regress to the removed
+	// top-level compatibility wrappers.
 	mcp, ok := got["mcp"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("mcp not a dict: %T (%v)", got["mcp"], got["mcp"])
 	}
-	for _, name := range []string{"imap", "telegram", "feishu", "wechat", "whatsapp"} {
+	wantSpecs := map[string]struct {
+		module string
+		envVar string
+		config string
+	}{
+		"imap":     {"lingtai.mcp_servers.imap", "LINGTAI_IMAP_CONFIG", filepath.Join(".secrets", "imap.json")},
+		"telegram": {"lingtai.mcp_servers.telegram", "LINGTAI_TELEGRAM_CONFIG", filepath.Join(".secrets", "telegram.json")},
+		"feishu":   {"lingtai.mcp_servers.feishu", "LINGTAI_FEISHU_CONFIG", filepath.Join(".secrets", "feishu.json")},
+		"wechat":   {"lingtai.mcp_servers.wechat", "LINGTAI_WECHAT_CONFIG", filepath.Join(".secrets", "wechat", "config.json")},
+		"whatsapp": {"lingtai.mcp_servers.whatsapp", "LINGTAI_WHATSAPP_CONFIG", filepath.Join(".secrets", "whatsapp.json")},
+	}
+	for name, want := range wantSpecs {
 		entry, ok := mcp[name].(map[string]interface{})
 		if !ok {
 			t.Errorf("mcp.%s missing or wrong type: %T", name, mcp[name])
@@ -84,16 +97,13 @@ func TestGenerateInitJSONWritesNewShapeWithLocalVenv(t *testing.T) {
 		if !strings.HasPrefix(cmd, expectedVenvFragment) {
 			t.Errorf("mcp.%s.command = %q, want path under %q", name, cmd, expectedVenvFragment)
 		}
-		// args must invoke the right module.
 		args, _ := entry["args"].([]interface{})
-		if len(args) != 2 || args[0] != "-m" || args[1] != "lingtai_"+name {
-			t.Errorf("mcp.%s.args = %v, want [-m lingtai_%s]", name, args, name)
+		if len(args) != 2 || args[0] != "-m" || args[1] != want.module {
+			t.Errorf("mcp.%s.args = %v, want [-m %s]", name, args, want.module)
 		}
-		// env must declare the canonical config-path env var.
 		env, _ := entry["env"].(map[string]interface{})
-		envVar := "LINGTAI_" + strings.ToUpper(name) + "_CONFIG"
-		if _, ok := env[envVar]; !ok {
-			t.Errorf("mcp.%s.env missing %s (got %v)", name, envVar, env)
+		if env[want.envVar] != want.config {
+			t.Errorf("mcp.%s.env[%s] = %v, want %q", name, want.envVar, env[want.envVar], want.config)
 		}
 	}
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -230,7 +230,14 @@ VENV_PY="$HOME/.lingtai-tui/runtime/venv/bin/python"
 # Where do addon/MCP modules import from? (sources only, never env values)
 "$VENV_PY" - <<'PY'
 import importlib.util, json
-mods = ["lingtai_imap", "lingtai_telegram", "lingtai_feishu", "lingtai_wechat"]
+mods = [
+    "lingtai.mcp_servers.imap",
+    "lingtai.mcp_servers.telegram",
+    "lingtai.mcp_servers.feishu",
+    "lingtai.mcp_servers.wechat",
+    "lingtai.mcp_servers.whatsapp",
+    "lingtai.mcp_servers.cloud_mail",
+]
 out = {}
 for m in mods:
     spec = importlib.util.find_spec(m)

--- a/tui/internal/preset/skills/swiss-knife/reference/headless-bot/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/headless-bot/SKILL.md
@@ -9,7 +9,7 @@ description: >
   the Telegram MCP case.
 version: 1.1.0
 tags: [utilities, bot, telegram, mcp, headless, bootstrap]
-last_changed_at: "2026-06-01T02:00:30-07:00"
+last_changed_at: "2026-07-15T22:54:37Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
@@ -83,7 +83,8 @@ The helper:
 2. Writes `<agent_dir>/.secrets/telegram.json` with mode `0600`.
 3. Adds `telegram` to top-level `addons`.
 4. Adds top-level `mcp.telegram` using the local LingTai runtime Python and
-   `LINGTAI_TELEGRAM_CONFIG=.secrets/telegram.json`.
+   invokes `lingtai.mcp_servers.telegram` with `args: ["-m", "lingtai.mcp_servers.telegram"]`;
+   it passes `LINGTAI_TELEGRAM_CONFIG=.secrets/telegram.json`.
 5. Optionally copies `manifest.preset` from `--preset-policy-from` into the new
    agent's `init.json` without copying any preset JSON files.
 6. Touches `<agent_dir>/.refresh` so a running agent reloads the updated config.
@@ -200,7 +201,7 @@ Patch `<agent_dir>/init.json` so these top-level keys exist:
     "telegram": {
       "type": "stdio",
       "command": "~/.lingtai-tui/runtime/venv/bin/python",
-      "args": ["-m", "lingtai_telegram"],
+      "args": ["-m", "lingtai.mcp_servers.telegram"],
       "env": {
         "LINGTAI_TELEGRAM_CONFIG": ".secrets/telegram.json"
       }

--- a/tui/internal/preset/skills/swiss-knife/reference/headless-bot/scripts/create_telegram_bot_project.py
+++ b/tui/internal/preset/skills/swiss-knife/reference/headless-bot/scripts/create_telegram_bot_project.py
@@ -90,15 +90,18 @@ def ensure_telegram_init(init_path: Path) -> None:
         mcp = {}
     if not isinstance(mcp, dict):
         raise SystemExit(f"{init_path}: top-level mcp exists but is not an object")
-    mcp.setdefault(
+    telegram = mcp.setdefault(
         "telegram",
         {
             "type": "stdio",
             "command": runtime_python(),
-            "args": ["-m", "lingtai_telegram"],
+            "args": ["-m", "lingtai.mcp_servers.telegram"],
             "env": {"LINGTAI_TELEGRAM_CONFIG": ".secrets/telegram.json"},
         },
     )
+    if not isinstance(telegram, dict):
+        raise SystemExit(f"{init_path}: mcp.telegram exists but is not an object")
+    telegram["args"] = ["-m", "lingtai.mcp_servers.telegram"]
     init["mcp"] = mcp
 
     write_json(init_path, init)

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -84,6 +84,30 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 	}
 }
 
+func TestPopulateBundledLibrary_HeadlessBotTelegramModule(t *testing.T) {
+	globalDir := t.TempDir()
+	PopulateBundledLibrary(globalDir)
+
+	utilitiesDir := filepath.Join(globalDir, "utilities", "swiss-knife", "reference", "headless-bot")
+	wantArgs := `"args": ["-m", "lingtai.mcp_servers.telegram"]`
+	for _, rel := range []string{
+		"SKILL.md",
+		"scripts/create_telegram_bot_project.py",
+	} {
+		body, err := os.ReadFile(filepath.Join(utilitiesDir, rel))
+		if err != nil {
+			t.Fatalf("read bundled headless-bot file %s: %v", rel, err)
+		}
+		text := string(body)
+		if strings.Contains(text, "lingtai_telegram") {
+			t.Errorf("bundled headless-bot file %s contains stale Telegram module path", rel)
+		}
+		if !strings.Contains(text, wantArgs) {
+			t.Errorf("bundled headless-bot file %s missing mcp.telegram args %q", rel, wantArgs)
+		}
+	}
+}
+
 func TestPopulateBundledLibrary_MinimaxCliCanonicalReference(t *testing.T) {
 	globalDir := t.TempDir()
 	PopulateBundledLibrary(globalDir)

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -173,10 +173,9 @@
   // =============================================================
   // Addons — curated MCP server integrations
   // =============================================================
-  // As of v0.7.3, addons are MCP servers that ship as separate PyPI
-  // packages (lingtai-imap, lingtai-telegram, lingtai-feishu, lingtai-wechat),
-  // installed alongside the kernel by `pip install lingtai`. The TUI
-  // wires them up in two halves:
+  // Curated addons are MCP servers bundled in the `lingtai` wheel under
+  // `lingtai.mcp_servers.*`. The TUI installs that wheel in its local runtime
+  // venv and wires the selected addons up in two halves:
   //
   // 1. The `addons:` list below — names of curated MCPs the agent
   //    should "register" on boot. The kernel's `mcp` capability looks
@@ -191,16 +190,17 @@
   //
   // Default for new agents (auto-populated by the TUI wizard):
   //
-  //   "addons": ["imap", "telegram", "feishu", "wechat"],
+  //   "addons": ["imap", "telegram", "feishu", "wechat", "whatsapp"],
   //   "mcp": {
   //     "imap":     { "type": "stdio", "command": "<venv>/bin/python",
-  //                   "args": ["-m", "lingtai_imap"],
+  //                   "args": ["-m", "lingtai.mcp_servers.imap"],
   //                   "env": { "LINGTAI_IMAP_CONFIG": ".secrets/imap.json" } },
-  //     "telegram": { ... }, "feishu": { ... }, "wechat": { ... }
+  //     "telegram": { ... }, "feishu": { ... }, "wechat": { ... },
+  //     "whatsapp": { ... }
   //   }
   //
-  // The `command` always points at the local venv Python where pip
-  // installed the MCP packages — no remote fetch at runtime.
+  // The `command` always points at the local venv Python where the `lingtai`
+  // wheel installed its bundled MCP modules — no remote fetch at runtime.
   //
   // Per-MCP secrets live in <agent>/.secrets/<name>.json — plaintext JSON
   // (no *_env indirection in the new MCP shape). Each MCP's README


### PR DESCRIPTION
## Summary

- Make the TUI headless Telegram helper deterministically emit `[-m, lingtai.mcp_servers.telegram]`, repairing both missing and stale existing `mcp.telegram.args` while preserving the rest of the entry.
- Replace the removed top-level wrappers with the bundled `lingtai.mcp_servers.*` modules for all five addons the TUI currently selects: IMAP, Telegram, Feishu, WeChat, and WhatsApp.
- Keep both m028 writers aligned: TUI and Portal now generate the same canonical five module/env/config mappings when converting the legacy dict-shaped `addons` schema.
- Synchronize the embedded/public init examples and runtime self-check with the bundled-wheel ownership model. The generic self-check probes all six current bundled modules, including `cloud_mail`.
- Add exact full-set regression coverage for new preset generation, TUI migration, Portal's mirrored table, and the bundled headless helper assets.

## Mechanical evidence

Using the actual LingTai runtime interpreter:

- `lingtai.mcp_servers.{imap,telegram,feishu,wechat,whatsapp,cloud_mail}`: all importable.
- `lingtai_{imap,telegram,feishu,wechat,whatsapp,cloud_mail}`: all absent.

No secret values were read or printed.

## Scope and preservation

- `cloud_mail` has a current bundled kernel module but no TUI wizard/default-writer/m028 selection or mapping anchor. This PR does **not** invent a new Cloud Mail UI surface; it only includes the module in the generic runtime self-check.
- Existing user-authored `mcp` entries retain their preservation/no-op semantics. This PR fixes canonical generation and legacy dict-to-list conversion; it does not silently normalize arbitrary already-list-shaped user configurations.
- The headless helper remains intentionally Telegram-specific because that workflow creates a Telegram bot project.
- No live/installed runtime, user configuration, auth, or secrets were changed.

## Validation

- `cd tui && go test ./internal/preset ./internal/migrate`
- `cd portal && go test ./internal/migrate`
- Focused embedded template / bundled headless skill tests passed.
- No-side-effect Python helper repair/consistency assertions passed.
- Actual-runtime current-six-importable / legacy-six-absent probe passed.
- `gofmt` and `git diff --check` passed.

Whole PR: **12 files, +179/-72**.

## Related documentation

The operator-facing readiness and diagnosis checklist is in the linked kernel docs PR:

- https://github.com/Lingtai-AI/lingtai-kernel/pull/956
