### PR TITLE
release: pin Kernel v0.17.0 for TUI v0.11.0

### DIFF
--- a/kernel-release.json
+++ b/kernel-release.json
@@ -1,5 +1,5 @@
 {
   "schema": "lingtai.tui.kernel-pin/v1",
-  "kernel_tag": "v0.16.4",
+  "kernel_tag": "v0.16.5",
   "comment": "Repo-owned pin: the kernel release tag a TUI release binds into its bundle manifest. Bump this deliberately in the same PR/commit that intends to ship a new kernel version with the next TUI release; the release workflow never resolves 'latest kernel' on its own. See RELEASING.md."
 }

--- a/kernel-release.json
+++ b/kernel-release.json
@@ -1,5 +1,5 @@
 {
   "schema": "lingtai.tui.kernel-pin/v1",
-  "kernel_tag": "v0.16.5",
+  "kernel_tag": "v0.17.0",
   "comment": "Repo-owned pin: the kernel release tag a TUI release binds into its bundle manifest. Bump this deliberately in the same PR/commit that intends to ship a new kernel version with the next TUI release; the release workflow never resolves 'latest kernel' on its own. See RELEASING.md."
 }

--- a/migration/migration.md
+++ b/migration/migration.md
@@ -1,3 +1,60 @@
+---
+product: tui-portal
+release_version: "0.11.0"
+release_tag: "v0.11.0"
+kernel_tag: "v0.17.0"
+migration: built-in-readers-only
+refresh_required: true
+related_files:
+  - RELEASING.md
+  - install.sh
+  - kernel-release.json
+maintenance: |
+  Keep the v0.11.0 release section aligned with the TUI/Portal release behavior,
+  kernel pin, and public installer update contract. Preserve the durable
+  migration-history and runtime-retirement record below; release tags preserve
+  this file's exact historical versions.
+---
+# LingTai TUI and Portal 0.11.0 migration
+
+## Applies when
+
+The target TUI/Portal release is `0.11.0` / tag `v0.11.0`, paired with kernel
+tag `v0.17.0`, and that TUI tag lies in the open update interval
+`(current, target]`.
+
+## Migration
+
+**No automatic project rewrite.** Confirm that the installer selected the
+intended current TUI installation and that the TUI bundle manifest, platform
+archive, checksum, kernel pin, and kernel release manifest agree before
+mutation. Existing Homebrew installations remain supported, but the public
+installer is the canonical one-command install/update entry; do not combine a
+Homebrew binary update with an independently selected kernel version.
+
+Production startup does not run the retired generic TUI/Portal migration
+runtime. Existing `.lingtai/` files remain stored as they are. Kernel readers
+and Nudge diagnose canonical drift; an Agent or human applies any explicit
+repair after reviewing the exact source file and authorization boundary.
+
+## Validate
+
+- Confirm this file was read from the TUI repository at exact tag `v0.11.0`.
+- Verify both `lingtai-tui version` and `lingtai-portal --version` when Portal is
+  installed, plus the selected runtime's `lingtai.__version__` and import paths.
+- If the product, tag, stable path, mirror content, bundle hash, or kernel pin
+  does not match, stop rather than borrowing a kernel migration or another
+  release's document.
+
+## Refresh
+
+A running agent still has its old kernel code loaded after the verified binaries
+and runtime are installed. After active work is checkpointed and refresh is
+authorized, call `system(action='refresh')` and verify the relaunched process
+uses the selected v0.17.0 runtime.
+
+---
+
 # Migration history
 
 This file is a Git-versioned prose history and decision record. It is not a

--- a/tui/internal/config/tui_updater.go
+++ b/tui/internal/config/tui_updater.go
@@ -359,11 +359,11 @@ func tuiReleaseURL(version string) string {
 
 func sourceInstallCommand(script, prefix, version string) (string, []string) {
 	if script == "" {
-		script = "https://raw.githubusercontent.com/Lingtai-AI/lingtai/" + version + "/install.sh"
+		script = "https://lingtai.ai/install.sh"
 	}
-	args := []string{"--update", "--prefix", prefix, "--version", version, "--non-interactive"}
+	args := []string{"update", "--prefix", prefix, "--tui-tag", version, "--non-interactive", "--yes"}
 	if strings.HasPrefix(script, "http://") || strings.HasPrefix(script, "https://") {
-		shell := `set -euo pipefail; curl -fsSL "$1" | bash -s -- "$2" "$3" "$4" "$5" "$6" "$7"`
+		shell := `set -euo pipefail; script="$1"; shift; curl -fsSL "$script" | bash -s -- "$@"`
 		shellArgs := []string{"-c", shell, "lingtai-source-update", script}
 		shellArgs = append(shellArgs, args...)
 		return "bash", shellArgs

--- a/tui/internal/config/tui_updater_test.go
+++ b/tui/internal/config/tui_updater_test.go
@@ -98,7 +98,7 @@ func TestSourceTUIUpdaterRunsInstallScriptAndVerifiesRuntime(t *testing.T) {
 	if !result.Healthy || !result.Updated {
 		t.Fatalf("expected healthy source update: %+v", result)
 	}
-	if !containsCall(runner.calls, "bash /tmp/install.sh --update --prefix "+prefix+" --version v0.8.1 --non-interactive") {
+	if !containsCall(runner.calls, "bash /tmp/install.sh update --prefix "+prefix+" --tui-tag v0.8.1 --non-interactive --yes") {
 		t.Fatalf("expected installer update call, got %#v", runner.calls)
 	}
 	if containsCall(runner.calls, "brew") {
@@ -329,7 +329,7 @@ func (r *sourceUpdateRunner) Run(name string, args ...string) CommandResult {
 	call := name + " " + strings.Join(args, " ")
 	r.calls = append(r.calls, call)
 	switch {
-	case strings.Contains(call, "--update"):
+	case strings.Contains(call, " update "):
 		if r.failInstall {
 			return CommandResult{Err: errors.New("exit status 1"), Stderr: "install failed"}
 		}
@@ -341,5 +341,22 @@ func (r *sourceUpdateRunner) Run(name string, args ...string) CommandResult {
 		return CommandResult{Stdout: r.runtimeVersion + "\n"}
 	default:
 		return CommandResult{Stdout: "ok\n"}
+	}
+}
+
+func TestSourceInstallCommandUsesCanonicalWebsiteInstallerAndForwardsAllArgs(t *testing.T) {
+	name, args := sourceInstallCommand("", "/tmp/lingtai prefix", "v0.11.0")
+	if name != "bash" {
+		t.Fatalf("name = %q, want bash", name)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"https://lingtai.ai/install.sh",
+		"update --prefix /tmp/lingtai prefix --tui-tag v0.11.0 --non-interactive --yes",
+		`shift; curl -fsSL "$script" | bash -s -- "$@"`,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("sourceInstallCommand args %q do not contain %q", joined, want)
+		}
 	}
 }

--- a/tui/internal/config/venv.go
+++ b/tui/internal/config/venv.go
@@ -599,7 +599,7 @@ type tuiInstallMetadata struct {
 	// a pinned release-bundle artifact by explicit local file path, rather
 	// than from PyPI. See kernelSourceFromMetadata / the provenance gate in
 	// UpgradePythonRuntime below.
-	KernelSource   string `json:"kernel_source,omitempty"`   // "" | "pypi" | "bundle"
+	KernelSource   string `json:"kernel_source,omitempty"`    // "" | "pypi" | "bundle"
 	KernelBundleID string `json:"kernel_bundle_id,omitempty"` // e.g. "tui-v0.11.0" — the TUI bundle manifest's bundle_id
 	KernelVersion  string `json:"kernel_version,omitempty"`   // the pinned kernel version installed from the bundle
 	KernelProvider string `json:"kernel_provider,omitempty"`  // "github" | "gitee" — which provider served the bundle
@@ -1321,7 +1321,7 @@ func UpgradePythonRuntime(globalDir string, force bool, opts *UpgradeRuntimeOpti
 	// not "abandon the compatibility pin and install an arbitrary version
 	// from a package index." A forced check on a bundle-provisioned runtime
 	// reports that the kernel is pinned to the TUI bundle and points at the
-	// bundle-update path (re-run the one-command installer / `--update`)
+	// bundle-update path (re-run the one-command installer / `update`)
 	// instead of running any PyPI query or install — unlike the editable-
 	// install gate above, this is not "same behavior, force or not" by
 	// accident; it is the explicit fix for a real defect where force used to
@@ -1329,7 +1329,7 @@ func UpgradePythonRuntime(globalDir string, force bool, opts *UpgradeRuntimeOpti
 	if isBundle, bundleMeta := kernelBundleProvenance(globalDir); isBundle {
 		if force {
 			result.add(DoctorOK,
-				"Python lingtai is pinned to release bundle %s (kernel %s via %s); a forced update does not override this pin. Re-run the one-command installer (or its --update path) to move to a newer bundle.",
+				"Python lingtai is pinned to release bundle %s (kernel %s via %s); a forced update does not override this pin. Re-run the one-command installer (or its update mode) to move to a newer bundle.",
 				valueOrUnknown(bundleMeta.KernelBundleID), valueOrUnknown(bundleMeta.KernelVersion), valueOrUnknown(bundleMeta.KernelProvider))
 		} else {
 			result.add(DoctorOK,

--- a/tui/upgrade_test.go
+++ b/tui/upgrade_test.go
@@ -79,7 +79,7 @@ func TestStartupSourceUpdateConfirmRoutesThroughSourceUpdater(t *testing.T) {
 	if !updated {
 		t.Fatalf("confirmed source startup update should stop startup after update; stderr=%q output=\n%s", errOut.String(), out.String())
 	}
-	if !startupContainsCall(runner.calls, "bash /tmp/install.sh --update --prefix "+prefix+" --version v0.8.1 --non-interactive") {
+	if !startupContainsCall(runner.calls, "bash /tmp/install.sh update --prefix "+prefix+" --tui-tag v0.8.1 --non-interactive --yes") {
 		t.Fatalf("expected source installer update call, got %#v", runner.calls)
 	}
 	if startupContainsCall(runner.calls, "brew") {
@@ -172,7 +172,7 @@ func (r *startupSourceUpdateRunner) Run(name string, args ...string) config.Comm
 	call := name + " " + strings.Join(args, " ")
 	r.calls = append(r.calls, call)
 	switch {
-	case strings.Contains(call, "--update"):
+	case strings.Contains(call, " update "):
 		writeStartupSourceInstallMetadata(r.t, r.globalDir, r.prefix, r.binDir, r.latest)
 		return config.CommandResult{Stdout: "updated\n"}
 	case strings.HasSuffix(call, "lingtai-tui version"):


### PR DESCRIPTION
## Summary
- pin the TUI/Portal v0.11.0 release bundle to Kernel v0.17.0
- prepend exact v0.11.0 migration metadata while preserving the full prior migration history
- make the TUI source updater call the canonical public entry exactly as:
  `update --prefix <prefix> --tui-tag <version> --non-interactive --yes`
- forward the complete argument vector safely through `bash -s -- "$@"`

## Validation
- targeted updater/config tests: **PASS**
- full `go test ./...` from `tui/`: **PASS**
- install/Gitee bundle and pin/migration gates: **PASS**
- independent exact-patch review: **APPROVED**
- final direct Claude Opus 4.8 review: **APPROVED** (`modelUsage=claude-opus-4-8`)

## Release lock
Kernel PR #978 is merged at `0177643cace284ce511d7c66dde865625745d8b0` with version v0.17.0. The public `https://lingtai.ai/install.sh` bytes already match merged website PR #55.
