### PR TITLE
release: repin Kernel v0.17.1 for TUI v0.11.0

### DIFF
--- a/kernel-release.json
+++ b/kernel-release.json
@@ -1,5 +1,5 @@
 {
   "schema": "lingtai.tui.kernel-pin/v1",
-  "kernel_tag": "v0.17.0",
+  "kernel_tag": "v0.17.1",
   "comment": "Repo-owned pin: the kernel release tag a TUI release binds into its bundle manifest. Bump this deliberately in the same PR/commit that intends to ship a new kernel version with the next TUI release; the release workflow never resolves 'latest kernel' on its own. See RELEASING.md."
 }

--- a/migration/migration.md
+++ b/migration/migration.md
@@ -2,7 +2,7 @@
 product: tui-portal
 release_version: "0.11.0"
 release_tag: "v0.11.0"
-kernel_tag: "v0.17.0"
+kernel_tag: "v0.17.1"
 migration: built-in-readers-only
 refresh_required: true
 related_files:
@@ -20,7 +20,7 @@ maintenance: |
 ## Applies when
 
 The target TUI/Portal release is `0.11.0` / tag `v0.11.0`, paired with kernel
-tag `v0.17.0`, and that TUI tag lies in the open update interval
+tag `v0.17.1`, and that TUI tag lies in the open update interval
 `(current, target]`.
 
 ## Migration
@@ -51,7 +51,7 @@ repair after reviewing the exact source file and authorization boundary.
 A running agent still has its old kernel code loaded after the verified binaries
 and runtime are installed. After active work is checkpointed and refresh is
 authorized, call `system(action='refresh')` and verify the relaunched process
-uses the selected v0.17.0 runtime.
+uses the selected v0.17.1 runtime.
 
 ---
 


### PR DESCRIPTION
## Summary
- repin the TUI/Portal v0.11.0 bundle from Kernel v0.17.0 to the non-destructive recovery release v0.17.1
- keep the v0.11.0 migration metadata and refresh guidance aligned with the exact pinned Kernel tag
- preserve the complete migration-history record unchanged

## Why
Kernel v0.17.0 built all 15 native wheels plus the sdist, but its isolated manifest job failed before assets published. v0.17.1 fixes that release-only dependency/exception path without deleting, moving, or rewriting the public v0.17.0 tag/release.

## Validation
- declarative pin/frontmatter/history gates: **PASS**
- full `go test ./...` from `tui/`: **PASS**
- `git diff --check`: **PASS**

## Publication gate
Do not tag TUI v0.11.0 until Kernel v0.17.1's strict release manifest and exact GitHub/Gitee artifacts have completed and validated.
