### PR TITLE
fix(tui): keep built-in presets visible in fresh drafts

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -711,15 +711,32 @@ func (m *FirstRunModel) discoverRecipes() {
 // the user the same question twice. langCursor is synced from the seeded
 // draft.Language so any step that consults it agrees with the prelude.
 // preset.List() is a pure read (lists existing on-disk presets to offer as
-// a starting point); the draft flow always proceeds through the picker so
-// the user can create/select a preset draft regardless of what's on disk
-// yet — it never detours through stepAPIKey. Esc/Back/Ctrl+C at
+// a starting point). On a truly fresh machine templates/ does not exist yet
+// because draft mode intentionally skips Bootstrap; in that case the compiled
+// built-ins are appended in memory and stamped as templates. This preserves the
+// full provider picker and correct RefFor/IsTemplate semantics without writing
+// anything before confirmation. The draft flow always proceeds through the
+// picker — it never detours through stepAPIKey. Esc/Back/Ctrl+C at
 // stepPickPreset emit ProjectDraftCancelledMsg (see its doc comment).
 func NewDraftFirstRunModel(baseDir, globalDir string, hasPresets bool, draft *ProjectDraft) FirstRunModel {
 	m := newFirstRunModelForPurpose(purposeDraft, baseDir, globalDir, hasPresets, "")
 	m.draft = draft
 	m.step = stepPickPreset
 	m.presets, _ = preset.List()
+	hasTemplate := false
+	for _, p := range m.presets {
+		if p.Source == preset.SourceTemplate {
+			hasTemplate = true
+			break
+		}
+	}
+	if !hasTemplate {
+		builtins := preset.BuiltinPresets()
+		for i := range builtins {
+			builtins[i].Source = preset.SourceTemplate
+		}
+		m.presets = append(m.presets, builtins...)
+	}
 	if draft != nil {
 		for i, l := range []string{"en", "zh", "wen"} {
 			if l == draft.Language {

--- a/tui/internal/tui/launcher_test.go
+++ b/tui/internal/tui/launcher_test.go
@@ -293,6 +293,42 @@ func buildDraftModel(t *testing.T) (FirstRunModel, string, string) {
 	return m, home, projectRoot
 }
 
+// TestDraftFirstRun_FreshHomeOffersBuiltinsWithoutWriting guards the no-project
+// Create regression where draft mode deliberately skipped Bootstrap to remain
+// pure, then populated its picker only from the not-yet-created templates/
+// directory. A truly fresh HOME must still expose every compiled template as a
+// template (including ordinary API-key and custom paths) without materializing
+// anything on disk before the user confirms the project.
+func TestDraftFirstRun_FreshHomeOffersBuiltinsWithoutWriting(t *testing.T) {
+	m, home, _ := buildDraftModel(t)
+
+	wantBuiltins := preset.BuiltinPresets()
+	if len(m.presets) != len(wantBuiltins) {
+		t.Fatalf("fresh draft preset count = %d, want %d compiled builtins; presets=%+v", len(m.presets), len(wantBuiltins), m.presets)
+	}
+
+	byName := make(map[string]preset.Preset, len(m.presets))
+	for _, p := range m.presets {
+		byName[p.Name] = p
+	}
+	for _, name := range []string{"minimax", "zhipu", "mimo", "deepseek", "custom"} {
+		p, ok := byName[name]
+		if !ok {
+			t.Errorf("fresh draft picker is missing compiled preset %q", name)
+			continue
+		}
+		if p.Source != preset.SourceTemplate {
+			t.Errorf("fresh draft preset %q source = %v, want SourceTemplate", name, p.Source)
+		}
+	}
+	if got := m.visiblePresetCount(); got != len(wantBuiltins) {
+		t.Errorf("visible preset count = %d, want %d", got, len(wantBuiltins))
+	}
+	if after := dirSnapshot(t, home); len(after) != 0 {
+		t.Fatalf("fresh draft constructor materialized files before confirmation: %+v", after)
+	}
+}
+
 // TestLauncherPrelude_ThemeLanguageDoNotPersist proves the launcher's
 // welcome prelude — which now owns theme (ctrl+t) and language (↑↓)
 // selection for the no-project flow — holds both choices in memory only,


### PR DESCRIPTION
## Summary

- restore all compiled provider presets in the no-project Create picker when a truly fresh machine has no on-disk `templates/` directory yet
- preserve the pre-confirmation zero-write invariant by appending `BuiltinPresets()` in memory and marking them `SourceTemplate`
- keep existing saved presets first and add a regression covering ordinary API-key/custom choices plus filesystem purity

This fixes the regression introduced by #650: draft mode correctly skipped `preset.Bootstrap()`, but then populated the picker only through `preset.List()`, so a fresh HOME supplied zero preset rows and left only the always-rendered Codex OAuth credential row.

## Validation

```text
# failing-first on current main before the implementation
$ go test ./internal/tui -run '^TestDraftFirstRun_FreshHomeOffersBuiltinsWithoutWriting$' -count=1
--- FAIL: TestDraftFirstRun_FreshHomeOffersBuiltinsWithoutWriting
fresh draft preset count = 0, want 12 compiled builtins

# after the fix
$ go test ./internal/tui -run '^TestDraftFirstRun_FreshHomeOffersBuiltinsWithoutWriting$' -count=1
ok  github.com/anthropics/lingtai-tui/internal/tui

$ go test ./internal/tui ./internal/preset -count=1
ok  github.com/anthropics/lingtai-tui/internal/tui  10.110s
ok  github.com/anthropics/lingtai-tui/internal/preset  0.784s

$ git diff --check
# clean
```
