### PR TITLE
fix: stop first-launch legacy init maintenance

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -54,7 +54,6 @@
   "firstrun.soul_flow_enabled": "Soul flow",
   "firstrun.soul_flow_enabled_hint": "opt in to autonomous soul flow (default OFF). When ON, the agent reflects on recent work, consults past selves, and surfaces insights on the cadence set below. Sets LINGTAI_SOUL_FLOW_ENABLED in the agent's env; leave OFF to keep the agent purely reactive (use the soul-manual tool for on-demand reflection)",
   "firstrun.covenant": "Covenant",
-  "firstrun.principle": "Principle",
   "firstrun.soul_flow": "Soul flow",
   "firstrun.comment": "Comment",
   "firstrun.comment_hint": "custom system prompt",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -54,7 +54,6 @@
   "firstrun.soul_flow_enabled": "心流",
   "firstrun.soul_flow_enabled_hint": "启自主心流（默闭）。既启，灵按下方之隔反观近功、咨询往昔、浮现洞明。此开关设器灵之境 LINGTAI_SOUL_FLOW_ENABLED；守闭则灵纯待应（可用 soul-manual 之器随需自省）",
   "firstrun.covenant": "约法",
-  "firstrun.principle": "原则",
   "firstrun.soul_flow": "心流",
   "firstrun.comment": "附言",
   "firstrun.comment_hint": "自定义系统提示",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -54,7 +54,6 @@
   "firstrun.soul_flow_enabled": "心流",
   "firstrun.soul_flow_enabled_hint": "启用自主心流（默认关闭）。开启后，器灵会按下方间隔反思近期工作、咨询往昔之我、浮现洞见。此开关会在器灵环境中设置 LINGTAI_SOUL_FLOW_ENABLED；保持关闭则器灵纯被动（可用 soul-manual 工具按需反思）",
   "firstrun.covenant": "约法",
-  "firstrun.principle": "原则",
   "firstrun.soul_flow": "心流",
   "firstrun.comment": "附言",
   "firstrun.comment_hint": "自定义系统提示",

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1263,11 +1263,6 @@ func customPreset() Preset {
 	}
 }
 
-// PrinciplePath returns the absolute path to the principle file for a language.
-func PrinciplePath(globalDir, lang string) string {
-	return filepath.Join(globalDir, "principle", lang, "principle.md")
-}
-
 // ProceduresPath returns the absolute path to the procedures file for a language.
 // Checks the lang-specific path first, falls back to the root procedures.md.
 func ProceduresPath(globalDir, lang string) string {

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1550,8 +1550,6 @@ type AgentOpts struct {
 	Karma           bool     // lifecycle control over other agents
 	Nirvana         bool     // permanent agent destruction
 	CovenantFile    string   // path to covenant file
-	PrincipleFile   string   // path to principle file
-	ProceduresFile  string   // path to procedures file
 	SoulFile        string   // path to soul flow file
 	CommentFile     string   // path to comment file (optional)
 	Addons          []string // addon names to auto-populate in init.json (e.g. ["imap", "telegram"])
@@ -1656,6 +1654,15 @@ func SyncCapabilityAPIKeyEnv(manifest map[string]interface{}) {
 	}
 }
 
+// stripObsoleteInitFields removes top-level init.json fields that the kernel
+// treats as ignored legacy input. New writers and explicit read-modify-write
+// paths must not carry them forward, because their presence triggers a
+// deterministic boot-time nudge before the agent can do useful work.
+func stripObsoleteInitFields(initJSON map[string]interface{}) {
+	delete(initJSON, "principle_file")
+	delete(initJSON, "procedures_file")
+}
+
 // GenerateInitJSONWithOpts creates a full init.json from a preset with explicit agent options.
 func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDir string, opts AgentOpts) error {
 	if err := p.NormalizeLegacyCapabilities(); err != nil {
@@ -1666,8 +1673,24 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 		return fmt.Errorf("create agent dir: %w", err)
 	}
 
+	// Keep the existing root and manifest fields when /setup regenerates an
+	// agent. Known generated fields below overwrite these values; unrelated
+	// user/kernel fields remain intact.
+	var existingInit map[string]interface{}
+	existingInitPath := filepath.Join(agentDir, "init.json")
+	if existingData, err := os.ReadFile(existingInitPath); err == nil {
+		if DecodeJSONUseNumber(existingData, &existingInit) != nil {
+			existingInit = nil
+		}
+	}
+
 	// Build manifest with opts
 	manifest := make(map[string]interface{})
+	if existingManifest, ok := existingInit["manifest"].(map[string]interface{}); ok {
+		for key, value := range existingManifest {
+			manifest[key] = value
+		}
+	}
 	manifest["agent_name"] = agentName
 	lang := opts.Language
 	if lang == "" {
@@ -1839,17 +1862,16 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	}
 
 	// Resolve file paths — use opts if set, fallback to language defaults
+	// Keep an existing supported covenant path during /setup; fresh agents
+	// use the language default. Obsolete principle/procedures paths are not
+	// resolved or emitted.
 	covenantFile := opts.CovenantFile
 	if covenantFile == "" {
-		covenantFile = CovenantPath(globalDir, lang)
-	}
-	principleFile := opts.PrincipleFile
-	if principleFile == "" {
-		principleFile = PrinciplePath(globalDir, lang)
-	}
-	proceduresFile := opts.ProceduresFile
-	if proceduresFile == "" {
-		proceduresFile = ProceduresPath(globalDir, lang)
+		if existing, ok := existingInit["covenant_file"].(string); ok && existing != "" {
+			covenantFile = existing
+		} else {
+			covenantFile = CovenantPath(globalDir, lang)
+		}
 	}
 	// Load existing init.json addons + mcp fields so we preserve them across
 	// regens. Critical for /setup: when the user changes non-addon settings,
@@ -1863,40 +1885,48 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	// disk file is normalized on the next refresh.
 	var existingAddonsList []interface{}
 	var existingMCP map[string]interface{}
-	existingInitPath := filepath.Join(agentDir, "init.json")
-	if existingData, err := os.ReadFile(existingInitPath); err == nil {
-		var existing map[string]interface{}
-		if DecodeJSONUseNumber(existingData, &existing) == nil {
-			switch v := existing["addons"].(type) {
-			case []interface{}:
-				existingAddonsList = v
-			case map[string]interface{}:
-				// Legacy dict shape — extract just the names.
-				for name := range v {
-					existingAddonsList = append(existingAddonsList, name)
-				}
-			}
-			if mcp, ok := existing["mcp"].(map[string]interface{}); ok && len(mcp) > 0 {
-				existingMCP = mcp
-			}
+	switch v := existingInit["addons"].(type) {
+	case []interface{}:
+		existingAddonsList = v
+	case map[string]interface{}:
+		// Legacy dict shape — extract just the names.
+		for name := range v {
+			existingAddonsList = append(existingAddonsList, name)
 		}
 	}
-
-	initJSON := map[string]interface{}{
-		"manifest":        manifest,
-		"covenant_file":   covenantFile,
-		"principle_file":  principleFile,
-		"procedures_file": proceduresFile,
-		"env_file":        config.EnvFilePath(globalDir),
-		"venv_path":       filepath.Join(globalDir, "runtime", "venv"),
-		"pad":             "",
-		// No seed-character field is written here. 灵台 (character) is durable
-		// state owned by the agent and managed after creation via
-		// system/lingtai.md / psyche — the kernel treats a missing seed as an
-		// empty seed and lets the agent author its own character. The legacy
-		// `prompt` field was an unknown key (boot warning, never honored); we
-		// emit neither `prompt` nor `lingtai`.
+	if mcp, ok := existingInit["mcp"].(map[string]interface{}); ok && len(mcp) > 0 {
+		existingMCP = mcp
 	}
+
+	envFile := config.EnvFilePath(globalDir)
+	if existing, ok := existingInit["env_file"].(string); ok && existing != "" {
+		envFile = existing
+	}
+	venvPath := filepath.Join(globalDir, "runtime", "venv")
+	if existing, ok := existingInit["venv_path"].(string); ok && existing != "" {
+		venvPath = existing
+	}
+	pad := interface{}("")
+	if existing, ok := existingInit["pad"]; ok {
+		pad = existing
+	}
+
+	initJSON := make(map[string]interface{}, len(existingInit)+8)
+	for key, value := range existingInit {
+		initJSON[key] = value
+	}
+	stripObsoleteInitFields(initJSON)
+	initJSON["manifest"] = manifest
+	initJSON["covenant_file"] = covenantFile
+	initJSON["env_file"] = envFile
+	initJSON["venv_path"] = venvPath
+	initJSON["pad"] = pad
+	// No seed-character field is written here. 灵台 (character) is durable
+	// state owned by the agent and managed after creation via
+	// system/lingtai.md / psyche — the kernel treats a missing seed as an
+	// empty seed and lets the agent author its own character. The legacy
+	// `prompt` field was an unknown key (boot warning, never honored); we
+	// emit neither `prompt` nor `lingtai`.
 
 	// Decide which addons to wire.
 	//
@@ -2106,6 +2136,7 @@ func rewritePresetBlock(initPath, defaultRef string, allowed []string, allowedSe
 	if err := DecodeJSONUseNumber(data, &raw); err != nil {
 		return fmt.Errorf("parse: %w", err)
 	}
+	stripObsoleteInitFields(raw)
 	manifest, ok := raw["manifest"].(map[string]interface{})
 	if !ok {
 		return nil // no manifest, nothing to propagate

--- a/tui/internal/preset/preset_legacy_init_fields_test.go
+++ b/tui/internal/preset/preset_legacy_init_fields_test.go
@@ -1,0 +1,108 @@
+package preset
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateInitJSONFreshOmitsObsoletePromptFiles(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	globalDir := filepath.Join(tmp, "global")
+	if err := GenerateInitJSON(minimaxPreset(), "fresh", "fresh", lingtaiDir, globalDir); err != nil {
+		t.Fatalf("GenerateInitJSON: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(lingtaiDir, "fresh", "init.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse init.json: %v", err)
+	}
+	for _, key := range []string{"principle_file", "procedures_file"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("fresh generated init.json contains obsolete %q", key)
+		}
+	}
+	if covenant, ok := got["covenant_file"].(string); !ok || covenant == "" {
+		t.Errorf("fresh generated init.json missing supported covenant_file: %#v", got["covenant_file"])
+	}
+}
+
+func TestGenerateInitJSONOmitsObsoletePromptFilesAndPreservesExistingConfig(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	agentDir := filepath.Join(lingtaiDir, "alice")
+	globalDir := filepath.Join(tmp, "global")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// /setup rewrites an existing init.json. The two *_file keys are stale
+	// kernel-facing fields, while the other top-level and manifest fields are
+	// supported or user-owned and must survive the rewrite.
+	old := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "alice",
+			"language":   "en",
+			"user_flag":  true,
+		},
+		"covenant_file":   "/project/.recipe/covenant.md",
+		"principle_file":  "/project/.lingtai/principle.md",
+		"procedures_file": "/project/.lingtai/procedures.md",
+		"env_file":        "/project/.lingtai/.env",
+		"venv_path":       "/project/.lingtai/runtime/venv",
+		"pad":             "keep this pad",
+		"user_config":     map[string]interface{}{"keep": "me"},
+	}
+	oldData, err := json.Marshal(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), oldData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := GenerateInitJSONWithOpts(minimaxPreset(), "alice", "alice", lingtaiDir, globalDir, DefaultAgentOpts()); err != nil {
+		t.Fatalf("GenerateInitJSONWithOpts: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(agentDir, "init.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse init.json: %v", err)
+	}
+	for _, key := range []string{"principle_file", "procedures_file"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("generated init.json still contains obsolete %q", key)
+		}
+	}
+
+	for key, want := range map[string]interface{}{
+		"covenant_file": "/project/.recipe/covenant.md",
+		"env_file":      "/project/.lingtai/.env",
+		"venv_path":     "/project/.lingtai/runtime/venv",
+		"pad":           "keep this pad",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %#v, want %#v", key, got[key], want)
+		}
+	}
+	userConfig, ok := got["user_config"].(map[string]interface{})
+	if !ok || userConfig["keep"] != "me" {
+		t.Errorf("unrelated user_config was not preserved: %#v", got["user_config"])
+	}
+	manifest, ok := got["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatal("manifest missing after rewrite")
+	}
+	if manifest["user_flag"] != true {
+		t.Errorf("unrelated manifest field was not preserved: %#v", manifest)
+	}
+}

--- a/tui/internal/preset/recipe_apply.go
+++ b/tui/internal/preset/recipe_apply.go
@@ -203,11 +203,8 @@ func RecipeNeedsApply(projectRoot string) bool {
 //     caller via the greetSubstitutor callback so this package stays free
 //     of TUI-only helpers.
 //   - Updates init.json:
-//   - comment_file / covenant_file / procedures_file fields in
-//     manifest.capabilities.{psyche, ...} (TODO: caller-specified
-//     structure — for v1 this function only handles skills.paths and
-//     .prompt; comment/covenant/procedures rewiring happens in the TUI
-//     layer that also owns init.json generation)
+//   - strips ignored legacy prompt-file fields when this additive
+//     skills-path rewrite serializes an existing document
 //   - manifest.capabilities.skills.paths gets "../../<library_name>"
 //     appended when the recipe declares a library (additive — existing
 //     entries are preserved, never removed)
@@ -338,6 +335,7 @@ func AppendSkillsPath(initJSONPath, pathEntry string) error {
 	if err := DecodeJSONUseNumber(data, &root); err != nil {
 		return fmt.Errorf("parse %s: %w", initJSONPath, err)
 	}
+	stripObsoleteInitFields(root)
 	manifest, ok := root["manifest"].(map[string]interface{})
 	if !ok {
 		return nil

--- a/tui/internal/preset/rehydrate.go
+++ b/tui/internal/preset/rehydrate.go
@@ -86,6 +86,8 @@ func RehydrateNetwork(lingtaiDir, orchDirName string) (workersRehydrated int, er
 			return workersRehydrated, fmt.Errorf("parse orchestrator init.json: %w", err)
 		}
 
+		stripObsoleteInitFields(workerInit)
+
 		// Override manifest.agent_name and manifest.admin.
 		manifest, ok := workerInit["manifest"].(map[string]interface{})
 		if !ok {

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -818,7 +818,7 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 	// inner shape — every consumer does p.Manifest["language"], ["llm"],
 	// ["capabilities"], etc. — so we extract the inner manifest dict.
 	// Stash the outer dict separately so enterAgentNameDir can read fields
-	// like covenant_file / principle_file that live at top level.
+	// like covenant_file that lives at top level.
 	if orchDir != "" {
 		initPath := filepath.Join(orchDir, "init.json")
 		if data, err := os.ReadFile(initPath); err == nil {
@@ -2456,7 +2456,6 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 						Karma:           m.karmaIdx == 0,
 						Nirvana:         m.nirvanaIdx == 0,
 						CovenantFile:    m.covenantInput.Value(),
-						PrincipleFile:   m.principleInput.Value(),
 						SoulFile:        m.soulFlowInput.Value(),
 						CommentFile:     m.commentInput.Value(),
 						AllowedPresets:  m.allowedPresetRefs(),
@@ -2508,7 +2507,6 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					Karma:           m.karmaIdx == 0,
 					Nirvana:         m.nirvanaIdx == 0,
 					CovenantFile:    m.covenantInput.Value(),
-					PrincipleFile:   m.principleInput.Value(),
 					SoulFile:        m.soulFlowInput.Value(),
 					CommentFile:     m.commentInput.Value(),
 					AllowedPresets:  m.allowedPresetRefs(),
@@ -4452,10 +4450,6 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 			m.covenantInput.SetValue(s)
 			m.covenantDirty = true
 		}
-		if s, ok := m.setupKeepInitJSON["principle_file"].(string); ok && s != "" {
-			m.principleInput.SetValue(s)
-			m.principleDirty = true
-		}
 		if s, ok := m.setupKeepInitJSON["soul_file"].(string); ok && s != "" {
 			m.soulFlowInput.SetValue(s)
 			m.soulFlowDirty = true
@@ -5166,11 +5160,8 @@ func (m FirstRunModel) performSetupSaveOnly() (FirstRunModel, tea.Cmd) {
 	p := m.currentPreset()
 	dirName := filepath.Base(m.setupOrchDir)
 
-	// Resolve prompt file paths from the project's staged .recipe/ so
-	// init.json stays consistent with whatever the user picked last. All
-	// four behavioral layers are optional — an empty return means "skip,
-	// kernel defaults take over" (for covenant/procedures) or "no file"
-	// (for comment/greet).
+	// Resolve supported prompt file paths from the project's staged .recipe/
+	// so init.json stays consistent with whatever the user picked last.
 	lang := m.pendingAgentOpts.Language
 	if lang == "" {
 		lang = "en"
@@ -5182,10 +5173,6 @@ func (m FirstRunModel) performSetupSaveOnly() (FirstRunModel, tea.Cmd) {
 	if covenantPath := resolveRecipeCovenant(projectRoot, lang); covenantPath != "" {
 		m.pendingAgentOpts.CovenantFile = covenantPath
 	}
-	if proceduresPath := resolveRecipeProcedures(projectRoot, lang); proceduresPath != "" {
-		m.pendingAgentOpts.ProceduresFile = proceduresPath
-	}
-
 	// /setup updates the default preset only — running agents keep their
 	// active preset until the next AED fallback or revert_preset call.
 	m.pendingAgentOpts.PreserveActivePreset = m.setupMode
@@ -5248,7 +5235,6 @@ func (m FirstRunModel) performRecipeSave(recipeName, customDir string) (FirstRun
 	// layers are optional in a recipe. Empty return = layer is absent:
 	//   - comment empty  → CommentFile stays unset (no comment file)
 	//   - covenant empty → CovenantFile stays unset (kernel default)
-	//   - procedures empty → ProceduresFile stays unset (kernel default)
 	//   - greet empty    → ApplyRecipe skips .prompt entirely
 	opts := m.pendingAgentOpts
 	if commentPath := resolveRecipeComment(projectRoot, lang); commentPath != "" {
@@ -5257,10 +5243,6 @@ func (m FirstRunModel) performRecipeSave(recipeName, customDir string) (FirstRun
 	if covenantPath := resolveRecipeCovenant(projectRoot, lang); covenantPath != "" {
 		opts.CovenantFile = covenantPath
 	}
-	if proceduresPath := resolveRecipeProcedures(projectRoot, lang); proceduresPath != "" {
-		opts.ProceduresFile = proceduresPath
-	}
-
 	// /setup: update default preset only, leave the running agent's active alone.
 	opts.PreserveActivePreset = m.setupMode
 

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -221,14 +221,12 @@ type FirstRunModel struct {
 	// soul-flow prompt/file path) and soulDelayInput (cadence after opt-in).
 	soulFlowEnabledIdx int
 	// Prompt path inputs
-	covenantInput  textinput.Model
-	principleInput textinput.Model
-	soulFlowInput  textinput.Model
-	commentInput   textinput.Model
+	covenantInput textinput.Model
+	soulFlowInput textinput.Model
+	commentInput  textinput.Model
 	// Track whether user manually edited prompt paths (dirty = don't auto-update on lang change)
-	covenantDirty  bool
-	principleDirty bool
-	soulFlowDirty  bool
+	covenantDirty bool
+	soulFlowDirty bool
 	// Welcome page language selector
 	langCursor            int
 	welcomeOnly           bool     // true when opened from /settings (return to mail after language pick)
@@ -537,11 +535,6 @@ func newFirstRunModelForPurpose(purpose firstRunPurpose, baseDir, globalDir stri
 	covi.SetWidth(50)
 	covi.Prompt = ""
 
-	prini := textinput.New()
-	prini.CharLimit = 256
-	prini.SetWidth(50)
-	prini.Prompt = ""
-
 	sfli := textinput.New()
 	sfli.CharLimit = 256
 	sfli.SetWidth(50)
@@ -608,7 +601,6 @@ func newFirstRunModelForPurpose(purpose firstRunPurpose, baseDir, globalDir stri
 		maxRpmInput:          mri,
 		maxAedInput:          mai,
 		covenantInput:        covi,
-		principleInput:       prini,
 		soulFlowInput:        sfli,
 		commentInput:         comi,
 		nirvanaIdx:           1, // default false (1=false)
@@ -1056,7 +1048,6 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 		m.nameInput.SetWidth(inputWidth)
 		m.dirInput.SetWidth(inputWidth)
 		m.covenantInput.SetWidth(inputWidth)
-		m.principleInput.SetWidth(inputWidth)
 		m.soulFlowInput.SetWidth(inputWidth)
 		m.commentInput.SetWidth(inputWidth)
 		return m, nil
@@ -2581,12 +2572,9 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					m.covenantInput, cmd = m.covenantInput.Update(msg)
 					m.covenantDirty = true
 				case 11:
-					m.principleInput, cmd = m.principleInput.Update(msg)
-					m.principleDirty = true
-				case 12:
 					m.soulFlowInput, cmd = m.soulFlowInput.Update(msg)
 					m.soulFlowDirty = true
-				case 13:
+				case 12:
 					m.commentInput, cmd = m.commentInput.Update(msg)
 				}
 				return m, cmd
@@ -2815,10 +2803,8 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 			case 10:
 				m.covenantInput, cmd = m.covenantInput.Update(msg)
 			case 11:
-				m.principleInput, cmd = m.principleInput.Update(msg)
-			case 12:
 				m.soulFlowInput, cmd = m.soulFlowInput.Update(msg)
-			case 13:
+			case 12:
 				m.commentInput, cmd = m.commentInput.Update(msg)
 			}
 		case stepRecipe:
@@ -3433,10 +3419,9 @@ func (m FirstRunModel) View() string {
 		// ── Prompts ──
 		b.WriteString("\n  " + sectionStyle.Render("── "+i18n.T("firstrun.section_prompts")+" ──") + "\n")
 		b.WriteString(cur(10) + i18n.T("firstrun.covenant") + ": " + m.covenantInput.View() + "\n")
-		b.WriteString(cur(11) + i18n.T("firstrun.principle") + ": " + m.principleInput.View() + "\n")
-		b.WriteString(cur(12) + i18n.T("firstrun.soul_flow") + ": " + m.soulFlowInput.View() + "\n")
+		b.WriteString(cur(11) + i18n.T("firstrun.soul_flow") + ": " + m.soulFlowInput.View() + "\n")
 		commentHint := StyleFaint.Render(" (" + i18n.T("firstrun.comment_hint") + ")")
-		b.WriteString(cur(13) + i18n.T("firstrun.comment") + ": " + m.commentInput.View() + commentHint + "\n")
+		b.WriteString(cur(12) + i18n.T("firstrun.comment") + ": " + m.commentInput.View() + commentHint + "\n")
 
 		if m.message != "" {
 			errStyle := lipgloss.NewStyle().Foreground(ColorSuspended)
@@ -3625,16 +3610,16 @@ func centerText(s string, width int) string {
 
 // agentNameDirFieldCount is the number of fields in stepAgentNameDir,
 // including the Back/Next button slots at the end.
-const agentNameDirFieldCount = 16
+const agentNameDirFieldCount = 15
 
 // Field indices:
 // 0=name, 1=dir, 2=lang,
 // 3=context_limit, 4=soul_delay, 5=max_rpm, 6=max_aed_attempts,
 // 7=karma, 8=nirvana, 9=soul_flow_enabled,
-// 10=covenant, 11=principle, 12=soul_flow (prompt path), 13=comment
-// 14=Back, 15=Next  (footer buttons; no input is focused here)
-const agentNameDirBackIdx = 14
-const agentNameDirNextIdx = 15
+// 10=covenant, 11=soul_flow (prompt path), 12=comment
+// 13=Back, 14=Next  (footer buttons; no input is focused here)
+const agentNameDirBackIdx = 13
+const agentNameDirNextIdx = 14
 
 // runCheckCaps runs `python -m lingtai check-caps` in a goroutine.
 func (m FirstRunModel) runCheckCaps() tea.Cmd {
@@ -4382,11 +4367,9 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 	langs := []string{"en", "zh", "wen"}
 	lang := langs[m.agentLangIdx]
 	m.covenantInput.SetValue(preset.CovenantPath(m.globalDir, lang))
-	m.principleInput.SetValue(preset.PrinciplePath(m.globalDir, lang))
 	m.soulFlowInput.SetValue(preset.SoulFlowPath(m.globalDir, lang))
 	m.commentInput.SetValue("")
 	m.covenantDirty = false
-	m.principleDirty = false
 	m.soulFlowDirty = false
 	m.karmaIdx = 0   // true
 	m.nirvanaIdx = 1 // false
@@ -4536,7 +4519,6 @@ func (m *FirstRunModel) focusAgentField() tea.Cmd {
 	m.maxRpmInput.Blur()
 	m.maxAedInput.Blur()
 	m.covenantInput.Blur()
-	m.principleInput.Blur()
 	m.soulFlowInput.Blur()
 	m.commentInput.Blur()
 
@@ -4560,10 +4542,8 @@ func (m *FirstRunModel) focusAgentField() tea.Cmd {
 	case 10:
 		return m.covenantInput.Focus()
 	case 11:
-		return m.principleInput.Focus()
-	case 12:
 		return m.soulFlowInput.Focus()
-	case 13:
+	case 12:
 		return m.commentInput.Focus()
 	}
 	return nil
@@ -4585,9 +4565,6 @@ func (m *FirstRunModel) updatePromptPaths() {
 	lang := langs[m.agentLangIdx]
 	if !m.covenantDirty {
 		m.covenantInput.SetValue(preset.CovenantPath(m.globalDir, lang))
-	}
-	if !m.principleDirty {
-		m.principleInput.SetValue(preset.PrinciplePath(m.globalDir, lang))
 	}
 	if !m.soulFlowDirty {
 		m.soulFlowInput.SetValue(preset.SoulFlowPath(m.globalDir, lang))

--- a/tui/internal/tui/firstrun_legacy_init_fields_test.go
+++ b/tui/internal/tui/firstrun_legacy_init_fields_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anthropics/lingtai-tui/internal/preset"
+)
+
+func TestSetupSaveStripsObsoletePromptFilesAndPreservesExistingConfig(t *testing.T) {
+	tmp := t.TempDir()
+	baseDir := filepath.Join(tmp, ".lingtai")
+	agentDir := filepath.Join(baseDir, "alice")
+	globalDir := filepath.Join(tmp, "global")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "alice",
+			"language":   "en",
+			"user_flag":  true,
+		},
+		"covenant_file":   "/project/.recipe/covenant.md",
+		"principle_file":  "/project/.lingtai/principle.md",
+		"procedures_file": "/project/.lingtai/procedures.md",
+		"env_file":        "/project/.lingtai/.env",
+		"venv_path":       "/project/.lingtai/runtime/venv",
+		"pad":             "keep this pad",
+		"user_config":     map[string]interface{}{"keep": "me"},
+	}
+	data, err := json.Marshal(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initPath := filepath.Join(agentDir, "init.json")
+	if err := os.WriteFile(initPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := FirstRunModel{
+		baseDir:          baseDir,
+		globalDir:        globalDir,
+		setupMode:        true,
+		setupOrchDir:     agentDir,
+		agentName:        "alice",
+		cursor:           0,
+		presets:          []preset.Preset{minimaxPresetForSetupTest()},
+		pendingAgentOpts: preset.DefaultAgentOpts(),
+	}
+	_, cmd := m.performSetupSaveOnly()
+	if cmd == nil {
+		t.Fatal("performSetupSaveOnly returned nil completion command")
+	}
+	msg := cmd()
+	if _, ok := msg.(SetupSavedMsg); !ok {
+		t.Fatalf("performSetupSaveOnly completion command returned %T, want SetupSavedMsg", msg)
+	}
+
+	data, err = os.ReadFile(initPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse init.json: %v", err)
+	}
+	for _, key := range []string{"principle_file", "procedures_file"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("setup rewrite still contains obsolete %q", key)
+		}
+	}
+	for key, want := range map[string]interface{}{
+		"covenant_file": "/project/.recipe/covenant.md",
+		"env_file":      "/project/.lingtai/.env",
+		"venv_path":     "/project/.lingtai/runtime/venv",
+		"pad":           "keep this pad",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %#v, want %#v", key, got[key], want)
+		}
+	}
+	userConfig, ok := got["user_config"].(map[string]interface{})
+	if !ok || userConfig["keep"] != "me" {
+		t.Errorf("unrelated user_config was not preserved: %#v", got["user_config"])
+	}
+	manifest, ok := got["manifest"].(map[string]interface{})
+	if !ok || manifest["user_flag"] != true {
+		t.Errorf("unrelated manifest field was not preserved: %#v", got["manifest"])
+	}
+}
+
+func minimaxPresetForSetupTest() preset.Preset {
+	return preset.Preset{
+		Name: "minimax",
+		Manifest: map[string]interface{}{
+			"language": "en",
+			"llm": map[string]interface{}{
+				"provider": "minimax",
+				"model":    "MiniMax-M2.5",
+			},
+			"capabilities": map[string]interface{}{},
+		},
+	}
+}

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -60,6 +60,45 @@ func TestSetupViewOmitsMoltPressureField(t *testing.T) {
 	}
 }
 
+func TestFirstRunAndSetupViewsOmitObsoletePrincipleControl(t *testing.T) {
+	i18n.SetLang("en")
+	for _, tc := range []struct {
+		name      string
+		setupMode bool
+	}{
+		{name: "first-run", setupMode: false},
+		{name: "setup", setupMode: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			baseDir := filepath.Join(t.TempDir(), ".lingtai")
+			globalDir := t.TempDir()
+			var m FirstRunModel
+			if tc.setupMode {
+				m = NewSetupModeModel(baseDir, globalDir, "", "test")
+			} else {
+				m = NewFirstRunModel(baseDir, globalDir, true, "")
+				m.presets = []preset.Preset{{
+					Name:     "test",
+					Manifest: map[string]interface{}{"language": "en"},
+				}}
+			}
+			m.width = 120
+			m.height = 40
+			m.enterAgentNameDir(m.currentPreset())
+			view := m.View()
+
+			if strings.Contains(view, i18n.T("firstrun.principle")) || strings.Contains(view, "firstrun.principle") {
+				t.Fatalf("%s view exposes the obsolete Principle control: %s", tc.name, view)
+			}
+			for _, label := range []string{i18n.T("firstrun.covenant"), i18n.T("firstrun.soul_flow"), i18n.T("firstrun.comment")} {
+				if !strings.Contains(view, label) {
+					t.Fatalf("%s view lost supported prompt %q: %s", tc.name, label, view)
+				}
+			}
+		})
+	}
+}
+
 func TestGetPresetProvider(t *testing.T) {
 	m := FirstRunModel{}
 

--- a/tui/internal/tui/model_validity_test.go
+++ b/tui/internal/tui/model_validity_test.go
@@ -305,7 +305,6 @@ func TestPresetKeyNext_BlocksUntilModelValidated(t *testing.T) {
 		maxRpmInput:    textinput.New(),
 		maxAedInput:    textinput.New(),
 		covenantInput:  textinput.New(),
-		principleInput: textinput.New(),
 		soulFlowInput:  textinput.New(),
 		commentInput:   textinput.New(),
 		presets: []preset.Preset{

--- a/tui/internal/tui/project_create.go
+++ b/tui/internal/tui/project_create.go
@@ -483,9 +483,6 @@ func RunProjectCreate(draft *ProjectDraft, opts CreateOptions) CreateResult {
 		if covenantPath := resolveRecipeCovenant(stagedProjectRoot, lang); covenantPath != "" {
 			agentOpts.CovenantFile = covenantPath
 		}
-		if proceduresPath := resolveRecipeProcedures(stagedProjectRoot, lang); proceduresPath != "" {
-			agentOpts.ProceduresFile = proceduresPath
-		}
 		if err := preset.GenerateInitJSONWithOpts(chosenPreset, agentName, dirName, stagingDir, opts.GlobalDir, agentOpts); err != nil {
 			cleanupStaging()
 			return fail(PhaseApplyRecipe, fmt.Errorf("write staged init.json: %w", err))

--- a/tui/internal/tui/settings.go
+++ b/tui/internal/tui/settings.go
@@ -383,6 +383,8 @@ func (m *SettingsModel) saveAgentName() {
 	if data, err := os.ReadFile(initPath); err == nil {
 		var init map[string]interface{}
 		if err := preset.DecodeJSONUseNumber(data, &init); err == nil {
+			delete(init, "principle_file")
+			delete(init, "procedures_file")
 			if manifest, ok := init["manifest"].(map[string]interface{}); ok {
 				manifest["agent_name"] = m.agentName
 			}
@@ -406,11 +408,12 @@ func (m *SettingsModel) saveAgentLang(lang string) {
 	if err := preset.DecodeJSONUseNumber(data, &initData); err != nil {
 		return
 	}
+	delete(initData, "principle_file")
+	delete(initData, "procedures_file")
 	if manifest, ok := initData["manifest"].(map[string]interface{}); ok {
 		manifest["language"] = lang
 	}
 	initData["covenant_file"] = preset.CovenantPath(m.globalDir, lang)
-	initData["principle_file"] = preset.PrinciplePath(m.globalDir, lang)
 	delete(initData, "covenant")
 	delete(initData, "principle")
 	if out, err := json.MarshalIndent(initData, "", "  "); err == nil {

--- a/tui/internal/tui/settings_legacy_init_fields_test.go
+++ b/tui/internal/tui/settings_legacy_init_fields_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeLegacyPromptFieldsInit(t *testing.T, orchDir string) string {
+	t.Helper()
+	path := filepath.Join(orchDir, "init.json")
+	init := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "old",
+			"language":   "en",
+			"user_flag":  true,
+		},
+		"covenant_file":   "/project/.recipe/covenant.md",
+		"principle_file":  "/project/.lingtai/principle.md",
+		"procedures_file": "/project/.lingtai/procedures.md",
+		"env_file":        "/project/.lingtai/.env",
+		"venv_path":       "/project/.lingtai/runtime/venv",
+		"pad":             "keep this pad",
+		"user_config":     map[string]interface{}{"keep": "me"},
+	}
+	data, err := json.Marshal(init)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func assertLegacyPromptFieldsStripped(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse init.json: %v", err)
+	}
+	for _, key := range []string{"principle_file", "procedures_file"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("settings rewrite still contains obsolete %q", key)
+		}
+	}
+	if covenant, ok := got["covenant_file"].(string); !ok || covenant == "" {
+		t.Errorf("supported covenant_file was not preserved: %#v", got["covenant_file"])
+	}
+	for key, want := range map[string]interface{}{
+		"env_file":  "/project/.lingtai/.env",
+		"venv_path": "/project/.lingtai/runtime/venv",
+		"pad":       "keep this pad",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %#v, want %#v", key, got[key], want)
+		}
+	}
+	userConfig, ok := got["user_config"].(map[string]interface{})
+	if !ok || userConfig["keep"] != "me" {
+		t.Errorf("unrelated user_config was not preserved: %#v", got["user_config"])
+	}
+	return got
+}
+
+func TestSettingsSaveAgentNameStripsObsoletePromptFiles(t *testing.T) {
+	orchDir := t.TempDir()
+	path := writeLegacyPromptFieldsInit(t, orchDir)
+	m := SettingsModel{orchDir: orchDir, agentName: "new-name"}
+
+	m.saveAgentName()
+	got := assertLegacyPromptFieldsStripped(t, path)
+	if got["covenant_file"] != "/project/.recipe/covenant.md" {
+		t.Errorf("saveAgentName changed supported covenant_file: %#v", got["covenant_file"])
+	}
+	manifest, ok := got["manifest"].(map[string]interface{})
+	if !ok || manifest["agent_name"] != "new-name" || manifest["user_flag"] != true {
+		t.Errorf("manifest rewrite lost supported/unrelated fields: %#v", got["manifest"])
+	}
+}
+
+func TestSettingsSaveAgentLangStripsObsoletePromptFiles(t *testing.T) {
+	orchDir := t.TempDir()
+	path := writeLegacyPromptFieldsInit(t, orchDir)
+	m := SettingsModel{orchDir: orchDir, globalDir: t.TempDir()}
+
+	m.saveAgentLang("zh")
+	got := assertLegacyPromptFieldsStripped(t, path)
+	manifest, ok := got["manifest"].(map[string]interface{})
+	if !ok || manifest["language"] != "zh" || manifest["user_flag"] != true {
+		t.Errorf("manifest rewrite lost supported/unrelated fields: %#v", got["manifest"])
+	}
+}


### PR DESCRIPTION
## Root cause

True first launch generated `principle_file` and `procedures_file` even though the kernel ignores them. The resulting nudge reached the same automatic first turn that prepares the greeting, so the new agent performed config maintenance before the user typed.

## Fix

- stop emitting both obsolete top-level fields in real generated `init.json`
- strip them from settings, setup/first-run, recipe propagation, and rehydrated worker rewrites
- preserve supported `covenant_file`, manifest, env/venv, pad, and unrelated user fields
- add runtime-output regressions for fresh generation and real settings/setup serialization paths

No greeting prompt, kernel/nudge behavior, new flag/schema, or broad startup migration is included.

## Validation

- failing-first regressions reproduced both legacy keys and unrelated-field loss on the old code
- focused generated-init/settings/setup regressions pass
- `cd tui && go test ./... -count=1`
- `cd tui && go vet ./...`
- `cd tui && go test -run TestArchitecture ./... -count=1`
- `git diff --check`

Requested emergency follow-up after the first-launch screenshot; intended for the next collision-free patch release after independent frozen review.

## Terra blocker follow-up

The first frozen review found one real blocker: first-run and `/setup` still rendered an editable Principle path even though the serialization option had been removed, making user input a silent no-op.

The updated candidate removes that dead Principle control and all focus/input/dirty/render plumbing, removes the orphaned path helper and locale labels, and adds a real rendered-model regression for both first-run and setup mode. The serialization change remains otherwise unchanged.

Updated validation:

- failing-first rendered-model regression reproduced the no-op control on the prior PR head
- focused blocker + legacy serialization regressions pass
- full uncached `cd tui && go test ./... -count=1` passes
- `go vet`, architecture, citation, and diff checks pass

A fresh exact-tree Terra review is required before merge.
