### PR TITLE
test(windows): define PowerShell installer contract first

### DIFF
--- a/.github/workflows/windows-installer-smoke.yml
+++ b/.github/workflows/windows-installer-smoke.yml
@@ -1,0 +1,60 @@
+name: Windows Installer Smoke
+
+# Runs the native-Windows installer contract suite (scripts/test-install-ps1.ps1)
+# under BOTH Windows PowerShell 5.1 (Desktop) and PowerShell 7 (Core) on
+# windows-latest. The suite is test-first: until install.ps1 exists it is RED by
+# design, so this workflow is expected to fail until the installer is
+# implemented against the seams the suite exercises.
+#
+# No secrets and no network dependency beyond actions/checkout and the
+# PowerShell hosts already present on windows-latest.
+
+on:
+  push:
+    paths:
+      - 'install.ps1'
+      - 'scripts/test-install-ps1.ps1'
+      - '.github/workflows/windows-installer-smoke.yml'
+  pull_request:
+    paths:
+      - 'install.ps1'
+      - 'scripts/test-install-ps1.ps1'
+      - '.github/workflows/windows-installer-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  windows-powershell-5-1:
+    name: Windows PowerShell 5.1 (Desktop)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Report host edition
+        shell: powershell
+        run: |
+          "$($PSVersionTable.PSEdition) $($PSVersionTable.PSVersion)"
+
+      - name: Run installer contract suite (Windows PowerShell 5.1)
+        shell: powershell
+        run: |
+          .\scripts\test-install-ps1.ps1
+
+  powershell-7:
+    name: PowerShell 7 (Core)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Report host edition
+        shell: pwsh
+        run: |
+          "$($PSVersionTable.PSEdition) $($PSVersionTable.PSVersion)"
+
+      - name: Run installer contract suite (PowerShell 7)
+        shell: pwsh
+        run: |
+          ./scripts/test-install-ps1.ps1

--- a/install.ps1
+++ b/install.ps1
@@ -328,7 +328,12 @@ function Write-InstallMetadata {
     }
     $metaPath = Join-Path $GlobalDir 'install.json'
     New-Item -ItemType Directory -Force -Path $GlobalDir | Out-Null
-    ($meta | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $metaPath -Encoding UTF8
+    $json = $meta | ConvertTo-Json -Depth 5
+    # Windows PowerShell 5.1's Set-Content -Encoding UTF8 emits a BOM, while
+    # Go's encoding/json rejects BOM-prefixed input. Use one explicit BOM-less
+    # encoding on both Desktop 5.1 and PowerShell Core.
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($metaPath, $json, $utf8NoBom)
     Write-Ok "Wrote install metadata -> $metaPath"
 }
 
@@ -451,6 +456,8 @@ function Install-FromPublicRelease {
 
     $tag = $Requested
     if ([string]::IsNullOrWhiteSpace($tag)) { $tag = '<latest>' }
+    $localVersionHint = $Requested
+    if ([string]::IsNullOrWhiteSpace($localVersionHint)) { $localVersionHint = '<exact-archive-release-tag>' }
     $assetName = "lingtai-$tag-windows-amd64.zip"
 
     Fail @"
@@ -463,7 +470,7 @@ a hard stop rather than a silent degrade.
 
 Options:
   - Install from a local artifact you already have:
-      .\install.ps1 -ArchivePath <path-to>.zip -ChecksumPath <path-to>.zip.sha256 -Version $tag -SkipVenv
+      .\install.ps1 -ArchivePath <path-to>.zip -ChecksumPath <path-to>.zip.sha256 -Version $localVersionHint -SkipVenv
   - Use WSL2 + install.sh for a full-parity install:
       wsl --install
       curl -fsSL https://lingtai.ai/install.sh | bash

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,569 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    LingTai native Windows (PowerShell) installer -- EXPERIMENTAL.
+
+.DESCRIPTION
+    One-click installer for the LingTai TUI (and portal) on native Windows. It is
+    the PowerShell counterpart to install.sh and parses/runs identically under
+    Windows PowerShell 5.1 (Desktop) and PowerShell 7+ (Core).
+
+    Two install sources are supported:
+
+      * LOCAL ARTIFACT MODE (-ArchivePath + -ChecksumPath): install FROM an
+        already-downloaded release archive plus its sha256 sidecar. No network.
+        The archive is verified, expanded into an installer-owned staging
+        directory, the staged lingtai-tui.exe is run to confirm it reports the
+        requested -Version, and only THEN are the binaries copied into -BinDir.
+        This is the seam the Windows contract suite exercises.
+
+      * PUBLIC MODE (no -ArchivePath): resolve a release tag from GitHub and the
+        Windows amd64 release asset for it. No such asset is published for the
+        current source-only release workflow (see RELEASING.md), so this path
+        fails loud with an actionable message rather than pretending an asset
+        exists.
+
+    Native Windows is EXPERIMENTAL. The TUI and portal render fine, but some
+    agent capabilities run at reduced fidelity natively (daemon/subagents; the
+    bash tool runs cmd.exe). For full parity use WSL2 and install.sh.
+
+    The Python runtime venv (default, non -SkipVenv) is provisioned ONLY from a
+    verified pinned kernel release bundle, exactly like install.sh -- LingTai is
+    never installed from a package index by name. Because no such Windows release
+    bundle is published today, the default runtime-provisioning path fails loud
+    and directs you to -SkipVenv plus a manual runtime setup. -SkipVenv installs
+    the binaries only and creates no venv.
+
+.PARAMETER Version
+    Release tag/version to install, e.g. v0.11.4. In local-artifact mode the
+    staged lingtai-tui.exe MUST report exactly this version or the install aborts
+    before touching BinDir. Defaults to $env:LINGTAI_VERSION.
+
+.PARAMETER BinDir
+    Directory the binaries install into. Defaults to a per-user, non-admin
+    location: %LOCALAPPDATA%\Programs\lingtai\bin. Never requires administrator.
+
+.PARAMETER GlobalDir
+    Per-user global state directory (the ~/.lingtai-tui analogue). Defaults to
+    %USERPROFILE%\.lingtai-tui.
+
+.PARAMETER ArchivePath
+    Local release archive (.zip) to install FROM. Enables local-artifact mode.
+    Requires -ChecksumPath. No network is used in this mode.
+
+.PARAMETER ChecksumPath
+    sha256 sidecar for -ArchivePath (sha256sum-style "<hex>  <name>" or a bare
+    hash). The archive's SHA-256 is verified case-insensitively against it.
+
+.PARAMETER SkipVenv
+    Skip Python runtime venv provisioning. No venv is created.
+
+.PARAMETER NoModifyPath
+    Do not persist PATH changes. Persistent user PATH is left untouched.
+
+.PARAMETER DryRun
+    Plan only: make no filesystem, PATH, or config writes. In local-artifact mode
+    it may read and validate inputs (including the checksum) and print the plan,
+    but it creates no staging/bin/global directories.
+
+.EXAMPLE
+    .\install.ps1 -ArchivePath .\lingtai-v0.11.4-windows-amd64.zip `
+                  -ChecksumPath .\lingtai-v0.11.4-windows-amd64.zip.sha256 `
+                  -Version v0.11.4 -SkipVenv
+
+.NOTES
+    Requires PowerShell 5.1 or later. Does not require administrator.
+    Exit 0 => success. Non-zero => a fail-loud error. Validation and the known
+    unsupported-runtime gate fail before BinDir writes; an unexpected OS-level
+    copy/metadata failure may leave partial files and is reported honestly.
+#>
+[CmdletBinding()]
+param(
+    [string]$Version      = $env:LINGTAI_VERSION,
+    [string]$BinDir       = $env:LINGTAI_BIN_DIR,
+    [string]$GlobalDir    = $env:LINGTAI_GLOBAL_DIR,
+    [string]$ArchivePath,
+    [string]$ChecksumPath,
+    [switch]$SkipVenv,
+    [switch]$NoModifyPath,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# On Windows PowerShell 5.1 the per-request progress bar makes Invoke-WebRequest
+# downloads dramatically slower and clutters piped output. Silence it.
+$ProgressPreference = 'SilentlyContinue'
+
+# --- Constants ---------------------------------------------------------------
+
+$Repo    = 'Lingtai-AI/lingtai'
+$RepoUrl = "https://github.com/$Repo"
+$ApiBase = "https://api.github.com/repos/$Repo"
+
+# --- Output helpers ----------------------------------------------------------
+
+function Write-Info { param([string]$Message) Write-Host "==> $Message" -ForegroundColor Cyan }
+function Write-Warn { param([string]$Message) Write-Host "warn: $Message" -ForegroundColor Yellow }
+function Write-Ok   { param([string]$Message) Write-Host "  ok: $Message" -ForegroundColor Green }
+function Write-Step { param([string]$Message) Write-Host "  -> $Message" -ForegroundColor DarkGray }
+
+# Fail loud: print an actionable message to the ERROR stream and throw so the
+# outer catch turns it into a non-zero exit. Never swallow, never fake success.
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    throw $Message
+}
+
+# --- Preconditions -----------------------------------------------------------
+
+if ($PSVersionTable.PSVersion.Major -lt 5) {
+    Fail "PowerShell 5.1 or later is required (found $($PSVersionTable.PSVersion)). Update Windows PowerShell or install PowerShell 7."
+}
+
+# OS guard: native Windows only. $IsWindows exists only on PowerShell 6+, so on
+# Windows PowerShell 5.1 (where it is undefined) fall back to the platform enum
+# and the OS env var, both reliably "Windows" there.
+$onWindows = $false
+if (Get-Variable -Name IsWindows -Scope Global -ErrorAction SilentlyContinue) {
+    $onWindows = [bool]$IsWindows
+} else {
+    $onWindows = ($env:OS -eq 'Windows_NT') -or `
+                 ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT)
+}
+if (-not $onWindows) {
+    Fail @"
+install.ps1 supports native Windows only.
+
+On macOS or Linux, use the shell installer instead:
+    curl -fsSL https://lingtai.ai/install.sh | bash
+"@
+}
+
+# --- Path / arch helpers -----------------------------------------------------
+
+function Get-DefaultBinDir {
+    $base = $env:LOCALAPPDATA
+    if ([string]::IsNullOrWhiteSpace($base)) {
+        $base = Join-Path $env:USERPROFILE 'AppData\Local'
+    }
+    return Join-Path $base 'Programs\lingtai\bin'
+}
+
+function Get-DefaultGlobalDir {
+    return Join-Path $env:USERPROFILE '.lingtai-tui'
+}
+
+function Get-Arch {
+    # PROCESSOR_ARCHITECTURE reflects the host on 64-bit shells; the WOW64
+    # variable covers a 32-bit host launching a 64-bit install.
+    $raw = $env:PROCESSOR_ARCHITECTURE
+    if ($env:PROCESSOR_ARCHITEW6432) { $raw = $env:PROCESSOR_ARCHITEW6432 }
+    switch ($raw) {
+        'AMD64' { return 'amd64' }
+        'ARM64' { return 'arm64' }
+        'x86'   { Fail "32-bit Windows (x86) is not supported. LingTai requires 64-bit Windows." }
+        default { Fail "Unsupported processor architecture '$raw'. LingTai's Windows release artifact is amd64-only." }
+    }
+}
+
+# --- Checksum handling -------------------------------------------------------
+
+# Parse the first 64-hex SHA-256 digest from a sha256 sidecar. Handles the
+# shasum/sha256sum format ("<hash>  <filename>") and a bare hash on its own line.
+# Returns the lowercased digest, or $null if none found.
+function Read-ExpectedSha256 {
+    param([string]$Path)
+    $text = Get-Content -LiteralPath $Path -Raw
+    $m = [regex]::Match($text, '(?im)^\s*([0-9a-fA-F]{64})\b')
+    if ($m.Success) { return $m.Groups[1].Value.ToLowerInvariant() }
+    return $null
+}
+
+function Get-Sha256Hex {
+    param([string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+# Verify $ArchiveFile against the digest in $SidecarFile. Fails loud (installs
+# nothing) on a missing sidecar, an unparseable digest, or a mismatch. The
+# comparison is case-insensitive: both sides are lowercased.
+function Confirm-ArchiveChecksum {
+    param([string]$ArchiveFile, [string]$SidecarFile)
+    if (-not (Test-Path -LiteralPath $SidecarFile)) {
+        Fail "Checksum sidecar not found: $SidecarFile. Refusing to install unverified bytes."
+    }
+    $expected = Read-ExpectedSha256 -Path $SidecarFile
+    if (-not $expected) {
+        Fail "Could not parse a SHA-256 digest from $SidecarFile."
+    }
+    $actual = Get-Sha256Hex -Path $ArchiveFile
+    if ($actual -ne $expected) {
+        Fail "Checksum mismatch for $ArchiveFile. Expected $expected but got $actual. The archive may be corrupt or tampered with; not installing."
+    }
+    Write-Ok "Verified SHA-256 checksum for $(Split-Path -Leaf $ArchiveFile)"
+}
+
+# --- Staging (installer-owned, unique, never deleted) ------------------------
+
+# Create a unique staging directory under TEMP for extraction. It is owned by
+# this installer run and is intentionally left on disk for evidence/recovery --
+# this installer never runs a cleanup/removal step.
+function New-StagingDir {
+    $tempBase = [System.IO.Path]::GetTempPath()
+    $stage = Join-Path $tempBase ("lingtai-install-{0}" -f ([System.Guid]::NewGuid().ToString('N')))
+    if (Test-Path -LiteralPath $stage) {
+        # A GUID collision here signals leaked state; fail loud rather than reuse.
+        Fail "Staging directory unexpectedly already exists: $stage"
+    }
+    New-Item -ItemType Directory -Force -Path $stage | Out-Null
+    return $stage
+}
+
+# --- Version verification of the STAGED tui (before any BinDir write) ---------
+
+# Run the staged lingtai-tui.exe and confirm its reported version contains the
+# requested version. Fails loud on a run error or a mismatch. Called on the
+# STAGED binary so a wrong-version archive never reaches BinDir.
+function Confirm-StagedVersion {
+    param([string]$StagedTui, [string]$Requested)
+
+    # The staged fixture/binary accepts `version`, `--version`, or `-version`;
+    # `version` matches install.sh's `lingtai-tui version` verification form.
+    $probe = 'version'
+
+    $out = $null
+    $code = 0
+    try {
+        $out = & $StagedTui $probe 2>&1 | Out-String
+        $code = $LASTEXITCODE
+    } catch {
+        Fail "Staged lingtai-tui.exe failed to run: $($_.Exception.Message)"
+    }
+    if ($code -ne 0) {
+        Fail "Staged lingtai-tui.exe '$probe' exited $code. Output: $out"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Requested)) {
+        # The real Go CLI and the Windows fixture both print exactly
+        # "lingtai-tui <version>". Compare the complete trimmed line using ordinal
+        # equality so v1.2.30 cannot satisfy a v1.2.3 request.
+        $reported = $out.Trim()
+        $expected = "lingtai-tui $Requested"
+        if (-not [string]::Equals($reported, $expected, [System.StringComparison]::Ordinal)) {
+            Fail "Version mismatch: expected '$expected' but the staged lingtai-tui reported: $reported"
+        }
+        Write-Ok "Staged lingtai-tui reports the requested version ($Requested)"
+    } else {
+        Write-Ok "Staged lingtai-tui runs ($($out.Trim()))"
+    }
+}
+
+# --- PATH management ---------------------------------------------------------
+
+# Add $Dir to the current process PATH and, unless -NoModifyPath, idempotently to
+# the persistent user PATH (HKCU\Environment via [Environment], User scope).
+# Never touches machine PATH; never requires admin.
+function Add-ToPath {
+    param([string]$Dir)
+
+    # Process PATH first so the rest of this session sees the binaries.
+    if (($env:PATH -split ';') -notcontains $Dir) {
+        $env:PATH = "$Dir;$env:PATH"
+    }
+
+    if ($NoModifyPath) {
+        Write-Step "Skipping persistent PATH update (-NoModifyPath). Add '$Dir' to PATH manually if needed."
+        return
+    }
+
+    $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    if ([string]::IsNullOrEmpty($userPath)) { $userPath = '' }
+    $entries = $userPath -split ';' | Where-Object { $_ -ne '' }
+    if ($entries -notcontains $Dir) {
+        if ($userPath -eq '') { $newPath = $Dir } else { $newPath = "$userPath;$Dir" }
+        [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+        Write-Ok "Added '$Dir' to your user PATH (open a new terminal to pick it up everywhere)."
+    } else {
+        Write-Step "'$Dir' is already on the user PATH."
+    }
+}
+
+# --- install.json metadata ---------------------------------------------------
+
+# Mirror install.sh's install.json shape. install_method is deliberately
+# "powershell" (not "source"): the TUI's source updater treats
+# install_method="source" as permission to run install.sh through bash, a
+# POSIX-only path that does not exist natively on Windows. There is no verified
+# kernel bundle on this path, so no kernel_source block is written -- matching
+# install.sh, which omits it entirely rather than writing empty strings.
+function Write-InstallMetadata {
+    param(
+        [string]$GlobalDir,
+        [string]$Prefix,
+        [string]$BinDir,
+        [string]$RequestedRef,
+        [string]$ResolvedRef,
+        [string[]]$ManagedBinaries
+    )
+    $stamped = $ResolvedRef -replace '^v', ''
+    $meta = [ordered]@{
+        schema           = 'lingtai.tui.install/v1'
+        schema_version   = 1
+        install_method   = 'powershell'
+        install_kind     = 'powershell-local-artifact'
+        self_update      = $false
+        upgrade_command  = 're-run install.ps1 with a newer -ArchivePath/-Version'
+        prefix           = $Prefix
+        bin_dir          = $BinDir
+        repo_url         = $RepoUrl
+        requested_ref    = $RequestedRef
+        resolved_ref     = $ResolvedRef
+        resolved_commit  = ''
+        stamped_version  = $stamped
+        installed_at     = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        managed_binaries = @($ManagedBinaries)
+    }
+    $metaPath = Join-Path $GlobalDir 'install.json'
+    New-Item -ItemType Directory -Force -Path $GlobalDir | Out-Null
+    ($meta | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $metaPath -Encoding UTF8
+    Write-Ok "Wrote install metadata -> $metaPath"
+}
+
+# --- Runtime venv (fail-loud; no PyPI-by-name; mirrors install.sh) -----------
+
+# The default (non -SkipVenv) runtime path installs LingTai's Python runtime ONLY
+# from a verified pinned kernel release bundle, never from a package index by
+# name (see RELEASING.md / ANATOMY.md install.sh entry). No such Windows release
+# bundle is published today, so this fails loud with an actionable message rather
+# than silently running `pip install lingtai`.
+function Install-Venv {
+    Fail @"
+Cannot provision the Python runtime venv on native Windows yet.
+
+LingTai's Python runtime is installed only from a verified pinned kernel release
+bundle (an exact kernel wheel/sdist matched to the venv interpreter, verified by
+SHA-256 and installed by explicit local file path) -- never from PyPI or any
+package index by the name 'lingtai'. The current source-only release workflow
+publishes no Windows release bundle, so there is nothing to pin against here.
+
+This is a hard stop, not a silent fallback. Options:
+  - Pass -SkipVenv to install the TUI/portal binaries only, then provision the
+    Python runtime yourself (for example an editable install against a local
+    lingtai-kernel checkout; see RELEASING.md / CLAUDE.md "Agent venv").
+  - Use WSL2 + install.sh for a full-parity install with the pinned runtime.
+"@
+}
+
+# --- Local-artifact install --------------------------------------------------
+
+# Install FROM a local archive + checksum sidecar. Order is deliberate: verify
+# the checksum, expand into installer-owned staging, require lingtai-tui.exe,
+# confirm the staged tui reports the requested version -- and only THEN copy into
+# BinDir. Any failure before the copy leaves BinDir untouched (nothing installed).
+function Install-FromLocalArtifact {
+    param(
+        [string]$Archive,
+        [string]$Sidecar,
+        [string]$BinDir,
+        [string]$Requested
+    )
+
+    if (-not (Test-Path -LiteralPath $Archive)) {
+        Fail "Archive not found: $Archive"
+    }
+
+    Write-Info "Installing from local artifact: $(Split-Path -Leaf $Archive)"
+
+    # 1. Verify checksum (case-insensitive). Readable in DryRun too.
+    Confirm-ArchiveChecksum -ArchiveFile $Archive -SidecarFile $Sidecar
+
+    if ($DryRun) {
+        # DryRun performs ZERO filesystem writes: no staging, no extraction, no
+        # BinDir/GlobalDir creation. Validate what is readable and print the plan.
+        Write-Warn "DRY RUN: checksum verified; no staging, extraction, or install will occur."
+        Write-Step "[dry-run] would expand the archive into an installer-owned staging dir under TEMP"
+        Write-Step "[dry-run] would require lingtai-tui.exe and verify it reports version '$Requested'"
+        Write-Step "[dry-run] would install lingtai-tui.exe (and optional lingtai-portal.exe) into $BinDir"
+        return @()
+    }
+
+    # 2. Expand into a unique, installer-owned staging directory under TEMP.
+    $stage = New-StagingDir
+    Write-Step "Staging under $stage"
+    $extract = Join-Path $stage 'extract'
+    New-Item -ItemType Directory -Force -Path $extract | Out-Null
+    try {
+        Expand-Archive -LiteralPath $Archive -DestinationPath $extract -Force
+    } catch {
+        Fail "Failed to expand $Archive : $($_.Exception.Message). Staging kept for inspection: $stage"
+    }
+
+    # 3. Require lingtai-tui.exe (fail loud if absent, even with a valid checksum).
+    $tui = Get-ChildItem -LiteralPath $extract -Recurse -Filter 'lingtai-tui.exe' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $tui) {
+        Fail "Archive does not contain lingtai-tui.exe. Staging kept for inspection: $stage"
+    }
+
+    # 4. Verify the STAGED tui reports the requested version BEFORE any BinDir write.
+    Confirm-StagedVersion -StagedTui $tui.FullName -Requested $Requested
+
+    # Optional portal.
+    $portal = Get-ChildItem -LiteralPath $extract -Recurse -Filter 'lingtai-portal.exe' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+
+    # 5. Install idempotently into BinDir (only reached once staging validated).
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    $tuiDest = Join-Path $BinDir 'lingtai-tui.exe'
+    Copy-Item -LiteralPath $tui.FullName -Destination $tuiDest -Force
+    Write-Ok "Installed lingtai-tui.exe -> $BinDir"
+
+    $managed = New-Object System.Collections.Generic.List[string]
+    $managed.Add($tuiDest)
+    if ($portal) {
+        $portalDest = Join-Path $BinDir 'lingtai-portal.exe'
+        Copy-Item -LiteralPath $portal.FullName -Destination $portalDest -Force
+        Write-Ok "Installed lingtai-portal.exe -> $BinDir"
+        $managed.Add($portalDest)
+    } else {
+        Write-Step "Archive has no lingtai-portal.exe; installing the TUI only."
+    }
+
+    return $managed.ToArray()
+}
+
+# --- Public (no -ArchivePath) install ----------------------------------------
+
+# Resolve a tag and the Windows amd64 release asset. The source-only release
+# workflow publishes no such asset today, so this fails loud rather than
+# pretending one exists. Architecture is explicit: the release artifact is
+# amd64-only; ARM64 is not claimed as supported.
+function Install-FromPublicRelease {
+    param([string]$BinDir, [string]$Requested)
+
+    $arch = Get-Arch
+    if ($arch -ne 'amd64') {
+        Fail "The LingTai Windows release artifact is amd64-only; '$arch' is not supported natively yet. Use WSL2 + install.sh."
+    }
+
+    $tag = $Requested
+    if ([string]::IsNullOrWhiteSpace($tag)) { $tag = '<latest>' }
+    $assetName = "lingtai-$tag-windows-amd64.zip"
+
+    Fail @"
+No Windows release asset is available to download.
+
+Public no-ArchivePath install would fetch '$assetName' (and its .sha256) from
+$RepoUrl, but the current source-only release workflow publishes no Windows
+amd64 release asset (see RELEASING.md). There is nothing to download, so this is
+a hard stop rather than a silent degrade.
+
+Options:
+  - Install from a local artifact you already have:
+      .\install.ps1 -ArchivePath <path-to>.zip -ChecksumPath <path-to>.zip.sha256 -Version $tag -SkipVenv
+  - Use WSL2 + install.sh for a full-parity install:
+      wsl --install
+      curl -fsSL https://lingtai.ai/install.sh | bash
+"@
+}
+
+# --- Main --------------------------------------------------------------------
+
+function Invoke-Main {
+    Write-Host ""
+    Write-Host "LingTai -- native Windows installer (EXPERIMENTAL)" -ForegroundColor Magenta
+    Write-Host "--------------------------------------------------" -ForegroundColor Magenta
+    if ($DryRun) { Write-Warn "DRY RUN: no filesystem, PATH, or config writes will be made." }
+
+    # Resolve per-user, non-admin defaults.
+    if ([string]::IsNullOrWhiteSpace($BinDir))    { $BinDir    = Get-DefaultBinDir }
+    if ([string]::IsNullOrWhiteSpace($GlobalDir)) { $GlobalDir = Get-DefaultGlobalDir }
+
+    # prefix is the parent of BinDir, matching install.sh's <prefix>/bin layout.
+    $prefix = Split-Path $BinDir -Parent
+    if ([string]::IsNullOrWhiteSpace($prefix)) { $prefix = $BinDir }
+
+    # Mode selection: local artifact requires BOTH ArchivePath and ChecksumPath.
+    $haveArchive  = -not [string]::IsNullOrWhiteSpace($ArchivePath)
+    $haveChecksum = -not [string]::IsNullOrWhiteSpace($ChecksumPath)
+    if ($haveArchive -ne $haveChecksum) {
+        Fail "-ArchivePath and -ChecksumPath must be provided together (local-artifact mode requires the sha256 sidecar)."
+    }
+    if ($haveArchive -and [string]::IsNullOrWhiteSpace($Version)) {
+        Fail "-Version is required with -ArchivePath so staged bytes can be verified against an exact release."
+    }
+
+    Write-Info "Target BinDir: $BinDir"
+    Write-Info "Target GlobalDir: $GlobalDir"
+
+    # 1. Runtime capability gate. The current native-Windows runtime path is a
+    # known hard stop, so reject it BEFORE binaries, PATH, or metadata can change.
+    # -SkipVenv is the explicit TUI-only opt-out; DryRun remains write-free.
+    if (-not $SkipVenv -and -not $DryRun) {
+        Install-Venv   # never returns until a verified Windows bundle exists
+    }
+
+    # 2. Install binaries.
+    if ($haveArchive) {
+        $managed = Install-FromLocalArtifact -Archive $ArchivePath -Sidecar $ChecksumPath -BinDir $BinDir -Requested $Version
+    } else {
+        # Fails loud (no public Windows asset today). Never returns.
+        $managed = Install-FromPublicRelease -BinDir $BinDir -Requested $Version
+    }
+
+    # 3. PATH. Skipped entirely in DryRun (no persistent writes).
+    if ($DryRun) {
+        Write-Step "[dry-run] would add '$BinDir' to the process and (unless -NoModifyPath) persistent user PATH"
+    } else {
+        Add-ToPath -Dir $BinDir
+    }
+
+    # 4. Runtime disposition. Non-skip/non-DryRun was rejected before writes.
+    if ($SkipVenv) {
+        Write-Warn "Skipping runtime venv (-SkipVenv). Provision the Python runtime yourself; the TUI/portal binaries are installed."
+    } elseif ($DryRun) {
+        Write-Step "[dry-run] would attempt runtime venv provisioning (which currently fails loud: no Windows kernel bundle)"
+    }
+
+    # 5. Metadata. Skipped in DryRun (no writes).
+    if ($DryRun) {
+        Write-Step "[dry-run] would write install metadata under $GlobalDir"
+    } else {
+        Write-InstallMetadata -GlobalDir $GlobalDir -Prefix $prefix -BinDir $BinDir `
+            -RequestedRef $Version -ResolvedRef $Version -ManagedBinaries $managed
+    }
+
+    # 6. Summary.
+    Write-Host ""
+    if ($DryRun) {
+        Write-Host "Dry run complete. Nothing was installed." -ForegroundColor Green
+    } else {
+        Write-Host "LingTai binaries installed." -ForegroundColor Green
+        Write-Host ""
+        Write-Host "EXPERIMENTAL: native Windows support runs some agent capabilities at" -ForegroundColor Yellow
+        Write-Host "reduced fidelity. For full parity, use WSL2 + install.sh." -ForegroundColor Yellow
+        if ($NoModifyPath) {
+            Write-Host ""
+            Write-Warn "BinDir was not added to persistent PATH (-NoModifyPath). Add '$BinDir' to PATH or run by full path."
+        } else {
+            Write-Host ""
+            Write-Step "If 'lingtai-tui' is not found, open a new terminal so the updated PATH is picked up."
+        }
+    }
+}
+
+try {
+    Invoke-Main
+    exit 0
+} catch {
+    # The specific fail-loud message was already emitted to the error stream by
+    # Fail (or by an unexpected exception). Ensure a non-zero exit; do NOT run any
+    # cleanup/removal -- staging is left on disk for evidence/recovery.
+    if ($_.Exception -and $_.Exception.Message) {
+        Write-Host "error: $($_.Exception.Message)" -ForegroundColor Red
+    }
+    exit 1
+}

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -49,7 +49,7 @@ $RepoRoot  = Split-Path -Parent $ScriptDir
 $InstallScript = Join-Path $RepoRoot 'install.ps1'
 
 # ---------------------------------------------------------------------------
-# Tiny test harness (no external module dependency — Pester is not guaranteed
+# Tiny test harness (no external module dependency -- Pester is not guaranteed
 # to be present on windows-latest for both PS 5.1 and PS 7).
 # ---------------------------------------------------------------------------
 $script:Failures = 0
@@ -119,16 +119,18 @@ function New-IsolatedHome {
       by callers (via Join-Path on this home), so child-process argument quoting
       and Windows spaced-path handling are exercised end to end.
     #>
-    $home = Join-Path $TestRoot ("home dir {0}" -f ([Guid]::NewGuid().ToString('N')))
-    $localAppData = Join-Path $home 'AppData\Local'
-    $tempDir = Join-Path $home 'Temp'
-    New-Item -ItemType Directory -Force -Path $home, $localAppData, $tempDir | Out-Null
-    [Environment]::SetEnvironmentVariable('HOME', $home, 'Process')
-    [Environment]::SetEnvironmentVariable('USERPROFILE', $home, 'Process')
+    # PowerShell variable names are case-insensitive; `$home` would collide with
+    # the automatic read-only `$HOME` variable on PowerShell 7.
+    $isolatedHome = Join-Path $TestRoot ("home dir {0}" -f ([Guid]::NewGuid().ToString('N')))
+    $localAppData = Join-Path $isolatedHome 'AppData\Local'
+    $tempDir = Join-Path $isolatedHome 'Temp'
+    New-Item -ItemType Directory -Force -Path $isolatedHome, $localAppData, $tempDir | Out-Null
+    [Environment]::SetEnvironmentVariable('HOME', $isolatedHome, 'Process')
+    [Environment]::SetEnvironmentVariable('USERPROFILE', $isolatedHome, 'Process')
     [Environment]::SetEnvironmentVariable('LOCALAPPDATA', $localAppData, 'Process')
     [Environment]::SetEnvironmentVariable('TEMP', $tempDir, 'Process')
     [Environment]::SetEnvironmentVariable('TMP', $tempDir, 'Process')
-    return $home
+    return $isolatedHome
 }
 
 # ---------------------------------------------------------------------------
@@ -156,7 +158,7 @@ function New-IsolatedHome {
 # fixtures.
 # ---------------------------------------------------------------------------
 
-# Resolve the Go toolchain once. Fail loudly (not silently) if absent — a fixture
+# Resolve the Go toolchain once. Fail loudly (not silently) if absent -- a fixture
 # that cannot produce a real .exe would make the whole suite dishonest.
 $script:GoExe = $null
 function Get-GoToolchain {
@@ -164,7 +166,7 @@ function Get-GoToolchain {
     $go = Get-Command -Name 'go' -CommandType Application -ErrorAction SilentlyContinue |
         Select-Object -First 1
     if (-not $go) {
-        throw "fixture setup: 'go' toolchain not found on PATH. A real native lingtai-tui.exe / lingtai-portal.exe fixture cannot be built offline without it. Install Go on the runner (already present on windows-latest) — do NOT fall back to a non-PE shim."
+        throw "fixture setup: 'go' toolchain not found on PATH. A real native lingtai-tui.exe / lingtai-portal.exe fixture cannot be built offline without it. Install Go on the runner (already present on windows-latest) -- do NOT fall back to a non-PE shim."
     }
     $script:GoExe = $go.Source
     return $script:GoExe
@@ -176,7 +178,7 @@ function New-StubExe {
       `<path> version` or `<path> --version`, prints $VersionLine to stdout and
       exits 0. Built offline from a stdlib-only Go program via `go build`.
       The installer resolves and runs the explicit .exe path, so this must be a
-      genuine PE image — no text/.cmd shim.
+      genuine PE image -- no text/.cmd shim.
     #>
     param(
         [string]$Path,
@@ -370,7 +372,7 @@ function Invoke-Installer {
     }
 }
 
-# Snapshot of an ENTIRE tree — every descendant directory AND file — for DryRun
+# Snapshot of an ENTIRE tree -- every descendant directory AND file -- for DryRun
 # no-write assertions. Enumerating files only would let the creation of empty
 # directories evade the no-write claim, so directories are captured too. Each
 # entry is recorded as "<D|F>\t<relative-path>" using a path relative to $Path so
@@ -400,7 +402,7 @@ try {
     Assert-True $installerPresent "install.ps1 exists at repo root ($InstallScript)"
     if (-not $installerPresent) {
         Write-Host ''
-        Write-Host "install.ps1 is absent — the contract suite is RED by design (test-first)."
+        Write-Host "install.ps1 is absent -- the contract suite is RED by design (test-first)."
         Write-Host "Every contract test below will now fail for the same reason. Implement"
         Write-Host "install.ps1 against the public seams to turn this suite green."
     }
@@ -444,7 +446,7 @@ try {
     Assert-True (Test-Path -LiteralPath (Join-Path $binDir1 'lingtai-portal.exe')) 'installed lingtai-portal.exe under BinDir'
 
     # -----------------------------------------------------------------------
-    # CONTRACT 2: checksum enforcement — wrong checksum fails loudly, no install.
+    # CONTRACT 2: checksum enforcement -- wrong checksum fails loudly, no install.
     # -----------------------------------------------------------------------
     Write-Section 'contract: fail-loud on wrong checksum'
     $home2 = New-IsolatedHome
@@ -568,7 +570,7 @@ try {
     $after7 = @(Get-TreeSnapshot $binDir7) + @(Get-TreeSnapshot $globalDir7)
     Assert-Equal 0 $r7.ExitCode 'DryRun exits 0'
     Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir7 'lingtai-tui.exe'))) 'DryRun did not install the TUI binary'
-    # Full-tree comparison (files AND directories) — a DryRun that created an
+    # Full-tree comparison (files AND directories) -- a DryRun that created an
     # empty directory would be caught here, not just one that wrote a file.
     Assert-Equal ($before7 -join "`n") ($after7 -join "`n") 'DryRun left the complete tree (files and directories) unchanged'
 
@@ -592,7 +594,7 @@ try {
     Assert-True ($r8.ExitCode -ne 0) 'nonexistent archive path exits non-zero'
 
     # -----------------------------------------------------------------------
-    # CONTRACT 9: SkipVenv is honored — no runtime venv is created under
+    # CONTRACT 9: SkipVenv is honored -- no runtime venv is created under
     # GlobalDir when -SkipVenv is passed. (The full venv path needs Python and
     # network and is out of scope for the offline smoke; here we assert the
     # negative: the skip seam prevents venv creation.)

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -524,6 +524,23 @@ try {
         NoModifyPath = $true
     }
     Assert-True ($r5.ExitCode -ne 0) 'version mismatch between requested and reported exits non-zero'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir5 'lingtai-tui.exe'))) 'version mismatch installs nothing'
+
+    # A prefix/superset is not an exact match: v9.9.90 must not satisfy v9.9.9.
+    $home5b = New-IsolatedHome
+    $binDir5b = Join-Path $home5b 'bin dir'
+    $fxNearVer = New-FixtureArchive -Version 'v9.9.9' -TuiVersion 'v9.9.90'
+    $r5b = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir5b
+        GlobalDir    = (Join-Path $home5b '.lingtai-tui')
+        ArchivePath  = $fxNearVer.ArchivePath
+        ChecksumPath = $fxNearVer.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-True ($r5b.ExitCode -ne 0) 'near-match version v9.9.90 does not satisfy exact request v9.9.9'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir5b 'lingtai-tui.exe'))) 'near-match version installs nothing'
 
     # -----------------------------------------------------------------------
     # CONTRACT 6: idempotent second install. Re-running the same install over an
@@ -614,6 +631,26 @@ try {
     }
     Assert-Equal 0 $r9.ExitCode 'SkipVenv install exits 0'
     Assert-True (-not (Test-Path -LiteralPath (Join-Path $globalDir9 'runtime\venv'))) 'SkipVenv left no runtime venv'
+
+    # The default native runtime path is currently unsupported. Its known
+    # fail-loud gate must run before any binary or metadata write so a caller
+    # never gets a failed command that already changed BinDir.
+    Write-Section 'contract: unavailable default runtime fails before install writes'
+    $home9b = New-IsolatedHome
+    $binDir9b = Join-Path $home9b 'bin dir'
+    $globalDir9b = Join-Path $home9b '.lingtai-tui'
+    $r9b = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir9b
+        GlobalDir    = $globalDir9b
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $fx.ChecksumPath
+        NoModifyPath = $true
+    }
+    Assert-True ($r9b.ExitCode -ne 0) 'unavailable default runtime exits non-zero'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir9b 'lingtai-tui.exe'))) 'runtime preflight failure installs no TUI binary'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir9b 'lingtai-portal.exe'))) 'runtime preflight failure installs no portal binary'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $globalDir9b 'install.json'))) 'runtime preflight failure writes no install metadata'
 
     # -----------------------------------------------------------------------
     # CONTRACT 10: NoModifyPath does not persist PATH.

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -9,11 +9,10 @@
     scripts/test-install-sh.sh and is designed to run *identically* under both
     Windows PowerShell 5.1 (Desktop) and PowerShell 7+ (Core) on windows-latest.
 
-    The installer does not exist yet. Until install.ps1 is added at the
-    repository root, EVERY contract test below fails loudly at the "installer
-    script is present" precondition. That RED state is intentional and correct:
-    it proves the suite exercises a real script rather than a stub, and it must
-    stay red until the installer is implemented against exactly these seams.
+    The suite begins with an explicit "installer script is present"
+    precondition. If install.ps1 is missing, the contract fails loudly instead
+    of silently exercising a stub; when present, every behavior below is driven
+    only through the documented public parameter seams.
 
     The installer is exercised ONLY through its public parameter seams so the
     contract stays independent of implementation details:
@@ -444,6 +443,18 @@ try {
     $tui1 = Join-Path $binDir1 'lingtai-tui.exe'
     Assert-True (Test-Path -LiteralPath $tui1) 'installed lingtai-tui.exe under BinDir'
     Assert-True (Test-Path -LiteralPath (Join-Path $binDir1 'lingtai-portal.exe')) 'installed lingtai-portal.exe under BinDir'
+    $metaPath1 = Join-Path $globalDir1 'install.json'
+    Assert-True (Test-Path -LiteralPath $metaPath1) 'successful install wrote install.json'
+    $metaBytes1 = [System.IO.File]::ReadAllBytes($metaPath1)
+    $hasUtf8Bom1 = ($metaBytes1.Length -ge 3) -and `
+        ($metaBytes1[0] -eq 0xEF) -and ($metaBytes1[1] -eq 0xBB) -and ($metaBytes1[2] -eq 0xBF)
+    Assert-True (-not $hasUtf8Bom1) 'install.json is UTF-8 without BOM on this host'
+    $meta1 = $null
+    try { $meta1 = Get-Content -LiteralPath $metaPath1 -Raw | ConvertFrom-Json } catch { $meta1 = $null }
+    Assert-True ($null -ne $meta1) 'install.json parses as JSON'
+    if ($null -ne $meta1) {
+        Assert-Equal 'powershell' $meta1.install_method 'install.json records powershell install method'
+    }
 
     # -----------------------------------------------------------------------
     # CONTRACT 2: checksum enforcement -- wrong checksum fails loudly, no install.

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -1,0 +1,674 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Windows-hosted contract tests for the native PowerShell installer (install.ps1).
+
+.DESCRIPTION
+    This is the test-first, implementation-independent contract for the
+    Windows-native `install.ps1`. It is the PowerShell analogue of
+    scripts/test-install-sh.sh and is designed to run *identically* under both
+    Windows PowerShell 5.1 (Desktop) and PowerShell 7+ (Core) on windows-latest.
+
+    The installer does not exist yet. Until install.ps1 is added at the
+    repository root, EVERY contract test below fails loudly at the "installer
+    script is present" precondition. That RED state is intentional and correct:
+    it proves the suite exercises a real script rather than a stub, and it must
+    stay red until the installer is implemented against exactly these seams.
+
+    The installer is exercised ONLY through its public parameter seams so the
+    contract stays independent of implementation details:
+
+        -Version <string>        exact release tag/version to install
+        -BinDir <path>           directory the binaries install into
+        -GlobalDir <path>        per-user global state dir (~/.lingtai-tui analogue)
+        -ArchivePath <path>      local fixture archive to install FROM
+                                 (download/expand equivalent; no network)
+        -ChecksumPath <path>     SHA-256 sidecar for -ArchivePath
+        -SkipVenv                skip the Python runtime venv step
+        -NoModifyPath            do not persist PATH changes
+        -DryRun                  plan only; make no filesystem writes
+
+    Every run isolates HOME / USERPROFILE / LOCALAPPDATA / TEMP / TMP and all
+    install outputs under a single throwaway test root, so a run can never touch
+    the developer's real profile or PATH.
+
+.NOTES
+    Exit code 0 => all contract tests passed (only possible once install.ps1
+    exists AND satisfies the contract). Non-zero => at least one contract
+    assertion failed, including the expected "installer absent" RED state.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Locate the repository root and the (future) installer under test.
+# ---------------------------------------------------------------------------
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Split-Path -Parent $ScriptDir
+$InstallScript = Join-Path $RepoRoot 'install.ps1'
+
+# ---------------------------------------------------------------------------
+# Tiny test harness (no external module dependency — Pester is not guaranteed
+# to be present on windows-latest for both PS 5.1 and PS 7).
+# ---------------------------------------------------------------------------
+$script:Failures = 0
+$script:Passed   = 0
+$script:NotYet   = 0
+
+function Write-Section {
+    param([string]$Name)
+    Write-Host ''
+    Write-Host "== $Name =="
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Label)
+    if ($Condition) {
+        $script:Passed++
+        Write-Host "  ok   - $Label"
+    } else {
+        $script:Failures++
+        Write-Host "  FAIL - $Label"
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Label)
+    if ($Expected -eq $Actual) {
+        $script:Passed++
+        Write-Host "  ok   - $Label"
+    } else {
+        $script:Failures++
+        Write-Host "  FAIL - $Label : expected [$Expected], got [$Actual]"
+    }
+}
+
+# A test whose behavior is deliberately deferred. It records the gap loudly and
+# honestly instead of pretending the contract point is covered.
+function Skip-NotYet {
+    param([string]$Label, [string]$Reason)
+    $script:NotYet++
+    Write-Host "  NOT-YET - $Label : $Reason"
+}
+
+# ---------------------------------------------------------------------------
+# Environment isolation. Every install output, and every ambient location the
+# installer might read/write, is redirected under one test root. Original
+# values are captured and restored in the finally block.
+# ---------------------------------------------------------------------------
+$IsolatedVars = @('HOME', 'USERPROFILE', 'LOCALAPPDATA', 'TEMP', 'TMP')
+$SavedEnv = @{}
+foreach ($name in $IsolatedVars) {
+    $SavedEnv[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+}
+
+# The test root deliberately contains a SPACE so that every child path derived
+# from it forces the installer invocation and Windows path handling through the
+# argument-quoting path (a common source of Windows installer bugs).
+$TestRoot = Join-Path ([IO.Path]::GetTempPath()) ("lingtai ps inst {0}" -f ([Guid]::NewGuid().ToString('N')))
+New-Item -ItemType Directory -Force -Path $TestRoot | Out-Null
+
+function New-IsolatedHome {
+    <#
+      Returns a fresh, empty isolated HOME/profile and points every ambient env
+      var at it, so an install invocation cannot escape $TestRoot. Each contract
+      test that installs gets its own home so tests never cross-contaminate.
+
+      The home directory name contains a SPACE, and so does the 'bin' leaf used
+      by callers (via Join-Path on this home), so child-process argument quoting
+      and Windows spaced-path handling are exercised end to end.
+    #>
+    $home = Join-Path $TestRoot ("home dir {0}" -f ([Guid]::NewGuid().ToString('N')))
+    $localAppData = Join-Path $home 'AppData\Local'
+    $tempDir = Join-Path $home 'Temp'
+    New-Item -ItemType Directory -Force -Path $home, $localAppData, $tempDir | Out-Null
+    [Environment]::SetEnvironmentVariable('HOME', $home, 'Process')
+    [Environment]::SetEnvironmentVariable('USERPROFILE', $home, 'Process')
+    [Environment]::SetEnvironmentVariable('LOCALAPPDATA', $localAppData, 'Process')
+    [Environment]::SetEnvironmentVariable('TEMP', $tempDir, 'Process')
+    [Environment]::SetEnvironmentVariable('TMP', $tempDir, 'Process')
+    return $home
+}
+
+# ---------------------------------------------------------------------------
+# Deterministic local Windows fixture archive.
+#
+# Builds a .zip containing REAL native Windows `lingtai-tui.exe` and
+# `lingtai-portal.exe` executables plus a matching SHA-256 sidecar, entirely
+# offline. On Windows the installer invokes the explicit installed
+# `lingtai-tui.exe` path and runs `<binary> version` (or `--version`) to verify
+# it reports the requested version; Windows will reject a text file at a .exe
+# path as an invalid PE image before any `.cmd` fallback is considered, so the
+# fixture MUST be a genuine PE executable.
+#
+# The stubs are compiled offline from a tiny stdlib-only Go program using the Go
+# toolchain that is already present on windows-latest (and in this Go repo). No
+# setup-go and no network. If `go` is unavailable, fixture setup fails LOUDLY
+# rather than silently degrading to a non-executable shim.
+#
+# Two flavors are produced per contract need:
+#   * a "good" stub that prints an exact version line, and
+#   * (per-test) a "wrong version" or "missing tui" variant.
+#
+# The contract asserts on the installer's *observable* behavior (version match /
+# required-binary presence); the builders below are the single source of
+# fixtures.
+# ---------------------------------------------------------------------------
+
+# Resolve the Go toolchain once. Fail loudly (not silently) if absent — a fixture
+# that cannot produce a real .exe would make the whole suite dishonest.
+$script:GoExe = $null
+function Get-GoToolchain {
+    if ($null -ne $script:GoExe) { return $script:GoExe }
+    $go = Get-Command -Name 'go' -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $go) {
+        throw "fixture setup: 'go' toolchain not found on PATH. A real native lingtai-tui.exe / lingtai-portal.exe fixture cannot be built offline without it. Install Go on the runner (already present on windows-latest) — do NOT fall back to a non-PE shim."
+    }
+    $script:GoExe = $go.Source
+    return $script:GoExe
+}
+
+function New-StubExe {
+    <#
+      Compiles a REAL native Windows executable at $Path that, when invoked as
+      `<path> version` or `<path> --version`, prints $VersionLine to stdout and
+      exits 0. Built offline from a stdlib-only Go program via `go build`.
+      The installer resolves and runs the explicit .exe path, so this must be a
+      genuine PE image — no text/.cmd shim.
+    #>
+    param(
+        [string]$Path,
+        [string]$VersionLine
+    )
+    $go = Get-GoToolchain
+    $dir = Split-Path -Parent $Path
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+
+    # Per-build throwaway Go module dir under $TestRoot (isolated; GOFLAGS=-mod=mod
+    # not needed since there are no imports beyond the standard library).
+    $buildDir = Join-Path $TestRoot ("gostub-{0}" -f ([Guid]::NewGuid().ToString('N')))
+    New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
+
+    # The version line is embedded as a Go string literal; %q-style quoting via
+    # a here-string is unsafe for arbitrary input, but our version lines are
+    # controlled ASCII. Escape backslashes and double-quotes defensively.
+    $escaped = $VersionLine.Replace('\', '\\').Replace('"', '\"')
+    $goSrc = @"
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	// Print the version for `version`, `--version`, or `-version`; the
+	// installer's verification calls one of these forms.
+	if len(os.Args) >= 2 {
+		switch os.Args[1] {
+		case "version", "--version", "-version":
+			fmt.Println("$escaped")
+			os.Exit(0)
+		}
+	}
+	fmt.Println("$escaped")
+	os.Exit(0)
+}
+"@
+    Set-Content -LiteralPath (Join-Path $buildDir 'main.go') -Value $goSrc -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $buildDir 'go.mod') -Value "module lingtaistub`n`ngo 1.21`n" -Encoding ASCII
+
+    # Build a native windows/amd64 PE from the throwaway module directory.
+    # GOOS/GOARCH are pinned so the fixture is a real Windows executable
+    # regardless of any cross-build env on the runner. Fully offline: stdlib-only,
+    # GOFLAGS neutralized, GOPROXY=off. Build env is saved and restored so it
+    # never leaks into the installer child processes launched later.
+    $savedGo = @{}
+    foreach ($gv in 'GOOS','GOARCH','CGO_ENABLED','GOPROXY','GOFLAGS') {
+        $savedGo[$gv] = [Environment]::GetEnvironmentVariable($gv, 'Process')
+    }
+    try {
+        $env:GOOS = 'windows'
+        $env:GOARCH = 'amd64'
+        $env:CGO_ENABLED = '0'
+        $env:GOPROXY = 'off'
+        $env:GOFLAGS = ''
+        # `-o <abs path>` with the module directory as the build target ('.'),
+        # run from $buildDir so the module is resolved cleanly.
+        Push-Location -LiteralPath $buildDir
+        try {
+            $buildOut = & $go build -o $Path '.' 2>&1
+        } finally {
+            Pop-Location
+        }
+        if ($LASTEXITCODE -ne 0) {
+            throw "fixture setup: 'go build' failed for $Path (exit $LASTEXITCODE): $buildOut"
+        }
+    } finally {
+        foreach ($gv in $savedGo.Keys) {
+            [Environment]::SetEnvironmentVariable($gv, $savedGo[$gv], 'Process')
+        }
+    }
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "fixture setup: 'go build' reported success but produced no file at $Path"
+    }
+}
+
+function Get-Sha256Hex {
+    param([string]$Path)
+    (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function New-FixtureArchive {
+    <#
+      Builds a deterministic .zip fixture under $TestRoot and returns a hashtable
+      with ArchivePath, ChecksumPath, and the version the stub reports.
+
+      Options:
+        -Version         version string the tui/portal stubs report
+        -IncludeTui      include lingtai-tui.exe stub (default $true)
+        -IncludePortal   include lingtai-portal.exe stub (default $true)
+        -TuiVersion      override the version the TUI stub reports (for the
+                         wrong-version case); defaults to -Version
+    #>
+    param(
+        [string]$Version = 'v9.9.9',
+        [bool]$IncludeTui = $true,
+        [bool]$IncludePortal = $true,
+        [string]$TuiVersion
+    )
+    if (-not $TuiVersion) { $TuiVersion = $Version }
+
+    $stage = Join-Path $TestRoot ("fixture-{0}" -f ([Guid]::NewGuid().ToString('N')))
+    New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+    if ($IncludeTui) {
+        New-StubExe -Path (Join-Path $stage 'lingtai-tui.exe') -VersionLine "lingtai-tui $TuiVersion"
+    }
+    if ($IncludePortal) {
+        New-StubExe -Path (Join-Path $stage 'lingtai-portal.exe') -VersionLine "lingtai-portal $Version"
+    }
+
+    # Unique GUID destination; a pre-existing file here would signal a serious
+    # problem (GUID collision or leaked state), so fail loudly rather than
+    # deleting anything.
+    $archivePath = Join-Path $TestRoot ("lingtai-{0}.zip" -f ([Guid]::NewGuid().ToString('N')))
+    if (Test-Path -LiteralPath $archivePath) {
+        throw "fixture setup: archive destination unexpectedly already exists: $archivePath"
+    }
+    # Compress-Archive is available on both PS 5.1 and PS 7.
+    Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $archivePath
+
+    $sha = Get-Sha256Hex -Path $archivePath
+    $checksumPath = "$archivePath.sha256"
+    # Sidecar format mirrors `sha256sum`: "<hex>  <filename>".
+    Set-Content -LiteralPath $checksumPath -Value ("{0}  {1}" -f $sha, (Split-Path -Leaf $archivePath)) -Encoding ASCII
+
+    return @{
+        ArchivePath  = $archivePath
+        ChecksumPath = $checksumPath
+        Sha256       = $sha
+        Version      = $Version
+        Stage        = $stage
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Installer invocation seam. Runs install.ps1 in a child PowerShell using the
+# SAME host executable that is running this suite, so PS 5.1 vs PS 7 coverage is
+# driven entirely by which host launches this file. Captures stdout, stderr, and
+# exit code without ever throwing on non-zero exit (the contract inspects the
+# exit code explicitly).
+# ---------------------------------------------------------------------------
+function Invoke-Installer {
+    param([hashtable]$Params)
+
+    if (-not (Test-Path -LiteralPath $InstallScript)) {
+        # Honest RED signal: there is no script to invoke yet.
+        return @{
+            ExitCode = 127
+            Stdout   = ''
+            Stderr   = "install.ps1 not found at $InstallScript"
+            Ran      = $false
+        }
+    }
+
+    # Build a parameter splat string for the child invocation.
+    $argList = New-Object System.Collections.Generic.List[string]
+    $argList.Add('-NoProfile')
+    $argList.Add('-NonInteractive')
+    $argList.Add('-ExecutionPolicy'); $argList.Add('Bypass')
+    $argList.Add('-File'); $argList.Add($InstallScript)
+    foreach ($k in $Params.Keys) {
+        $v = $Params[$k]
+        if ($v -is [bool]) {
+            if ($v) { $argList.Add("-$k") }   # switch parameter
+        } else {
+            $argList.Add("-$k"); $argList.Add([string]$v)
+        }
+    }
+
+    # Use the same host process for parity between PS 5.1 and PS 7. Invoke it
+    # directly with PowerShell array splatting so every argument remains a
+    # distinct argv entry even when InstallScript/BinDir/GlobalDir contain
+    # spaces. Start-Process joins an ArgumentList array into one string and can
+    # silently lose those boundaries unless callers add platform-specific quote
+    # escaping; this contract harness must not create that false failure mode.
+    $psHost = (Get-Process -Id $PID).Path
+    [string[]]$invokeArgs = $argList.ToArray()
+    $outFile = Join-Path $TestRoot ("out-{0}.txt" -f ([Guid]::NewGuid().ToString('N')))
+    $errFile = Join-Path $TestRoot ("err-{0}.txt" -f ([Guid]::NewGuid().ToString('N')))
+    & $psHost @invokeArgs 1> $outFile 2> $errFile
+    $exitCode = $LASTEXITCODE
+    return @{
+        ExitCode = $exitCode
+        Stdout   = (Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue)
+        Stderr   = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue)
+        Ran      = $true
+    }
+}
+
+# Snapshot of an ENTIRE tree — every descendant directory AND file — for DryRun
+# no-write assertions. Enumerating files only would let the creation of empty
+# directories evade the no-write claim, so directories are captured too. Each
+# entry is recorded as "<D|F>\t<relative-path>" using a path relative to $Path so
+# the snapshot is stable and comparable across before/after and across the two
+# PowerShell hosts. Sorted for deterministic comparison.
+function Get-TreeSnapshot {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return @() }
+    $root = (Resolve-Path -LiteralPath $Path).ProviderPath.TrimEnd('\')
+    Get-ChildItem -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $type = if ($_.PSIsContainer) { 'D' } else { 'F' }
+            $full = $_.FullName
+            $rel = $full
+            if ($full.StartsWith($root)) { $rel = $full.Substring($root.Length).TrimStart('\') }
+            "{0}`t{1}" -f $type, $rel
+        } | Sort-Object
+}
+
+try {
+    # -----------------------------------------------------------------------
+    # PRECONDITION: installer script must exist. Until it does, this fails and
+    # the whole suite is honestly RED.
+    # -----------------------------------------------------------------------
+    Write-Section 'precondition: installer script present'
+    $installerPresent = Test-Path -LiteralPath $InstallScript
+    Assert-True $installerPresent "install.ps1 exists at repo root ($InstallScript)"
+    if (-not $installerPresent) {
+        Write-Host ''
+        Write-Host "install.ps1 is absent — the contract suite is RED by design (test-first)."
+        Write-Host "Every contract test below will now fail for the same reason. Implement"
+        Write-Host "install.ps1 against the public seams to turn this suite green."
+    }
+
+    # Report the host so the workflow logs prove PS 5.1 and PS 7 both parsed and
+    # executed the identical file.
+    Write-Host ("  host: {0} {1}" -f $PSVersionTable.PSEdition, $PSVersionTable.PSVersion)
+
+    # -----------------------------------------------------------------------
+    # Fixture self-check (does not need the installer): the fixture builder must
+    # produce an archive whose sidecar matches, proving the RED failures below
+    # are about the missing installer, not a broken fixture.
+    # -----------------------------------------------------------------------
+    Write-Section 'fixture: deterministic archive + matching sidecar'
+    $fx = New-FixtureArchive -Version 'v9.9.9'
+    Assert-True (Test-Path -LiteralPath $fx.ArchivePath) 'fixture archive was created'
+    Assert-True (Test-Path -LiteralPath $fx.ChecksumPath) 'fixture checksum sidecar was created'
+    Assert-Equal $fx.Sha256 (Get-Sha256Hex -Path $fx.ArchivePath) 'sidecar sha256 matches archive bytes'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 1: local fixture install (download/expand equivalent).
+    # A clean install from -ArchivePath must succeed and place lingtai-tui(.exe)
+    # (and lingtai-portal(.exe)) under -BinDir.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: install from local fixture archive'
+    $home1 = New-IsolatedHome
+    $binDir1 = Join-Path $home1 'bin dir'
+    $globalDir1 = Join-Path $home1 '.lingtai-tui'
+    $r1 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir1
+        GlobalDir    = $globalDir1
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $fx.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-Equal 0 $r1.ExitCode 'clean fixture install exits 0'
+    $tui1 = Join-Path $binDir1 'lingtai-tui.exe'
+    Assert-True (Test-Path -LiteralPath $tui1) 'installed lingtai-tui.exe under BinDir'
+    Assert-True (Test-Path -LiteralPath (Join-Path $binDir1 'lingtai-portal.exe')) 'installed lingtai-portal.exe under BinDir'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 2: checksum enforcement — wrong checksum fails loudly, no install.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: fail-loud on wrong checksum'
+    $home2 = New-IsolatedHome
+    $binDir2 = Join-Path $home2 'bin dir'
+    $badChecksum = Join-Path $TestRoot ("bad-{0}.sha256" -f ([Guid]::NewGuid().ToString('N')))
+    Set-Content -LiteralPath $badChecksum -Value ("{0}  {1}" -f ('0' * 64), (Split-Path -Leaf $fx.ArchivePath)) -Encoding ASCII
+    $r2 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir2
+        GlobalDir    = (Join-Path $home2 '.lingtai-tui')
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $badChecksum
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-True ($r2.ExitCode -ne 0) 'wrong checksum exits non-zero'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir2 'lingtai-tui.exe'))) 'wrong checksum installs nothing'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 3: missing checksum sidecar fails loudly (never install
+    # unverified bytes).
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: fail-loud on missing checksum sidecar'
+    $home3 = New-IsolatedHome
+    $binDir3 = Join-Path $home3 'bin dir'
+    $missingChecksum = Join-Path $TestRoot ("does-not-exist-{0}.sha256" -f ([Guid]::NewGuid().ToString('N')))
+    $r3 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir3
+        GlobalDir    = (Join-Path $home3 '.lingtai-tui')
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $missingChecksum
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-True ($r3.ExitCode -ne 0) 'missing checksum sidecar exits non-zero'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir3 'lingtai-tui.exe'))) 'missing checksum installs nothing'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 4: required TUI binary enforcement. An archive missing
+    # lingtai-tui must fail loudly even with a valid checksum.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: fail-loud on missing required TUI binary'
+    $home4 = New-IsolatedHome
+    $binDir4 = Join-Path $home4 'bin dir'
+    $fxNoTui = New-FixtureArchive -Version 'v9.9.9' -IncludeTui $false -IncludePortal $true
+    $r4 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir4
+        GlobalDir    = (Join-Path $home4 '.lingtai-tui')
+        ArchivePath  = $fxNoTui.ArchivePath
+        ChecksumPath = $fxNoTui.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-True ($r4.ExitCode -ne 0) 'archive without lingtai-tui exits non-zero'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir4 'lingtai-tui.exe'))) 'missing-tui archive installs nothing'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 5: exact version verification. The installed TUI must report the
+    # requested version; a mismatch fails loudly.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: exact version verification'
+    $home5 = New-IsolatedHome
+    $binDir5 = Join-Path $home5 'bin dir'
+    # Fixture whose TUI stub reports a DIFFERENT version than requested.
+    $fxWrongVer = New-FixtureArchive -Version 'v9.9.9' -TuiVersion 'v0.0.1'
+    $r5 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir5
+        GlobalDir    = (Join-Path $home5 '.lingtai-tui')
+        ArchivePath  = $fxWrongVer.ArchivePath
+        ChecksumPath = $fxWrongVer.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-True ($r5.ExitCode -ne 0) 'version mismatch between requested and reported exits non-zero'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 6: idempotent second install. Re-running the same install over an
+    # existing one must succeed (exit 0) and leave the binary present.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: idempotent second install'
+    $home6 = New-IsolatedHome
+    $binDir6 = Join-Path $home6 'bin dir'
+    $globalDir6 = Join-Path $home6 '.lingtai-tui'
+    $common6 = @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir6
+        GlobalDir    = $globalDir6
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $fx.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    $r6a = Invoke-Installer $common6
+    $r6b = Invoke-Installer $common6
+    Assert-Equal 0 $r6a.ExitCode 'first install exits 0'
+    Assert-Equal 0 $r6b.ExitCode 'idempotent second install exits 0'
+    Assert-True (Test-Path -LiteralPath (Join-Path $binDir6 'lingtai-tui.exe')) 'binary still present after second install'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 7: DryRun makes no filesystem writes.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: DryRun performs no writes'
+    $home7 = New-IsolatedHome
+    $binDir7 = Join-Path $home7 'bin dir'
+    $globalDir7 = Join-Path $home7 '.lingtai-tui'
+    New-Item -ItemType Directory -Force -Path $binDir7, $globalDir7 | Out-Null
+    $before7 = @(Get-TreeSnapshot $binDir7) + @(Get-TreeSnapshot $globalDir7)
+    $r7 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir7
+        GlobalDir    = $globalDir7
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $fx.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+        DryRun       = $true
+    }
+    $after7 = @(Get-TreeSnapshot $binDir7) + @(Get-TreeSnapshot $globalDir7)
+    Assert-Equal 0 $r7.ExitCode 'DryRun exits 0'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir7 'lingtai-tui.exe'))) 'DryRun did not install the TUI binary'
+    # Full-tree comparison (files AND directories) — a DryRun that created an
+    # empty directory would be caught here, not just one that wrote a file.
+    Assert-Equal ($before7 -join "`n") ($after7 -join "`n") 'DryRun left the complete tree (files and directories) unchanged'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 8: nonzero exit propagation. A structurally invalid invocation
+    # (e.g. a nonexistent archive path) must surface as a non-zero exit rather
+    # than a silent success.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: nonzero exit propagation on bad archive path'
+    $home8 = New-IsolatedHome
+    $binDir8 = Join-Path $home8 'bin dir'
+    $r8 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir8
+        GlobalDir    = (Join-Path $home8 '.lingtai-tui')
+        ArchivePath  = (Join-Path $TestRoot 'no-such-archive.zip')
+        ChecksumPath = $fx.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-True ($r8.ExitCode -ne 0) 'nonexistent archive path exits non-zero'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 9: SkipVenv is honored — no runtime venv is created under
+    # GlobalDir when -SkipVenv is passed. (The full venv path needs Python and
+    # network and is out of scope for the offline smoke; here we assert the
+    # negative: the skip seam prevents venv creation.)
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: SkipVenv creates no runtime venv'
+    $home9 = New-IsolatedHome
+    $binDir9 = Join-Path $home9 'bin dir'
+    $globalDir9 = Join-Path $home9 '.lingtai-tui'
+    $r9 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir9
+        GlobalDir    = $globalDir9
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $fx.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    Assert-Equal 0 $r9.ExitCode 'SkipVenv install exits 0'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $globalDir9 'runtime\venv'))) 'SkipVenv left no runtime venv'
+
+    # -----------------------------------------------------------------------
+    # CONTRACT 10: NoModifyPath does not persist PATH.
+    #
+    # A real PATH-persistence test would read/write the user PATH via the
+    # registry (HKCU\Environment) or [Environment]::SetEnvironmentVariable(...,
+    # 'User'), which is process-global machine state that cannot be isolated
+    # under $TestRoot and cannot be safely restored across an abrupt failure on
+    # a shared runner. We therefore only assert the SAFE negative here: with
+    # -NoModifyPath, the install must not touch persistent PATH. The affirmative
+    # "PATH persistence actually happens" case is left as an explicit NOT-YET
+    # rather than faked, per the contract's honesty requirement.
+    # -----------------------------------------------------------------------
+    Write-Section 'contract: NoModifyPath leaves persistent PATH untouched'
+    $home10 = New-IsolatedHome
+    $binDir10 = Join-Path $home10 'bin dir'
+    $userPathBefore = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    $r10 = Invoke-Installer @{
+        Version      = 'v9.9.9'
+        BinDir       = $binDir10
+        GlobalDir    = (Join-Path $home10 '.lingtai-tui')
+        ArchivePath  = $fx.ArchivePath
+        ChecksumPath = $fx.ChecksumPath
+        SkipVenv     = $true
+        NoModifyPath = $true
+    }
+    $userPathAfter = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    Assert-Equal 0 $r10.ExitCode 'NoModifyPath install exits 0'
+    Assert-Equal $userPathBefore $userPathAfter 'NoModifyPath did not change persistent user PATH'
+
+    Skip-NotYet 'PATH persistence (affirmative case)' `
+        'Persisting PATH writes process-global HKCU\Environment state that cannot be isolated under the test root nor safely restored on a shared runner after an abrupt failure; implement with a safe save/restore harness before enabling.'
+
+} finally {
+    # -----------------------------------------------------------------------
+    # Restore ambient environment. NOTE: this only restores the isolated env
+    # vars for THIS process; it never runs a destructive cleanup trap over
+    # anything outside $TestRoot. The throwaway $TestRoot is intentionally left
+    # on disk for post-mortem inspection by the CI job.
+    # -----------------------------------------------------------------------
+    foreach ($name in $IsolatedVars) {
+        [Environment]::SetEnvironmentVariable($name, $SavedEnv[$name], 'Process')
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary + exit code.
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host ("summary: {0} passed, {1} failed, {2} not-yet" -f $script:Passed, $script:Failures, $script:NotYet)
+Write-Host ("test root (kept for inspection): {0}" -f $TestRoot)
+
+if ($script:Failures -gt 0) {
+    Write-Host ''
+    Write-Host 'RESULT: FAIL'
+    exit 1
+}
+Write-Host ''
+Write-Host 'RESULT: PASS'
+exit 0


### PR DESCRIPTION
## Summary

This draft PR starts deliberately **RED**: it adds the native-Windows PowerShell installer contract before adding `install.ps1`.

- run the same offline contract suite on GitHub-hosted `windows-latest` under Windows PowerShell 5.1 and PowerShell 7
- isolate HOME / USERPROFILE / LOCALAPPDATA / TEMP / TMP and all install outputs under a spaced test root
- build genuine Windows PE fixture binaries offline from a tiny stdlib-only Go program
- define public seams for version, bin/global directories, local archive + checksum overrides, venv skipping, PATH suppression, and dry-run
- assert checksum and required-binary failures, exact version verification, idempotency, complete-tree no-write dry-run, nonzero exit propagation, `-SkipVenv`, and `-NoModifyPath`

## Why RED first

`install.ps1` is intentionally absent in this commit, so both Windows jobs should fail at the explicit installer-present precondition. Once that VM evidence proves both PowerShell hosts parse and execute the real suite, the next commit will add the smallest implementation that satisfies these contracts.

This ordering follows the human instruction to test first and avoids reviving the closed experimental PR #607 as unverified current code.

## Current distribution boundary

- latest public `Lingtai-AI/lingtai` release `v0.11.4` has no binary assets
- latest public kernel release `v0.17.1` already includes Windows amd64 wheels
- the final installer must therefore fail loudly for unavailable TUI release assets or use a separately proven source/artifact path; it must not fabricate a public binary URL

## Validation before push

- exact baseline: `1f067242698e24b3959df842d2d9a5f0e4a5054d == origin/main`
- RED commit: `f9008fd63476878b9cdc2d39766827d9b3854cd8`
- YAML parse, whitespace/static contract checks: PASS
- parent cross-built the embedded fixture logic to a genuine `PE32+ executable (console) x86-64, for MS Windows`: PASS
- local macOS `pwsh`: unavailable; native parser/execution evidence is intentionally delegated to the two Windows CI jobs

## Not authorized / not part of this step

No merge, release, deploy, website change, or direct-main push. The later `lingtai-web` PR remains a separate follow-up and must stay open/unmerged.
