### PR TITLE
fix(tui): raise default context limit to 300k

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1565,7 +1565,7 @@ type AgentOpts struct {
 func DefaultAgentOpts() AgentOpts {
 	return AgentOpts{
 		Language:       "en",
-		ContextLimit:   250000,
+		ContextLimit:   300000,
 		SoulDelay:      nil,
 		MaxRpm:         60,
 		MaxAedAttempts: DefaultMaxAedAttempts,

--- a/tui/internal/preset/preset_context_limit_test.go
+++ b/tui/internal/preset/preset_context_limit_test.go
@@ -12,13 +12,13 @@ import (
 // intended budget. This is the canonical default; the firstrun wizard's
 // zero/invalid-input fallbacks mirror it.
 func TestDefaultAgentOpts_ContextLimit(t *testing.T) {
-	if got := DefaultAgentOpts().ContextLimit; got != 250000 {
-		t.Errorf("DefaultAgentOpts().ContextLimit = %d, want 250000", got)
+	if got := DefaultAgentOpts().ContextLimit; got != 300000 {
+		t.Errorf("DefaultAgentOpts().ContextLimit = %d, want 300000", got)
 	}
 }
 
 // TestGenerateInitJSON_WritesContextLimit verifies the default flows into the
-// generated manifest as 250000, and — crucially — that an explicit user
+// generated manifest as 300000, and — crucially — that an explicit user
 // override is preserved verbatim rather than being clamped back to the default.
 func TestGenerateInitJSON_WritesContextLimit(t *testing.T) {
 	withTempPresets(t, func() {
@@ -46,13 +46,13 @@ func TestGenerateInitJSON_WritesContextLimit(t *testing.T) {
 			return m
 		}
 
-		// Default flows through to the manifest as 250000.
+		// Default flows through to the manifest as 300000.
 		if err := GenerateInitJSONWithOpts(DefaultPreset(), "alice", "alice", lingtaiDir, globalDir, DefaultAgentOpts()); err != nil {
 			t.Fatalf("GenerateInitJSONWithOpts: %v", err)
 		}
 		// JSON numbers decode as float64.
-		if v, ok := readManifest("alice")["context_limit"].(float64); !ok || int(v) != 250000 {
-			t.Errorf("alice context_limit = %v (ok=%v), want 250000", readManifest("alice")["context_limit"], ok)
+		if v, ok := readManifest("alice")["context_limit"].(float64); !ok || int(v) != 300000 {
+			t.Errorf("alice context_limit = %v (ok=%v), want 300000", readManifest("alice")["context_limit"], ok)
 		}
 
 		// Explicit override is preserved, not reset to the default.

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -2434,7 +2434,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					// Stash current values for stepRecipe.
 					ctxLimit, _ := strconv.Atoi(m.ctxLimitInput.Value())
 					if ctxLimit <= 0 {
-						ctxLimit = 250000
+						ctxLimit = 300000
 					}
 					soulDelay := resolveSoulDelay(m.soulDelayInput.Value(), m.soulFlowEnabledIdx == 1)
 					maxRpm, _ := strconv.Atoi(m.maxRpmInput.Value())
@@ -2482,7 +2482,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 				}
 				ctxLimit, err := strconv.Atoi(m.ctxLimitInput.Value())
 				if err != nil || ctxLimit <= 0 {
-					ctxLimit = 250000
+					ctxLimit = 300000
 				}
 				soulDelay := resolveSoulDelay(m.soulDelayInput.Value(), m.soulFlowEnabledIdx == 1)
 				maxRpm, err := strconv.Atoi(m.maxRpmInput.Value())
@@ -4363,7 +4363,7 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 	}
 
 	// Numeric defaults — overridden by saved init.json values in setup mode below.
-	m.ctxLimitInput.SetValue("250000")
+	m.ctxLimitInput.SetValue("300000")
 	m.soulDelayInput.SetValue("")
 	m.maxRpmInput.SetValue("60")
 	m.maxAedInput.SetValue(strconv.Itoa(preset.DefaultMaxAedAttempts))

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -99,6 +99,28 @@ func TestFirstRunAndSetupViewsOmitObsoletePrincipleControl(t *testing.T) {
 	}
 }
 
+// TestFirstRunContextLimitDefault pins the wizard's fresh-agent context-limit
+// input to 300000, mirroring preset.DefaultAgentOpts (see
+// TestDefaultAgentOpts_ContextLimit). Explicit-override preservation through
+// GenerateInitJSONWithOpts is covered separately by
+// TestGenerateInitJSON_WritesContextLimit.
+func TestFirstRunContextLimitDefault(t *testing.T) {
+	i18n.SetLang("en")
+
+	baseDir := filepath.Join(t.TempDir(), ".lingtai")
+	globalDir := t.TempDir()
+	m := NewFirstRunModel(baseDir, globalDir, true, "")
+	m.presets = []preset.Preset{{
+		Name:     "test",
+		Manifest: map[string]interface{}{"language": "en"},
+	}}
+	m.enterAgentNameDir(m.currentPreset())
+
+	if got := m.ctxLimitInput.Value(); got != "300000" {
+		t.Fatalf("fresh-agent ctxLimitInput = %q, want %q", got, "300000")
+	}
+}
+
 func TestGetPresetProvider(t *testing.T) {
 	m := FirstRunModel{}
 

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -99,28 +99,6 @@ func TestFirstRunAndSetupViewsOmitObsoletePrincipleControl(t *testing.T) {
 	}
 }
 
-// TestFirstRunContextLimitDefault pins the wizard's fresh-agent context-limit
-// input to 300000, mirroring preset.DefaultAgentOpts (see
-// TestDefaultAgentOpts_ContextLimit). Explicit-override preservation through
-// GenerateInitJSONWithOpts is covered separately by
-// TestGenerateInitJSON_WritesContextLimit.
-func TestFirstRunContextLimitDefault(t *testing.T) {
-	i18n.SetLang("en")
-
-	baseDir := filepath.Join(t.TempDir(), ".lingtai")
-	globalDir := t.TempDir()
-	m := NewFirstRunModel(baseDir, globalDir, true, "")
-	m.presets = []preset.Preset{{
-		Name:     "test",
-		Manifest: map[string]interface{}{"language": "en"},
-	}}
-	m.enterAgentNameDir(m.currentPreset())
-
-	if got := m.ctxLimitInput.Value(); got != "300000" {
-		t.Fatalf("fresh-agent ctxLimitInput = %q, want %q", got, "300000")
-	}
-}
-
 func TestGetPresetProvider(t *testing.T) {
 	m := FirstRunModel{}
 


### PR DESCRIPTION
## Summary

Raise the fresh/default agent context limit from 250,000 to 300,000:

- one canonical default in `preset.DefaultAgentOpts`
- the first-run input default and its two invalid-input fallbacks
- existing test expectations updated from 250,000 to 300,000

Explicit user overrides, saved presets/manifests, provider metadata, migrations, and live telemetry are unchanged.

## Diff

3 files, +10 / -10. No new test framework or product surface.

## Validation

- `go test ./internal/preset ./internal/tui -count=1` — PASS
- `git diff --check` — PASS
- earlier full `go test ./...`, build, and vet — PASS