### PR TITLE
docs(recipe): stop suggesting /btw in adaptive mode

### DIFF
--- a/tui/internal/preset/recipe_assets/recommended/adaptive/.recipe/comment/comment.md
+++ b/tui/internal/preset/recipe_assets/recommended/adaptive/.recipe/comment/comment.md
@@ -31,7 +31,6 @@ Use `/help` as the canonical human-facing markdown reference for slash commands.
 
 | Context | Suggest |
 |---------|---------|
-| Human wants a quick reflective take from a mirrored copy of you while your current work keeps running | `/btw` — one-shot, no tools, cannot act on it; NOT a way to steer you, add a requirement, queue a task, set a reminder, or be remembered. For those, tell the human to send a normal message. |
 | Human says they're done or going away | `/sleep` or `/suspend all` |
 | Agent is unresponsive or stuck | `/refresh` (preferred) or `/cpr` |
 | Conversation has grown long and confused | `/clear` |

--- a/tui/internal/preset/recipe_assets/recommended/adaptive/.recipe/comment/wen/comment.md
+++ b/tui/internal/preset/recipe_assets/recommended/adaptive/.recipe/comment/wen/comment.md
@@ -31,7 +31,6 @@ Use `/help` as the canonical human-facing markdown reference for slash commands.
 
 | Context | Suggest |
 |---------|---------|
-| Human wants a quick reflective take from a mirrored copy of you while your current work keeps running | `/btw` — one-shot, no tools, cannot act on it; NOT a way to steer you, add a requirement, queue a task, set a reminder, or be remembered. For those, tell the human to send a normal message. |
 | Human says they're done or going away | `/sleep` or `/suspend all` |
 | Agent is unresponsive or stuck | `/refresh` (preferred) or `/cpr` |
 | Conversation has grown long and confused | `/clear` |

--- a/tui/internal/preset/recipe_assets/recommended/adaptive/.recipe/comment/zh/comment.md
+++ b/tui/internal/preset/recipe_assets/recommended/adaptive/.recipe/comment/zh/comment.md
@@ -31,7 +31,6 @@ Use `/help` as the canonical human-facing markdown reference for slash commands.
 
 | Context | Suggest |
 |---------|---------|
-| Human wants a quick reflective take from a mirrored copy of you while your current work keeps running | `/btw` — one-shot, no tools, cannot act on it; NOT a way to steer you, add a requirement, queue a task, set a reminder, or be remembered. For those, tell the human to send a normal message. |
 | Human says they're done or going away | `/sleep` or `/suspend all` |
 | Agent is unresponsive or stuck | `/refresh` (preferred) or `/cpr` |
 | Conversation has grown long and confused | `/clear` |


### PR DESCRIPTION
## Summary

- remove the Adaptive Discovery row that proactively suggests `/btw`
- keep the default, Wen, and Zh recipe comments in lockstep
- leave the `/btw` command implementation and canonical help untouched

Ordinary side questions can now be answered normally instead of triggering command-teaching from the Adaptive recipe.

## Validation

- `cd tui && go test ./internal/preset`
- `git diff --check`
- verified zero `/btw` occurrences under `recipe_assets/recommended/adaptive/.recipe/comment`
- verified `/btw` command/help references remain elsewhere in TUI

No merge requested or performed.