### PR TITLE
fix(tui): show knowledge parent dirs with sub-entries even without KNOWLEDGE.md

### DIFF
--- a/tui/internal/tui/knowledge_entries.go
+++ b/tui/internal/tui/knowledge_entries.go
@@ -68,6 +68,20 @@ func buildAgentKnowledgeEntries(agentDir string) []MarkdownEntry {
 		path := filepath.Join(knowledgeDir, name, "KNOWLEDGE.md")
 		data, err := os.ReadFile(path)
 		if err != nil {
+			// No direct KNOWLEDGE.md — check for sub-entries to
+			// synthesise a routing-parent entry, so nested knowledge
+			// folders remain reachable from /knowledge.
+			subEntries := findKnowledgeSubEntries(filepath.Join(knowledgeDir, name))
+			if len(subEntries) == 0 {
+				continue
+			}
+			desc := fmt.Sprintf("%d sub-entries", len(subEntries))
+			entries = append(entries, knowledgeEntry{
+				Name:        name,
+				Description: desc,
+				Path:        filepath.Join(knowledgeDir, name),
+				RelDir:      name,
+			})
 			continue
 		}
 		fm := parseFrontmatter(string(data))
@@ -107,6 +121,28 @@ func buildAgentKnowledgeEntries(agentDir string) []MarkdownEntry {
 	return result
 }
 
+
+// findKnowledgeSubEntries returns the names of immediate subdirectories
+// under dir that contain a KNOWLEDGE.md file.  Used to detect whether a
+// parent directory without its own KNOWLEDGE.md still has navigable
+// children and should appear in the /knowledge catalog.
+func findKnowledgeSubEntries(dir string) []string {
+	dirents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var sub []string
+	for _, de := range dirents {
+		if !de.IsDir() || isHiddenEntry(de.Name()) {
+			continue
+		}
+		subPath := filepath.Join(dir, de.Name(), "KNOWLEDGE.md")
+		if _, err := os.Stat(subPath); err == nil {
+			sub = append(sub, de.Name())
+		}
+	}
+	return sub
+}
 func cleanFrontmatterScalar(s string) string {
 	s = strings.TrimSpace(s)
 	if len(s) >= 2 {


### PR DESCRIPTION
## Problem

The /knowledge command silently skips directories that have nested sub-entries but no KNOWLEDGE.md at the parent level. This makes nested knowledge (e.g., session journals under knowledge/session-journal/) completely invisible in the TUI.

## Fix

Added findKnowledgeSubEntries() that detects child directories containing KNOWLEDGE.md files. When a parent directory lacks its own KNOWLEDGE.md but has navigable children, a synthetic routing-parent entry is created with a sub-entry count description.

## Testing

- TUI compiles cleanly (go build ./... passes)
- Previously invisible session-journal directory now appears in /knowledge