### PR TITLE
docs(presets): rewrite Codex manual for dynamic accounts

### DIFF
--- a/tui/internal/preset/preset_skill_router_test.go
+++ b/tui/internal/preset/preset_skill_router_test.go
@@ -368,9 +368,10 @@ func TestPresetSkillRouter_ProviderChildContracts(t *testing.T) {
 }
 
 // TestPresetSkillRouter_CodexPoolContract checks the codex-pool manual holds
-// the critical pool-format/selection/manual-edit facts the #691 brief
-// requires, without asserting on prose wording beyond the load-bearing
-// technical terms.
+// the critical pool-format/manual-edit facts and correctly redirects
+// selection-behavior questions to the canonical reference/codex/SKILL.md
+// manual instead of restating superseded per-session-sticky selection
+// claims (kernel now selects dynamically per send; see reference/codex).
 func TestPresetSkillRouter_CodexPoolContract(t *testing.T) {
 	data, err := fs.ReadFile(skillsFS, "skills/lingtai-preset-skill/reference/codex-pool/SKILL.md")
 	if err != nil {
@@ -387,11 +388,6 @@ func TestPresetSkillRouter_CodexPoolContract(t *testing.T) {
 		"stores only refs and integer weights",
 		"never token",
 		"Weight 0 means the account is present but disabled",
-		"sticky within one agent wake/session",
-		"excludes `molt_count`",
-		"Selection happens at adapter/service construction",
-		"does **not** reselect an",
-		"already-running session",
 		"Configured weights are inputs, not measured shares",
 		"falls back to the legacy",
 		"Exact authorization",
@@ -403,11 +399,20 @@ func TestPresetSkillRouter_CodexPoolContract(t *testing.T) {
 		"Never print token/auth contents or absolute auth paths",
 		"tui/internal/tui/codex_pool_store.go:11-330",
 		"login.go:171-201,285-299,603-702",
-		"auth/codex_pool.py:72-323",
-		"_register.py:424-497",
+		"reference/codex/SKILL.md",
+		"canonical",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("codex-pool manual missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{
+		"sticky within one agent wake/session",
+		"excludes `molt_count`",
+		"Selection happens at adapter/service construction",
+	} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("codex-pool manual still asserts superseded per-session-sticky selection claim %q; selection behavior now belongs to reference/codex/SKILL.md", unwanted)
 		}
 	}
 }

--- a/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
@@ -96,8 +96,8 @@ lifecycle mechanics and never encode provider-specific facts.
 | `kimi` | `reference/kimi/SKILL.md` | Kimi Code, OpenAI-compatible |
 | `nvidia` | `reference/nvidia/SKILL.md` | NVIDIA NIM/API Catalog gateway |
 | `openrouter` | `reference/openrouter/SKILL.md` | OpenRouter gateway |
-| `codex` | `reference/codex/SKILL.md` | ChatGPT OAuth Codex route |
-| `codex-pool` | `reference/codex-pool/SKILL.md` | pooled ChatGPT OAuth Codex route |
+| `codex` | `reference/codex/SKILL.md` | ChatGPT OAuth Codex route — canonical Codex behavior manual |
+| `codex-pool` | `reference/codex-pool/SKILL.md` | pool file format/edit protocol only — behavior is `reference/codex/SKILL.md` |
 | `claude-agent-sdk` | `reference/claude-agent-sdk/SKILL.md` | local Claude Code login |
 | `custom` | `reference/custom/SKILL.md` | user-supplied compatible endpoint |
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
@@ -1,59 +1,62 @@
 ---
 name: preset-skill-codex-pool
-description: Official-source-led manual for the TUI `codex-pool` template, including the codex-auth-pool.json format and manual-edit protocol.
-version: 2.1.0
-last_changed_at: "2026-07-19T12:00:00Z"
+description: Compatibility redirect for the TUI `codex-pool` template — the pool file format and manual-edit protocol live here; account-selection behavior is canonically described in reference/codex/SKILL.md.
+version: 3.0.0
+last_changed_at: "2026-07-20T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `codex-pool`
 
+**This page is a compatibility redirect, not a second behavior source.**
 `codexPoolPreset()` (`tui/internal/preset/preset.go:1178-1208`) ships
 provider `codex-pool`, exact model `gpt-5.6-sol`,
 `https://chatgpt.com/backend-api/codex`, `thinking: xhigh`, and an empty
 `api_key_env` because it selects from local ChatGPT OAuth token files. The
-manifest declares `vision` parity with `codex`; pooling changes account
-selection, not the model or endpoint.
+kernel treats `codex`, `codex-pool`, and `codex_pool` as aliases into the
+same underlying Codex provider — **for how an account is actually selected,
+per-send vs. fixed-account override, failure semantics, and safe
+observability, read the canonical `reference/codex/SKILL.md` manual.** That
+manual owns Codex behavior; this page owns only the pool file this template
+draws from and the protocol for hand-editing it.
 
-## Template-specific settings
-
-That manifest parity requires the companion kernel pool-vision dispatch support.
-Kernel versions before the pool-vision fix can silently skip this capability
-because `codex-pool` was absent from the vision-provider allow-list. Do not
-claim current-main runtime parity before that companion support is merged and
-verified. No separate official vision MCP is established; a native failure must
-remain visible rather than falling back to generic OpenAI, guessing credentials,
-or auto-loading an MCP.
-
-Read the official [Codex authentication](https://developers.openai.com/codex/auth)
-and [Codex models](https://developers.openai.com/codex/models) pages on demand.
-Verify the template’s model, endpoint, and capability fields in TUI source;
-never document pool membership or OAuth token contents here.
+## Checking live quota for one pooled account
 
 To check live OAuth quota/rate-limit state for **one pooled account**,
 query that account's app-server directly: complete `initialize`, then send
-the `account/rateLimits/read` request (params are structurally `null`),
-and read the `GetAccountRateLimitsResponse`. This is per-account —
-querying one pooled account's rate limits says nothing about the other
-accounts in the pool, and the pool file itself carries no rate-limit or
-credit data (it is refs + integer weights only, see below). Optionally
-watch `account/rateLimits/updated` as a rolling supplement, never a
-substitute. Full field-by-field routing, the official-272K-vs-measured-372K
+the `account/rateLimits/read` request (params are structurally `null`), and
+read the `GetAccountRateLimitsResponse`. This is per-account — querying one
+pooled account's rate limits says nothing about the other accounts in the
+pool, and the pool file itself carries no rate-limit or credit data (it is
+refs + integer weights only, see below). Optionally watch
+`account/rateLimits/updated` as a rolling supplement, never a substitute.
+Full field-by-field routing, the official-272K-vs-measured-372K
 distinction, and secret-safety rules live in
 `reference/operations/endpoint-capabilities/SKILL.md` — do not restate or
 re-derive that evidence here.
 
+## Template-specific settings
+
+Read the official [Codex authentication](https://developers.openai.com/codex/auth)
+and [Codex models](https://developers.openai.com/codex/models) pages on
+demand. Verify the template's model, endpoint, and capability fields in TUI
+source; never document pool membership or OAuth token contents here. No
+separate official vision MCP is established; a native failure must remain
+visible rather than falling back to generic OpenAI, guessing credentials, or
+auto-loading an MCP.
+
 ## The pool file: `codex-auth-pool.json`
 
-The kernel's `codex-pool` provider reads a NON-SECRET pool file that lists the
-Codex OAuth token files to load-balance across, each with an integer weight.
-The pool file is the single source of truth for load balancing — presets do
-not encode weights, and enabling the pool never rewrites saved presets.
+The kernel's Codex provider reads a NON-SECRET pool file that lists the
+Codex OAuth token files eligible for load balancing, each with an integer base
+weight. The file is the source of truth for membership and configured weights;
+a complete realtime quota snapshot may scale those weights for one dynamic draw
+as described in `reference/codex/SKILL.md`. Presets do not encode weights, and
+enabling or drawing from the pool never rewrites saved presets or this file.
 
 **Default path:** `$LINGTAI_TUI_DIR/codex-auth-pool.json` when
 `LINGTAI_TUI_DIR` is set, else `~/.lingtai-tui/codex-auth-pool.json`.
-(TUI: `tui/internal/tui/codex_pool_store.go:97-102`, `107-112`. Kernel:
-`auth/codex_pool.py:72-95`.)
+(`tui/internal/tui/codex_pool_store.go:97-102`, `107-112`.)
 
 ### v1 — flat
 
@@ -68,22 +71,20 @@ not encode weights, and enabling the pool never rewrites saved presets.
 ```
 
 A top-level `models` dict maps an exact, case-sensitive model string to an
-account list of the same entry shape as the flat v1 `accounts` list. **Presence
-of the `models` key is what classifies the pool — not its size, and not the
-`version` field.** An empty `{}` still classifies (every model then falls back
-to the legacy token); `models: null` is not a dict and leaves the pool flat.
-The kernel keys off structure, never off `version`. When `models` is present
-it is the sole source of truth and any `accounts` list in the same file is
-ignored. There is no prefix, family, wildcard, or default matching: a model
-with no exact category behaves like an unusable pool (legacy fallback). Flat
-v1 files keep byte-identical behavior for every model.
-(Kernel: `auth/codex_pool.py:117-180`.)
+account list of the same entry shape as the flat v1 `accounts` list.
+**Presence of the `models` key is what classifies the pool** — not its
+size, and not the `version` field. An empty `{}` still classifies (every
+model then falls back to the legacy token); `models: null` is not a dict
+and leaves the pool flat. There is no prefix, family, wildcard, or default
+matching: a model with no exact category behaves like an unusable pool
+(legacy fallback). Flat v1 files keep byte-identical behavior for every
+model.
 
 **Classified pools refuse flat TUI edits.** The TUI has no category editor
 yet — it round-trips `models` losslessly, stamps version 2, and refuses flat
 +/-/0 weight edits on a classified pool (`errCodexPoolModelClassified`) so it
-can never destroy a hand-authored classification or write an entry the kernel
-would ignore. Edit a classified pool by hand.
+can never destroy a hand-authored classification or write an entry the
+kernel would ignore. Edit a classified pool by hand.
 (`tui/internal/tui/codex_pool_store.go:64-70`, `301-306`;
 `tui/internal/tui/login.go:653-661`.)
 
@@ -96,49 +97,26 @@ would ignore. Edit a classified pool by hand.
 - The pool file stores only refs and integer weights — **never token
   contents.** Nothing in this store reads, logs, or writes token material.
 - **Weight 0 means the account is present but disabled** — it stays in the
-  pool file (so its membership is visible in the TUI) but the kernel excludes
-  it from selection because `_coerce_weight` requires a strictly-positive
-  int; a live kernel selection only ever picks among positive enabled
-  weights. (`tui/internal/tui/codex_pool_store.go:73-77`;
-  kernel `auth/codex_pool.py:183-197`.)
+  pool file (so its membership is visible in the TUI) but is excluded from
+  selection; only positive weights are eligible.
+  (`tui/internal/tui/codex_pool_store.go:73-77`.)
 - Manual edits: a missing `weight` defaults to `1`; `enabled: false` drops
   the entry entirely rather than zero-weighting it; non-numeric or
-  non-positive weights are dropped. (Kernel `auth/codex_pool.py:117-138`.)
+  non-positive weights are dropped.
+- **Configured weights are inputs, not measured shares.** A weight of 3 vs 1
+  biases selection toward the heavier account; it is not a live
+  traffic-split percentage guaranteed over any single sample of sends.
+- **Invalid or missing pool falls back to the legacy** single-account
+  `codex-auth.json` token — a missing file, unreadable file, malformed
+  JSON, non-dict/non-list structure, or a classified pool with no
+  exact-model category all yield no valid accounts. See
+  `reference/codex/SKILL.md` for the distinction between this
+  truly-empty-pool fallback and a nonempty-but-exhausted pool, which fails
+  closed instead.
 
-### Deterministic, sticky selection
-
-Selection is weighted (cumulative weights, no giant list expansion) and
-**sticky within one agent wake/session**: the seed is derived from the
-stable `codex_session_anchor` plus the agent's `.agent.json` `started_at`,
-and deliberately **excludes `molt_count`** — an auth account must not
-rotate on a molt. (Kernel `auth/codex_pool.py:200-263`.)
-
-The model is **not** mixed into the selection seed: a flat v1 pool picks the
-same account regardless of `model` (zero churn); for v2 the category list
-itself already differentiates the outcome.
-
-**Selection happens at adapter/service construction** — the kernel's
-`_codex_pool` adapter factory calls `select_codex_pool_auth` when the
-`codex-pool` provider is registered for a request/service, not per-turn.
-Editing the pool file (or a preset) therefore does **not** reselect an
-account for an already-running session; an explicit refresh, relaunch, or
-new service construction is required to pick up the change.
-(Kernel `_register.py:424-497`, specifically the `select_codex_pool_auth`
-call at line 436 inside the `_codex_pool` factory registered at 496-497.)
-
-**Configured weights are inputs, not measured shares.** A weight of 3 vs 1
-biases the deterministic hash-based pick toward the heavier account across
-many distinct sessions; it is not a live traffic-split percentage for any
-single session, and a small number of sessions can deviate from the nominal
-ratio.
-
-**Invalid or missing pool falls back to the legacy token.** A missing file,
-unreadable file, malformed JSON, non-dict/non-list structure, or a
-classified pool with no exact-model category all yield no valid accounts,
-and `select_codex_pool_auth`/`select_codex_pool_auth_path` return `None` — the
-caller then falls back to the legacy single-account `codex-auth.json` path,
-exactly the same fallback the single-account `codex` preset uses.
-(Kernel `auth/codex_pool.py:266-341`.)
+For exactly when and how often an account is picked from this file, and
+what changing the selection does to WS/cache/compaction state, see
+`reference/codex/SKILL.md` — do not infer selection timing from this page.
 
 ## Manual pool-file edit protocol
 
@@ -157,8 +135,10 @@ discipline used elsewhere in this codebase:
    never a truncate-in-place write, so a crash mid-write cannot leave a
    half-written pool file that then falls back unpredictably.
 5. **Validate with the actual live `load_codex_auth_pool`** (not a
-   hand-rolled JSON-shape check) before treating the edit as active,
-   since that function is the authority on what counts as a valid entry.
+   hand-rolled JSON-shape check) before treating the edit as active, since
+   that function is the authority on what counts as a valid entry. This is
+   the kernel's own validator; verify its exact name and location in kernel
+   source rather than this TUI-side manual before depending on it.
 6. **Preserve the original file on any validation failure** — restore from
    the timestamped backup rather than leaving a partially-applied edit.
 
@@ -178,16 +158,15 @@ Evidence anchors:
 
 - TUI pool store: `tui/internal/tui/codex_pool_store.go:11-330`
 - TUI login/credentials wiring: `tui/internal/tui/login.go:171-201,285-299,603-702`
-- Live kernel logical sources: `auth/codex_pool.py:72-323`,
-  `_register.py:424-497`
 
 ## Operations
 
-For base URL/API-compat/model/capability declaration shape versus
-credentials, and the full Codex OAuth quota-inspection routing (exact
-app-server sequence, secret-safe fields, official-vs-measured context
-window), see `reference/operations/endpoint-capabilities/SKILL.md`. For
-the availability/save gate a pool-bound preset still goes through, see
+For account-selection behavior (this is the **canonical** page for it), see
+`reference/codex/SKILL.md`. For base URL/API-compat/model/capability
+declaration shape versus credentials, and the full Codex OAuth
+quota-inspection routing, see
+`reference/operations/endpoint-capabilities/SKILL.md`. For the
+availability/save gate this template still goes through, see
 `reference/operations/availability-save-gate/SKILL.md`. For what an explicit
 refresh actually does (and does not) reselect, see
 `reference/operations/activation-session-refresh/SKILL.md`.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -1,45 +1,152 @@
 ---
 name: preset-skill-codex
-description: Official-source-led manual for the TUI `codex` template.
-version: 2.1.0
-last_changed_at: "2026-07-19T12:00:00Z"
+description: Canonical, official-source-led manual for the TUI Codex templates (`codex`, `codex-pool`) and the kernel's unified Codex provider — default dynamic account selection, fixed-account override, compatibility aliases, and safe observability.
+version: 3.0.0
+last_changed_at: "2026-07-20T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `codex`
 
-`codexPreset()` (`tui/internal/preset/preset.go:1148-1176`) uses provider
-`codex`, model `gpt-5.6-sol`, the Codex endpoint
-`https://chatgpt.com/backend-api/codex`, and ChatGPT OAuth rather than an API
-key env-var. The manifest exposes provider-native `vision` and web search.
+**One kernel provider, one factory, two TUI templates.** The kernel serves
+`codex`, `codex-pool`, and `codex_pool` as settings/provider aliases into a
+single `_codex` factory — there is one native Codex adapter, not separate
+adapters, sessions, or retry implementations per alias. The TUI ships two
+built-in templates that both route into this one provider: `codexPreset()`
+(`tui/internal/preset/preset.go:1148-1176`) and `codexPoolPreset()`
+(`tui/internal/preset/preset.go:1178-1208`). Both use model `gpt-5.6-sol`,
+the Codex endpoint `https://chatgpt.com/backend-api/codex`, `thinking: xhigh`,
+and ChatGPT OAuth rather than an API key env-var; the manifest exposes
+provider-native `vision` and web search on both. This manual is the single
+canonical Codex behavior description — `reference/codex-pool/SKILL.md` is a
+short compatibility redirect here, not a second source of truth.
+
+## Default: dynamic per-request account selection
+
+With no explicit `codex_auth_path` set on the preset, the kernel provider
+uses a `WeightedAccountSource` and **dynamically selects one account at each
+real provider-send boundary** — not once at chat/session construction. Chat
+construction and any rebuild/replay consume no account draw; only an actual
+send to the provider selects. This is the default for both the `codex` and
+`codex-pool` templates when neither carries a bound `codex_auth_path` — the
+weighted pool (see `codex-auth-pool.json` below) is live-consulted per send,
+not fixed for the life of a session. When a complete, comparable quota snapshot
+exists, effective weight is `configured weight × remaining-quota fraction`; if
+any eligible account lacks a comparable value, the whole draw falls back to
+configured weights rather than mixing stale and fresh quota data.
+
+Changing the selected account across sends resets the authenticated WS epoch
+and its `previous_response_id` continuation before the new account is used. The
+prompt-cache key remains stable across the switch. Inspect live ledger/cache
+evidence when diagnosing a deployment; do not turn one measured cache rate or
+calls/min sample into a permanent product guarantee.
+
+## Fixed-account override
+
+Setting an explicit `codex_auth_path` on the preset (the single-account
+`codex` template's per-account binding; see
+`reference/operations/endpoint-capabilities/SKILL.md` for how
+`ResolveRefsWithAuth` judges its credential validity) pins the provider to
+that one account for every send — this is the override, not the default.
+Absent an explicit path, the provider falls back through
+`WeightedAccountSource` as described above, never to a silently-fixed single
+account chosen once and reused.
+
+## What the kernel owns vs. what Codex itself owns
+
+Selecting an account per send is the kernel provider's job. Once a send is
+underway, ordinary Codex owns its own history, client, token refresh,
+REST/WS transport, cache, compaction, service tier, and built-in self-heal —
+the kernel does not reimplement these per alias. The kernel's outer AED layer
+owns retry, rebuild, and replay across sends; it does not own what happens
+inside one Codex call. Do not describe per-alias retry or session logic here
+that the kernel does not actually carry — verify any such claim against
+kernel source before repeating it in this manual.
+
+## `service_tier` / fast tier
+
+`service_tier: fast` is user-facing LingTai configuration; the kernel
+normalizes it onto the Codex wire field `priority`. Treat `service_tier` as
+the name to use when discussing or configuring this from the TUI/preset
+side; `priority` is the wire-level detail, not a separate user-facing knob.
+
+## Pool exhaustion and failure semantics
+
+A **nonempty but exhausted** pool (every account present but currently
+unusable) fails closed — it does not silently fall back to the legacy
+single-account token. Legacy fallback is reserved for a **truly empty**
+pool (no valid accounts at all): a missing file, unreadable file, malformed
+JSON, or a classified pool with no exact-model category. Do not conflate
+"exhausted" with "empty" when describing or triaging a Codex failure; they
+have different fallback outcomes.
+
+## Safe per-call observability
+
+Safe per-call metadata/ledger fields for account selection may include the
+account's sha8, its source index within the pool, and its configured weight
+— never plaintext token contents, the auth file path, the account email, or
+any other credential material. Current quota/rate-limit metadata is availability-dependent, not a promised
+field on every response. Merged source can emit `codex_pool_quota_left` for a
+dynamic selection when its quota snapshot is complete, but it is not yet
+consistently present for every real request: fixed-account binding does not yet
+probe it, and narrower ledger/event projections may omit it. A kernel follow-up
+will make the selected account's realtime balance ratio consistent in both
+dynamic and fixed modes. Until that merges, do not promise per-row coverage or
+present configured `weight` as if it were account balance.
+
+## Account-pool / auth setup ownership
+
+The account pool file, its format, weights, and the manual-edit protocol are
+owned by `reference/codex-pool/SKILL.md` — read it for
+`codex-auth-pool.json`'s v1/v2 shape, weight-0 disable semantics, and the
+destructive-edit discipline for hand-editing it. This canonical manual
+describes selection *behavior* against that pool; it does not restate the
+pool file's format.
 
 ## Template-specific settings
 
-Exact image support can depend on the current model/account; verify it rather
-than treating this manual as a promise.
-
-Read the official [Codex authentication](https://developers.openai.com/codex/auth)
-and [Codex models](https://developers.openai.com/codex/models) pages on demand.
+Exact image support can depend on the current model/account; verify it
+rather than treating this manual as a promise. Read the official
+[Codex authentication](https://developers.openai.com/codex/auth) and
+[Codex models](https://developers.openai.com/codex/models) pages on demand.
 No separate Codex vision MCP is established. If the native route fails,
 report the failure and use this manual for discovery; do not fall back to a
 generic OpenAI key, switch providers, or auto-load/invoke an MCP. Recheck the
 TUI preset source for model and capability changes. Never inspect, print, or
 reproduce OAuth token contents.
 
+Kernel source of truth lives in the separate `lingtai-kernel` repository:
+`src/lingtai/llm/_register.py::_codex` owns the aliases and fixed-vs-weighted
+source choice; `src/lingtai/auth/codex_account_source.py` owns pool snapshots and
+weight arithmetic; and
+`src/lingtai/llm/openai/adapter.py::{_select_codex_account,send_stream}` owns the
+per-request bind, quota lookup, exclusion/failover, and WS reset. The unified
+architecture landed in [kernel PR #1003](https://github.com/Lingtai-AI/lingtai-kernel/pull/1003).
+Verify those symbols before changing exact behavior claims; TUI source alone
+cannot prove kernel behavior.
+
 ## Operations
 
 For base URL/API-compat/model/capability declaration shape versus
-credentials, see `reference/operations/endpoint-capabilities/SKILL.md`. See
-also `reference/codex-pool/SKILL.md` for the pooled multi-account variant.
+credentials, see `reference/operations/endpoint-capabilities/SKILL.md`.
 
-To check live OAuth quota/rate-limit state for this account, query the
+To check live OAuth quota/rate-limit state for one account, query the
 app-server directly: complete `initialize`, then send the
 `account/rateLimits/read` request (its params are structurally `null` — no
 request body), and read the `GetAccountRateLimitsResponse`
 (`usedPercent`/`windowDurationMins`/`resetsAt` per window, plan/credits
 fields). Optionally also watch the sparse `account/rateLimits/updated`
-notification as a rolling supplement, never a substitute for the read.
-Full field-by-field routing, the official-272K-vs-measured-372K distinction,
-and secret-safety rules live in
+notification as a rolling supplement, never a substitute for the read. Under
+dynamic selection this is inherently per-account, not per-preset — querying
+one account's rate limits says nothing about another account the same
+preset may select on its next send. Full field-by-field routing, the
+official-272K-vs-measured-372K distinction, and secret-safety rules live in
 `reference/operations/endpoint-capabilities/SKILL.md` — do not restate or
 re-derive that evidence here.
+
+For the availability/save gate this preset still goes through, see
+`reference/operations/availability-save-gate/SKILL.md` — note its documented
+`codex-pool`-vs-`oauthProviders` gap is a TUI-side Save-editor fact, not a
+kernel routing fact, and is unaffected by anything in this manual. For what
+an explicit refresh actually does (and does not) reselect, see
+`reference/operations/activation-session-refresh/SKILL.md`.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/operations/activation-session-refresh/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/operations/activation-session-refresh/SKILL.md
@@ -73,11 +73,12 @@ already succeeded.
 **Saving a preset alone does not switch a running session.** A saved or
 even newly-activated (`default`) preset only takes effect on the *next*
 launch/refresh of a given agent — an explicit `/refresh [preset]`,
-relaunch, or new service construction is required to pick it up. This
-mirrors the codex-pool selection-at-construction rule in
-`reference/codex-pool/SKILL.md` — that pool selection is one more thing
-an in-place preset/pool-file edit does not retroactively touch on an
-already-running session.
+relaunch, or new service construction is required to pick it up: which
+*template/provider* a session uses is fixed at launch/refresh time. This is
+distinct from which *account* a Codex-provider session draws from within an
+already-running session — see `reference/codex/SKILL.md` for that, since
+the kernel now selects an account dynamically per send rather than fixing
+one at construction.
 
 ## Operations
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/operations/troubleshooting-migration/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/operations/troubleshooting-migration/SKILL.md
@@ -35,10 +35,19 @@ migration internals it doesn't own.
   `reference/operations/availability-save-gate/SKILL.md` first — pending,
   hard-blocked, and retryable-warned are three different states with
   different next actions.
-- **"I edited the preset/pool file but the running agent didn't change."**
+- **"I edited the preset but the running agent didn't switch templates."**
   Expected — see `reference/operations/activation-session-refresh/SKILL.md`:
   saving alone never switches a running session; an explicit refresh,
-  relaunch, or new service construction is required.
+  relaunch, or new service construction is required to pick up a *different
+  template/provider*.
+- **"I edited the Codex pool file and the running agent's account
+  selection looks unaffected."** Check `reference/codex/SKILL.md` first —
+  under the current default, account selection happens dynamically per
+  send, so a pool-file edit is live-consulted on the *next* send within an
+  already-running Codex session; it does not require a refresh the way a
+  template/provider switch does. If it still looks wrong after that, then
+  check `reference/codex-pool/SKILL.md` for the pool file's own format and
+  edit protocol.
 - **"codex-pool file looks wrong / refuses my edit."** See
   `reference/codex-pool/SKILL.md` — check whether the pool is
   model-classified (a `models` key, even `{}`) before assuming a flat edit
@@ -46,11 +55,11 @@ migration internals it doesn't own.
 
 ## Out of scope — route, don't guess
 
-- Deeper **runtime** questions (kernel adapter registration, request-scoped
-  failover behavior beyond what's cited in `reference/codex-pool/SKILL.md`,
-  live provider request/response shapes) belong to kernel-side skills or
-  direct kernel source reading — do not extrapolate kernel internals from
-  TUI-side evidence.
+- Deeper **runtime** questions (kernel provider/factory internals, ledger
+  fields not yet documented in `reference/codex/SKILL.md`, live provider
+  request/response shapes) belong to kernel-side skills or direct kernel
+  source reading — do not extrapolate kernel internals from TUI-side
+  evidence.
 - **Update/upgrade mechanics** (how a TUI version bump itself is delivered,
   migration numbering, `tui/internal/migrate/`) belong to the migration
   package's own ANATOMY.md and ownership, not this preset skill tree.


### PR DESCRIPTION
## Why

Kernel PR [Lingtai-AI/lingtai-kernel#1003](https://github.com/Lingtai-AI/lingtai-kernel/pull/1003) unified `codex`, `codex-pool`, and `codex_pool` behind one native Codex adapter and changed the default no-`codex_auth_path` behavior to dynamic account selection at each real provider send. The bundled preset manual still documented the old construction-time sticky pool behavior.

Jason asked for a Sonnet rewrite and an early Draft PR to inspect before the separate balance-ledger follow-up continues.

## Draft scope

- make `reference/codex/SKILL.md` the canonical behavior manual for both TUI Codex templates
- document default dynamic selection, explicit fixed-account override, alias unification, `service_tier: fast` → wire `priority`, empty-vs-exhausted failure semantics, account switching, and safe observability
- keep `reference/codex-pool/SKILL.md` as the pool-file/edit-protocol compatibility page rather than a second behavior source
- remove stale construction-time/sticky and old vision-gap claims from routing/operations guidance
- update the embedded router contract test to reject the superseded claims

## Important current boundary

This Draft does **not** change TUI runtime behavior or remove either built-in template. Current kernel source can emit `codex_pool_quota_left` for dynamic selection when a complete quota snapshot exists, but it is not yet consistently present for every fixed/dynamic real-request ledger projection. The cross-mode realtime balance-ratio implementation is a separate kernel follow-up and is not represented here as shipped.

## Validation

- `go test ./internal/preset/...`
- `go test ./internal/tui/... -run 'TestCodex|TestPreset|TestLogin'`
- `go build ./...` (Sonnet lane)
- `go vet ./internal/preset/...` (Sonnet lane)
- `git diff --check`

Implementation provenance: explicit Claude Sonnet session (`claude-sonnet-5` only in the exact session transcript); parent source-checked against merged kernel `main` and corrected the quota/ledger wording before commit.