### PR TITLE
fix(tui): keep doctor help side-effect free

### DIFF
--- a/tui/main.go
+++ b/tui/main.go
@@ -28,6 +28,20 @@ import (
 // version is set at build time via -ldflags "-X main.version=v0.4.2"
 var version = "dev"
 
+func dispatchDoctor(args []string, showHelp func(), runDoctor func()) {
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		showHelp()
+		return
+	}
+	runDoctor()
+}
+
+func printDoctorHelp() {
+	printWelcomeInfo()
+	fmt.Println()
+	printHelp()
+}
+
 func main() {
 	// Handle flags
 	if len(os.Args) > 1 {
@@ -75,7 +89,7 @@ func main() {
 			return
 		}
 		if arg == "doctor" {
-			doctorMain()
+			dispatchDoctor(os.Args[2:], printDoctorHelp, doctorMain)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\nRun 'lingtai-tui --help' for usage.\n", arg)

--- a/tui/main_doctor_test.go
+++ b/tui/main_doctor_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestDispatchDoctor(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantHelp   bool
+		wantDoctor bool
+	}{
+		{name: "no arguments runs doctor", wantDoctor: true},
+		{name: "help flag shows help", args: []string{"--help"}, wantHelp: true},
+		{name: "short help flag shows help", args: []string{"-h"}, wantHelp: true},
+		{name: "ordinary argument preserves doctor path", args: []string{"--force"}, wantDoctor: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var helpCalls, doctorCalls int
+
+			dispatchDoctor(tt.args,
+				func() { helpCalls++ },
+				func() { doctorCalls++ },
+			)
+
+			if got := helpCalls == 1; got != tt.wantHelp {
+				t.Fatalf("help calls = %d, want help called = %t", helpCalls, tt.wantHelp)
+			}
+			if got := doctorCalls == 1; got != tt.wantDoctor {
+				t.Fatalf("doctor calls = %d, want doctor called = %t", doctorCalls, tt.wantDoctor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Route `lingtai-tui doctor --help` and `doctor -h` to the help callback before `doctorMain`.
- Prevent the help path from entering the forced update/bootstrap flow.
- Add a dispatch regression test that asserts the doctor callback is not invoked.

## Tests
- `go test -run TestDispatchDoctor ./tui`
- `cd tui && go test ./...`
- `cd tui && make build`

Fixes #703