### PR TITLE
fix(installer): guide zsh PATH setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -168,6 +168,28 @@ say()  { echo "==> $*"; }
 warn() { echo "warning: $*" >&2; }
 note() { echo "    $*"; }
 
+# print_path_hint gives the user a shell-specific command without changing the
+# current process PATH or writing a shell rc file. SHELL is the user's login
+# shell on the supported macOS/Linux paths; use a direct export for an
+# unrecognized or unset shell rather than guessing its startup file.
+print_path_hint() {
+  local bin_dir="$1" shell_name="${SHELL:-}" rc_file
+  case ":${PATH}:" in
+    *":${bin_dir}:"*) return 0 ;;
+  esac
+  case "${shell_name##*/}" in
+    zsh)  rc_file="$HOME/.zshrc" ;;
+    bash) rc_file="$HOME/.bashrc" ;;
+    *)
+      say "Note: $bin_dir is not on your PATH. Add this export to your shell startup file:"
+      note "export PATH=\"$bin_dir:\$PATH\""
+      return 0
+      ;;
+  esac
+  say "Note: $bin_dir is not on your PATH. Add it with:"
+  note "echo 'export PATH=\"$bin_dir:\$PATH\"' >> \"$rc_file\" && source \"$rc_file\""
+}
+
 # is_wsl reports whether we're running under Windows Subsystem for Linux.
 is_wsl() {
   if [[ -n "${WSL_DISTRO_NAME:-}" || -n "${WSL_INTEROP:-}" ]]; then
@@ -2010,13 +2032,7 @@ say "Wrote install metadata to $GLOBAL_DIR/install.json"
 say "Done. $("$BIN_DIR/lingtai-tui" version 2>&1 || echo "$VERSION")"
 
 # Tell the user how to put BIN_DIR on PATH if it isn't already.
-case ":$PATH:" in
-  *":$BIN_DIR:"*) ;;
-  *)
-    say "Note: $BIN_DIR is not on your PATH. Add it with:"
-    note "echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
-    ;;
-esac
+print_path_hint "$BIN_DIR"
 }
 
 if [[ "${LINGTAI_INSTALL_SH_SOURCE_ONLY:-0}" != "1" ]]; then

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -82,6 +82,77 @@ assert_eq '\u0001' "$(json_escape $'\001')" "json generic control-byte escaping"
 assert_eq "$tmp/prefix/bin" "$(bin_dir_for_prefix "$tmp/prefix")" "bin dir from prefix"
 assert_eq "$tmp/prefix/bin" "$(bin_dir_for_prefix "$tmp/prefix/")" "bin dir from slash-suffixed prefix"
 
+# --- PATH guidance is shell-aware and does not mutate the host -----------------
+(
+  hint_home="$tmp/path-hint-zsh-home"
+  hint_bin="$tmp/path-hint-zsh-bin"
+  mkdir -p "$hint_home"
+  export HOME="$hint_home"
+  export SHELL="/bin/zsh"
+  export PATH="/usr/bin:/bin"
+
+  out="$(print_path_hint "$hint_bin")"
+  case "$out" in
+    *"Note: $hint_bin is not on your PATH."*) ;;
+    *) fail "zsh PATH hint should explain that the bin dir is absent: $out" ;;
+  esac
+  case "$out" in
+    *"$hint_home/.zshrc"*) ;;
+    *) fail "zsh PATH hint should target ~/.zshrc: $out" ;;
+  esac
+  [[ ! -e "$hint_home/.zshrc" ]] || fail "PATH hint must not write the zsh rc file"
+  assert_eq "/usr/bin:/bin" "$PATH" "zsh PATH hint leaves current PATH unchanged"
+)
+
+(
+  hint_home="$tmp/path-hint-bash-home"
+  hint_bin="$tmp/path-hint-bash-bin"
+  mkdir -p "$hint_home"
+  export HOME="$hint_home"
+  export SHELL="/bin/bash"
+  export PATH="/usr/bin:/bin"
+
+  out="$(print_path_hint "$hint_bin")"
+  case "$out" in
+    *"$hint_home/.bashrc"*) ;;
+    *) fail "bash PATH hint should target ~/.bashrc: $out" ;;
+  esac
+  [[ ! -e "$hint_home/.bashrc" ]] || fail "PATH hint must not write the bash rc file"
+)
+
+(
+  hint_home="$tmp/path-hint-present-home"
+  hint_bin="$tmp/path-hint-present-bin"
+  mkdir -p "$hint_home"
+  export HOME="$hint_home"
+  export SHELL="/bin/zsh"
+  export PATH="$hint_bin:/usr/bin:/bin"
+
+  out="$(print_path_hint "$hint_bin")"
+  assert_eq "" "$out" "PATH hint is silent when bin dir is already present"
+  [[ ! -e "$hint_home/.zshrc" ]] || fail "present PATH check must not write the zsh rc file"
+)
+
+(
+  hint_home="$tmp/path-hint-unknown-home"
+  hint_bin="$tmp/path-hint-unknown-bin"
+  mkdir -p "$hint_home"
+  export HOME="$hint_home"
+  export SHELL="/bin/fish"
+  export PATH="/usr/bin:/bin"
+
+  out="$(print_path_hint "$hint_bin")"
+  case "$out" in
+    *"shell startup file"*) ;;
+    *) fail "unknown shell PATH hint should name the shell startup file: $out" ;;
+  esac
+  case "$out" in
+    *"export PATH="*) ;;
+    *) fail "unknown shell PATH hint should provide a direct export: $out" ;;
+  esac
+  [[ ! -e "$hint_home/.profile" ]] || fail "unknown-shell PATH hint must not write .profile"
+)
+
 # --- uv bootstrap: no uv, system python3 too old (jammy scenario) -------------
 # Simulates Ubuntu jammy: python3 exists but reports 3.10 and there is no uv on
 # PATH. ensure_uv must download the official installer (via a fake curl) and run


### PR DESCRIPTION
## Summary

- Make installer PATH guidance shell-aware: zsh uses `~/.zshrc`, bash uses `~/.bashrc`, and unknown or unset shells receive a direct `export`.
- Preserve silent behavior when the install bin directory is already on `PATH`.
- Keep guidance print-only: no PATH mutation and no profile-file writes.

This local candidate came from dev-3's Luna handoff and was approved as-is in the Fable existing-candidates review. The exact approved patch was reproduced against base `f9feff5cdc4e8a6562c3353c10fcacc96e8c355c`.

## Validation

- `bash -n install.sh scripts/test-install-sh.sh` — passed.
- `bash scripts/test-install-sh.sh` — passed (`install.sh helper tests passed`).
- `git diff --check HEAD` — passed.
- Exact binary diff comparison against the approved patch — passed; SHA-256 `4452c73b95887ac8bd5be7e2f5e287f3b9b2e4685703ae051e1e859629492c63`.
- Old behavior preserved: PATH-present remains silent; bash guidance remains `.bashrc`-based; install destination, Homebrew, and UV behavior are untouched.
- No-profile-mutation boundary: the helper only prints guidance; tests verify PATH invariance and non-creation of `.zshrc`, `.bashrc`, and `.profile`.
