### PR TITLE
chore(release): pin kernel v0.18.1 for TUI v0.11.6

### DIFF
--- a/kernel-release.json
+++ b/kernel-release.json
@@ -1,5 +1,5 @@
 {
   "schema": "lingtai.tui.kernel-pin/v1",
-  "kernel_tag": "v0.18.0",
+  "kernel_tag": "v0.18.1",
   "comment": "Repo-owned pin: the kernel release tag a TUI release binds into its bundle manifest. Bump this deliberately in the same PR/commit that intends to ship a new kernel version with the next TUI release; the release workflow never resolves 'latest kernel' on its own. See RELEASING.md."
 }


### PR DESCRIPTION
## Summary
- pin the authorized TUI `v0.11.6` release to kernel `v0.18.1`
- preserve the existing three-segment release machinery and bundle contract

## Validation
- parsed `kernel-release.json` and confirmed schema `lingtai.tui.kernel-pin/v1` + tag `v0.18.1`
- `git diff --check`

No TUI/runtime behavior, installer, workflow, or unrelated source is changed.