### PR TITLE
fix(tui): harden Codex pool preflight and weight parsing

### DIFF
--- a/tui/internal/tui/codex_model_probe.go
+++ b/tui/internal/tui/codex_model_probe.go
@@ -15,6 +15,10 @@ import (
 // proves token reachability, not that this model/account can serve a real
 // Responses request. Pool candidates are the same token paths the kernel can
 // select, and a non-empty pool never falls back silently to the legacy token.
+// Because the kernel weighted-selects among ALL of those candidates at
+// runtime, probeOK certifies a pool only when every candidate passed: the
+// probe walks the candidates in file order and fails fast at the first
+// account that cannot serve the model.
 func probeCodexModel(provider, model, baseURL, globalDir, authRef string) (probeStatus, string) {
 	if strings.TrimSpace(model) == "" {
 		return probeUnknown, "selected Codex model is missing"
@@ -23,8 +27,9 @@ func probeCodexModel(provider, model, baseURL, globalDir, authRef string) (probe
 		return probeNoKey, "Codex credential directory is unavailable"
 	}
 
+	isPool := provider == "codex-pool" || provider == "codex_pool"
 	paths := []string{}
-	if provider == "codex-pool" || provider == "codex_pool" {
+	if isPool {
 		pool, err := loadCodexPool(globalDir)
 		if err != nil {
 			return probeUnknown, "Codex pool is unreadable"
@@ -57,24 +62,28 @@ func probeCodexModel(provider, model, baseURL, globalDir, authRef string) (probe
 		return probeAuthError, fmt.Sprintf("no eligible Codex account for model %s", model)
 	}
 
-	var lastStatus probeStatus = probeAuthError
-	var lastDetail string
+	// Every candidate must pass the same real Responses probe: the runtime may
+	// weighted-select any of them, so the first non-OK candidate (or a missing
+	// token, which costs no request) fails the whole preflight immediately and
+	// keeps its existing status/detail taxonomy. The detail stays count-free
+	// and never carries tokens, paths, or pool refs.
+	fail := func(status probeStatus, detail string) (probeStatus, string) {
+		if isPool {
+			return status, fmt.Sprintf("no eligible Codex pool account served model %s: %s", model, detail)
+		}
+		return status, detail
+	}
 	for _, path := range paths {
 		tokens, ok := readCodexTokenFile(path)
 		if !ok || strings.TrimSpace(tokens.AccessToken) == "" {
-			lastStatus, lastDetail = probeAuthError, "Codex OAuth credential is missing or unusable"
-			continue
+			return fail(probeAuthError, "Codex OAuth credential is missing or unusable")
 		}
 		status, detail := probeCodexResponses(path, tokens.AccessToken, model, baseURL)
-		if status == probeOK {
-			return status, ""
+		if status != probeOK {
+			return fail(status, detail)
 		}
-		lastStatus, lastDetail = status, detail
 	}
-	if provider == "codex-pool" || provider == "codex_pool" {
-		return lastStatus, fmt.Sprintf("no eligible Codex pool account served model %s: %s", model, lastDetail)
-	}
-	return lastStatus, lastDetail
+	return probeOK, ""
 }
 
 func probeCodexResponses(authPath, accessToken, model, baseURL string) (probeStatus, string) {

--- a/tui/internal/tui/codex_pool_store.go
+++ b/tui/internal/tui/codex_pool_store.go
@@ -1,10 +1,14 @@
 package tui
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"math"
+	"math/big"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -78,6 +82,83 @@ type codexPoolAccount struct {
 	Path    string `json:"path"`
 	Weight  int    `json:"weight"`
 	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+// errCodexPoolInvalidWeight marks an entry whose present `weight` value is not
+// an exact integer the kernel reader would accept; decodeCodexPoolAccounts
+// drops such entries (fail-closed) instead of laundering them into a weight.
+var errCodexPoolInvalidWeight = errors.New("codex pool account weight is not a usable integer")
+
+// UnmarshalJSON decodes one pool account with the same practical weight
+// semantics as the kernel reader: an omitted `weight` key defaults to 1, and a
+// finite positive integral number spelling (`1.0`, `2e0`) decodes to its exact
+// int value. Explicit integer 0/negative values are retained so their
+// disabled/unrepresentable semantics survive. A present null, bool, string,
+// fractional, zero/negative float-form, or out-of-int-range value fails the
+// entry so it is dropped, never silently rewritten. Saving still marshals the
+// plain struct, so weights canonicalize to JSON integers on write.
+func (a *codexPoolAccount) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Path    string          `json:"path"`
+		Weight  json.RawMessage `json:"weight"`
+		Enabled *bool           `json:"enabled"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	weight, ok := codexPoolWeightFromRaw(raw.Weight)
+	if !ok {
+		return errCodexPoolInvalidWeight
+	}
+	*a = codexPoolAccount{Path: raw.Path, Weight: weight, Enabled: raw.Enabled}
+	return nil
+}
+
+// codexPoolWeightFromRaw converts a raw JSON `weight` value into the exact
+// integer weight. A nil/empty raw value means the key was absent (kernel
+// default: 1). A present value must be a JSON number: pure integer literals
+// keep their exact value (including 0/negative), while decimal/exponent
+// spellings are accepted only when finite, positive, and exactly integral.
+// Acceptance never rounds through float64.
+func codexPoolWeightFromRaw(raw json.RawMessage) (int, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return 1, true
+	}
+	// Only a JSON number token may carry a weight; null/bool/string/object/
+	// array forms fail closed.
+	if c := trimmed[0]; c != '-' && (c < '0' || c > '9') {
+		return 0, false
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	dec.UseNumber()
+	var num json.Number
+	if err := dec.Decode(&num); err != nil {
+		return 0, false
+	}
+	s := num.String()
+	if !strings.ContainsAny(s, ".eE") {
+		n, err := strconv.ParseInt(s, 10, strconv.IntSize)
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	}
+	// Decimal/exponent spelling. Reject non-finite magnitudes first so a huge
+	// exponent cannot force an enormous exact expansion below; this gate only
+	// rejects, it never accepts.
+	if f, err := strconv.ParseFloat(s, 64); err != nil || math.IsInf(f, 0) || math.IsNaN(f) {
+		return 0, false
+	}
+	r, ok := new(big.Rat).SetString(s)
+	if !ok || !r.IsInt() || r.Sign() <= 0 {
+		return 0, false
+	}
+	n := r.Num()
+	if !n.IsInt64() || n.Int64() > math.MaxInt {
+		return 0, false
+	}
+	return int(n.Int64()), true
 }
 
 // codexPool is the on-disk pool file shape. Models (v2) classifies accounts by

--- a/tui/internal/tui/codex_pool_store_test.go
+++ b/tui/internal/tui/codex_pool_store_test.go
@@ -682,6 +682,182 @@ func TestCodexPoolEligibilityFacts_FallbackAndFailClosed(t *testing.T) {
 	}
 }
 
+// TestCodexPoolWeightDecodeKernelParity pins per-entry weight decoding to the
+// kernel reader's practical contract (codex_pool.py's weight coercion): an
+// omitted weight defaults to 1, exact positive integral number spellings are
+// accepted as ints, explicit integer 0/negative values stay retained but
+// unrepresentable, and every other form fails closed by dropping the entry —
+// never rounding, wrapping, or coercing it into a usable weight.
+func TestCodexPoolWeightDecodeKernelParity(t *testing.T) {
+	cases := []struct {
+		name              string
+		weightJSON        string // raw JSON after `"weight":`; "" = key omitted
+		wantWeight        int
+		wantKept          bool
+		wantRepresentable bool
+	}{
+		{"omitted-defaults-to-1", "", 1, true, true},
+		{"null-dropped", "null", 0, false, false},
+		{"positive-int", "2", 2, true, true},
+		{"zero-int-disabled", "0", 0, true, false},
+		{"negative-int-retained", "-3", -3, true, false},
+		{"integral-float", "1.0", 1, true, true},
+		{"integral-exponent", "2e0", 2, true, true},
+		{"larger-integral-exponent", "3e2", 300, true, true},
+		{"fractional", "1.5", 0, false, false},
+		{"negative-fraction", "-0.5", 0, false, false},
+		{"zero-float-form", "0.0", 0, false, false},
+		{"negative-float-form", "-2.0", 0, false, false},
+		{"bool", "true", 0, false, false},
+		{"numeric-string", `"2"`, 0, false, false},
+		{"int64-overflow", "9223372036854775808", 0, false, false},
+		{"huge-exponent-overflow", "1e309", 0, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LINGTAI_TUI_DIR", "")
+			dir := t.TempDir()
+			entry := `{"path":"codex-auth/a.json"`
+			if tc.weightJSON != "" {
+				entry += `,"weight":` + tc.weightJSON
+			}
+			entry += `}`
+			raw := `{"version":1,"accounts":[` + entry + `]}`
+			if err := os.WriteFile(codexPoolPath(dir), []byte(raw), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			pool, err := loadCodexPool(dir)
+			if err != nil {
+				t.Fatalf("loadCodexPool: %v", err)
+			}
+			if tc.wantKept {
+				if pool.DroppedEntries != 0 || len(pool.Accounts) != 1 {
+					t.Fatalf("kept form dropped: accounts=%d dropped=%d", len(pool.Accounts), pool.DroppedEntries)
+				}
+				if pool.Accounts[0].Weight != tc.wantWeight {
+					t.Fatalf("weight = %d, want %d", pool.Accounts[0].Weight, tc.wantWeight)
+				}
+			} else {
+				if pool.DroppedEntries != 1 || len(pool.Accounts) != 0 {
+					t.Fatalf("invalid form not dropped: accounts=%#v dropped=%d", pool.Accounts, pool.DroppedEntries)
+				}
+			}
+			gotRepresentable := len(codexPoolAccountsRepresentable(pool.Accounts)) == 1
+			if gotRepresentable != tc.wantRepresentable {
+				t.Fatalf("representable = %v, want %v", gotRepresentable, tc.wantRepresentable)
+			}
+		})
+	}
+}
+
+// TestCodexPoolWeightNonFiniteSyntaxFailsClosed proves the JSON-invalid
+// non-finite spellings never become a weight: the whole file fails to parse,
+// which the callers already surface as corruption (fail-closed).
+func TestCodexPoolWeightNonFiniteSyntaxFailsClosed(t *testing.T) {
+	for _, form := range []string{"NaN", "Infinity", "-Infinity"} {
+		t.Run(form, func(t *testing.T) {
+			t.Setenv("LINGTAI_TUI_DIR", "")
+			dir := t.TempDir()
+			raw := `{"version":1,"accounts":[{"path":"codex-auth/a.json","weight":` + form + `}]}`
+			if err := os.WriteFile(codexPoolPath(dir), []byte(raw), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadCodexPool(dir); err == nil {
+				t.Fatalf("non-finite weight %s must fail the load, not decode", form)
+			}
+		})
+	}
+}
+
+// TestCodexPoolWeightDecodeModelClassifiedCategories proves the same decoder
+// runs inside every exact-model category: omitted and `1.0` weights are
+// accepted in the selected category while the other category stays untouched.
+func TestCodexPoolWeightDecodeModelClassifiedCategories(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	raw := `{"version":2,"models":{"gpt-test":[{"path":"codex-auth/a.json"},{"path":"codex-auth/b.json","weight":1.0}],"gpt-other":[{"path":"codex-auth/c.json","weight":3}]}}`
+	if err := os.WriteFile(codexPoolPath(dir), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := loadCodexPool(dir)
+	if err != nil {
+		t.Fatalf("loadCodexPool: %v", err)
+	}
+	if pool.Models == nil || pool.DroppedEntries != 0 {
+		t.Fatalf("classified pool mis-decoded: models=%v dropped=%d", pool.Models, pool.DroppedEntries)
+	}
+	selected := (*pool.Models)["gpt-test"]
+	if len(selected) != 2 || selected[0].Weight != 1 || selected[1].Weight != 1 {
+		t.Fatalf("gpt-test category = %#v, want omitted→1 and 1.0→1", selected)
+	}
+	other := (*pool.Models)["gpt-other"]
+	if len(other) != 1 || other[0].Path != "codex-auth/c.json" || other[0].Weight != 3 {
+		t.Fatalf("gpt-other category mangled: %#v", other)
+	}
+}
+
+// TestLoadSaveCodexPool_CanonicalizesWeightSpellings proves load→save→reload
+// rewrites omitted/float weight spellings as explicit JSON integers while an
+// explicit zero stays zero — semantic parity, not byte preservation.
+func TestLoadSaveCodexPool_CanonicalizesWeightSpellings(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	raw := `{"version":1,"accounts":[{"path":"codex-auth/a.json","weight":1.0},{"path":"codex-auth/b.json"},{"path":"codex-auth/c.json","weight":0}]}`
+	if err := os.WriteFile(codexPoolPath(dir), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := loadCodexPool(dir)
+	if err != nil {
+		t.Fatalf("loadCodexPool: %v", err)
+	}
+	if err := saveCodexPool(dir, pool); err != nil {
+		t.Fatalf("saveCodexPool: %v", err)
+	}
+	body, err := os.ReadFile(codexPoolPath(dir))
+	if err != nil {
+		t.Fatalf("read saved pool: %v", err)
+	}
+	if strings.Contains(string(body), "1.0") {
+		t.Fatalf("saved pool kept a float weight spelling: %s", body)
+	}
+	reloaded, err := loadCodexPool(dir)
+	if err != nil {
+		t.Fatalf("reload pool: %v", err)
+	}
+	if reloaded.Version != codexPoolVersion || len(reloaded.Accounts) != 3 {
+		t.Fatalf("reloaded pool = %#v", reloaded)
+	}
+	for i, want := range []int{1, 1, 0} {
+		if reloaded.Accounts[i].Weight != want {
+			t.Fatalf("account %d weight = %d, want %d (canonical integer)", i, reloaded.Accounts[i].Weight, want)
+		}
+	}
+}
+
+// TestCodexPoolWeightFractionalEntryBlocksWeightEdits extends the dropped-entry
+// write refusal to the new decoder's fail-closed forms: a fractional weight is
+// dropped on read, so a weight edit must refuse and leave the operator's file
+// byte-identical — invalid forms are never laundered into valid entries.
+func TestCodexPoolWeightFractionalEntryBlocksWeightEdits(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	raw := []byte(`{"version":1,"accounts":[{"path":"codex-auth/typo.json","weight":1.5},{"path":"codex-auth/work.json","weight":1}]}`)
+	if err := os.WriteFile(codexPoolPath(dir), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := setCodexPoolWeight(dir, filepath.Join(dir, codexAuthSubdir, "work.json"), 2)
+	if !errors.Is(err, errCodexPoolDroppedEntries) {
+		t.Fatalf("edit on a pool with a fractional weight = %v, want errCodexPoolDroppedEntries", err)
+	}
+	got, readErr := os.ReadFile(codexPoolPath(dir))
+	if readErr != nil {
+		t.Fatalf("read pool file back: %v", readErr)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("refused edit must leave the pool file byte-identical;\n got: %s\nwant: %s", got, raw)
+	}
+}
+
 func TestCodexPoolEligibility_DroppedEntriesUseLegacyFallback(t *testing.T) {
 	t.Setenv("LINGTAI_TUI_DIR", "")
 	dir := t.TempDir()

--- a/tui/internal/tui/model_validity_test.go
+++ b/tui/internal/tui/model_validity_test.go
@@ -110,6 +110,208 @@ func TestCodexModelValidityRequiresSelectedModel(t *testing.T) {
 	}
 }
 
+// codexPoolProbeServer records the Authorization header of every Responses
+// call and answers with the per-bearer status code (200 with a valid envelope
+// when unlisted), so pool preflight tests can assert exactly which accounts
+// were probed, and in what order, against a purely local fake backend.
+func codexPoolProbeServer(t *testing.T, statusByBearer map[string]int) (*httptest.Server, *[]string) {
+	t.Helper()
+	calls := &[]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		*calls = append(*calls, auth)
+		code, listed := statusByBearer[auth]
+		if !listed {
+			code = http.StatusOK
+		}
+		w.WriteHeader(code)
+		if code == http.StatusOK {
+			_, _ = w.Write([]byte(`{"object":"response","output":[]}`))
+		} else {
+			_, _ = w.Write([]byte(`{"error":"probe fixture failure"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+// seedTwoAccountCodexPool writes a two-account flat pool plus a valid legacy
+// token that must never be probed while the pool is non-empty. The fake token
+// values are secret-shaped so redaction assertions are meaningful.
+func seedTwoAccountCodexPool(t *testing.T, dir string) {
+	t.Helper()
+	writeCodexProbeToken(t, filepath.Join(dir, "codex-auth", "first.json"), "first-access-secret")
+	writeCodexProbeToken(t, filepath.Join(dir, "codex-auth", "second.json"), "second-access-secret")
+	writeCodexProbeToken(t, filepath.Join(dir, "codex-auth.json"), "legacy-access-secret")
+	pool := `{"version":1,"accounts":[{"path":"codex-auth/first.json","weight":1},{"path":"codex-auth/second.json","weight":1}]}`
+	if err := os.WriteFile(codexPoolPath(dir), []byte(pool), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCodexPoolModelValidityChecksEveryAccount is the #706 false-green
+// regression: the runtime weighted-selects among ALL pool accounts, so one
+// passing account must not certify a pool whose later account cannot serve
+// the model. Both accounts must be probed and the result must be the
+// deterministic failure, with no hidden legacy fallback request.
+func TestCodexPoolModelValidityChecksEveryAccount(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	seedTwoAccountCodexPool(t, dir)
+	srv, calls := codexPoolProbeServer(t, map[string]int{
+		"Bearer second-access-secret": http.StatusForbidden,
+	})
+
+	status, detail := probeCodexModel("codex-pool", "gpt-test", srv.URL, dir, "")
+	if status != probeAuthError || !strings.Contains(detail, "no eligible Codex pool account") {
+		t.Fatalf("probe = %v, %q; want deterministic ineligible-pool failure", status, detail)
+	}
+	if len(*calls) != 2 || (*calls)[0] != "Bearer first-access-secret" || (*calls)[1] != "Bearer second-access-secret" {
+		t.Fatalf("calls = %v; want both pool accounts probed in file order and no legacy fallback", *calls)
+	}
+}
+
+// TestCodexPoolModelValidityFailFastSkipsLaterAccounts pins the fail-fast
+// half of the invariant: once the first account fails deterministically the
+// preflight stops — later accounts (which would succeed) are not probed and
+// cannot rescue the pool.
+func TestCodexPoolModelValidityFailFastSkipsLaterAccounts(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	seedTwoAccountCodexPool(t, dir)
+	srv, calls := codexPoolProbeServer(t, map[string]int{
+		"Bearer first-access-secret": http.StatusForbidden,
+	})
+
+	status, detail := probeCodexModel("codex-pool", "gpt-test", srv.URL, dir, "")
+	if status != probeAuthError || !strings.Contains(detail, "no eligible Codex pool account") {
+		t.Fatalf("probe = %v, %q; want deterministic ineligible-pool failure", status, detail)
+	}
+	if len(*calls) != 1 || (*calls)[0] != "Bearer first-access-secret" {
+		t.Fatalf("calls = %v; want exactly the first (failing) account and nothing after it", *calls)
+	}
+}
+
+// TestCodexPoolModelValidityAllAccountsPassIsGreen proves probeOK requires the
+// loop to reach the end: every account is probed exactly once and only then is
+// the pool certified.
+func TestCodexPoolModelValidityAllAccountsPassIsGreen(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	seedTwoAccountCodexPool(t, dir)
+	srv, calls := codexPoolProbeServer(t, nil)
+
+	status, detail := probeCodexModel("codex-pool", "gpt-test", srv.URL, dir, "")
+	if status != probeOK || detail != "" {
+		t.Fatalf("probe = %v, %q; want probeOK for an all-pass pool", status, detail)
+	}
+	if len(*calls) != 2 || (*calls)[0] != "Bearer first-access-secret" || (*calls)[1] != "Bearer second-access-secret" {
+		t.Fatalf("calls = %v; want exactly one probe per pool account, in file order", *calls)
+	}
+}
+
+// TestCodexPoolModelValidityTransientFailureIsNotGreen proves a transient
+// non-OK result on a later account keeps the pool non-green under the
+// existing status taxonomy (429 stays retryable, 5xx stays overloaded).
+func TestCodexPoolModelValidityTransientFailureIsNotGreen(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want probeStatus
+	}{
+		{"rate-limited", http.StatusTooManyRequests, probeRateLimit},
+		{"overloaded", http.StatusInternalServerError, probeOverloaded},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LINGTAI_TUI_DIR", "")
+			dir := t.TempDir()
+			seedTwoAccountCodexPool(t, dir)
+			srv, calls := codexPoolProbeServer(t, map[string]int{
+				"Bearer second-access-secret": tc.code,
+			})
+
+			status, detail := probeCodexModel("codex-pool", "gpt-test", srv.URL, dir, "")
+			if status != tc.want || !strings.Contains(detail, "no eligible Codex pool account") {
+				t.Fatalf("probe = %v, %q; want transient %v and no green", status, detail, tc.want)
+			}
+			if len(*calls) != 2 {
+				t.Fatalf("calls = %v; want the passing account then the transient one", *calls)
+			}
+		})
+	}
+}
+
+// TestCodexPoolModelValidityMissingTokenFailsWithoutRequest pins the local
+// deterministic failure: an unreadable/missing token file fails the preflight
+// immediately, costs no HTTP request for that entry or any later entry, and
+// never falls back to the valid legacy token.
+func TestCodexPoolModelValidityMissingTokenFailsWithoutRequest(t *testing.T) {
+	cases := []struct {
+		name      string
+		pool      string
+		wantCalls []string
+	}{
+		{
+			name:      "first-account-missing",
+			pool:      `{"version":1,"accounts":[{"path":"codex-auth/absent.json","weight":1},{"path":"codex-auth/first.json","weight":1}]}`,
+			wantCalls: nil,
+		},
+		{
+			name:      "later-account-missing",
+			pool:      `{"version":1,"accounts":[{"path":"codex-auth/first.json","weight":1},{"path":"codex-auth/absent.json","weight":1}]}`,
+			wantCalls: []string{"Bearer first-access-secret"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LINGTAI_TUI_DIR", "")
+			dir := t.TempDir()
+			writeCodexProbeToken(t, filepath.Join(dir, "codex-auth", "first.json"), "first-access-secret")
+			writeCodexProbeToken(t, filepath.Join(dir, "codex-auth.json"), "legacy-access-secret")
+			if err := os.WriteFile(codexPoolPath(dir), []byte(tc.pool), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			srv, calls := codexPoolProbeServer(t, nil)
+
+			status, detail := probeCodexModel("codex-pool", "gpt-test", srv.URL, dir, "")
+			if status != probeAuthError || !strings.Contains(detail, "no eligible Codex pool account") {
+				t.Fatalf("probe = %v, %q; want deterministic missing-credential failure", status, detail)
+			}
+			if len(*calls) != len(tc.wantCalls) {
+				t.Fatalf("calls = %v, want %v (no request for the missing entry or anything after it)", *calls, tc.wantCalls)
+			}
+			for i, want := range tc.wantCalls {
+				if (*calls)[i] != want {
+					t.Fatalf("calls = %v, want %v", *calls, tc.wantCalls)
+				}
+			}
+		})
+	}
+}
+
+// TestCodexPoolModelValidityDetailOmitsSecretsAndPaths guards the display
+// boundary: a pool preflight failure detail may name the model but must never
+// carry token material, absolute paths, or pool refs.
+func TestCodexPoolModelValidityDetailOmitsSecretsAndPaths(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	seedTwoAccountCodexPool(t, dir)
+	srv, _ := codexPoolProbeServer(t, map[string]int{
+		"Bearer second-access-secret": http.StatusForbidden,
+	})
+
+	_, detail := probeCodexModel("codex-pool", "gpt-test", srv.URL, dir, "")
+	for _, banned := range []string{
+		"first-access-secret", "second-access-secret", "legacy-access-secret",
+		dir, "codex-auth/first.json", "codex-auth/second.json",
+	} {
+		if strings.Contains(detail, banned) {
+			t.Fatalf("detail leaked %q: %q", banned, detail)
+		}
+	}
+}
+
 // newPresetKeyTestInput builds a textarea pre-filled with val, matching
 // the shape FirstRunModel.presetKeyInput expects in production.
 func newPresetKeyTestInput(val string) textarea.Model {


### PR DESCRIPTION
## Summary

- require every account in the TUI-managed default Codex pool to pass the real model preflight before the UI reports success;
- fail fast on the first missing token or non-successful model response, while preserving the existing status taxonomy and secret-safe detail surface;
- default omitted pool weights to `1`, accept positive integral JSON numeric forms such as `1`, `1.0`, and `2e0` within Go `int` bounds, and fail closed on invalid forms without float rounding or string coercion;
- add regression coverage for mixed-account pools, fail-fast behavior, all-pass success, transient failures, missing tokens, detail redaction, weight categories, canonical round-trips, and edit refusal when raw entries would be lost.

## Why

The TUI preflight previously returned green as soon as any one account in its default Codex pool served the requested model. Runtime pool selection may then choose a different account, so a mixed-eligibility pool could validate successfully and still fail on the first real Agent call.

The TUI also decoded an omitted `weight` as Go's zero value and rejected integral numeric syntax such as `1.0`, while the kernel defaults a missing weight to `1` and accepts positive integral numeric values. This could make the UI and runtime operate on different eligible-account sets for ordinary valid pool files.

## Scope

- TUI only; no kernel change.
- No new dependency.
- Applies to the TUI-managed default Codex pool path. It does not change or claim validation of custom `codex_auth_pool_path` sources or unbound non-pool provider aliases.
- Uses exact Go-number/integer semantics rather than claiming byte-identical Python float behavior for pathological high-precision lexemes.
- No account path, token, response body, or credential is added to user-visible details.
- The all-pass path may make up to one sequential preflight request per eligible account; failures stop at the first blocker.

## Validation

- `gofmt` clean on all four changed files
- `go test ./internal/tui -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

All passed on macOS arm64 with Go 1.26.4.
