### PR TITLE
fix(tui): simplify built-in capabilities and Codex validation

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1975,7 +1975,10 @@ func ValidateCodexAuthOnStartup(globalDir string) string {
 // validateOneCodexAuthFile refreshes a single Codex token file in place,
 // returning a banner string only on a malformed file or a server-side-revoked
 // grant. label identifies the account in the banner without leaking secrets.
-// Token material is written 0600 and never logged.
+// Token material is written 0600 and never logged. The actual expiry check,
+// refresh call, and atomic write-back live in ensureFreshCodexTokens
+// (oauth.go), shared with the save-time Codex eligibility probe
+// (codex_model_probe.go) so both agree on staleness/revocation handling.
 func validateOneCodexAuthFile(authPath, label string) string {
 	raw, err := os.ReadFile(authPath)
 	if err != nil {
@@ -1986,36 +1989,19 @@ func validateOneCodexAuthFile(authPath, label string) string {
 		return fmt.Sprintf("⚠ Codex OAuth (%s): credential malformed — re-login via /setup", label)
 	}
 
-	const refreshBufferSeconds = 300
-	if tokens.ExpiresAt > time.Now().Unix()+refreshBufferSeconds {
-		return ""
+	_, err = ensureFreshCodexTokens(authPath, tokens)
+	if err == ErrCodexAuthRevoked {
+		// Localized banner (#412). The %s slot is a navigation hint
+		// (/setup → <credentials section>), so it carries the section
+		// label, not the account. Per-account coverage (#415) is provided
+		// by validateCodexAuthOnStartup iterating every account file; the
+		// account itself is identified via the malformed banner below.
+		return i18n.TF("codex.oauth_expired_banner", i18n.T("preset.codex_credential_section"))
 	}
-
-	fresh, err := refreshCodexTokens(tokens.RefreshToken, tokens)
-	if err != nil {
-		if err == ErrCodexAuthRevoked {
-			// Localized banner (#412). The %s slot is a navigation hint
-			// (/setup → <credentials section>), so it carries the section
-			// label, not the account. Per-account coverage (#415) is provided
-			// by validateCodexAuthOnStartup iterating every account file; the
-			// account itself is identified via the malformed banner below.
-			return i18n.TF("codex.oauth_expired_banner", i18n.T("preset.codex_credential_section"))
-		}
-		return ""
-	}
-
-	out, err := json.MarshalIndent(fresh, "", "  ")
-	if err != nil {
-		return ""
-	}
-	tmpPath := authPath + ".tmp"
-	if err := os.WriteFile(tmpPath, out, 0o600); err != nil {
-		return ""
-	}
-	if err := os.Rename(tmpPath, authPath); err != nil {
-		os.Remove(tmpPath)
-		return ""
-	}
+	// Both nil (already fresh, or refreshed and persisted) and
+	// ErrCodexAuthTransient (network/5xx/timeout/write failure) are silent
+	// here, matching pre-extraction behavior: do not penalize the user for
+	// being offline, and do not surface anything when nothing is wrong.
 	return ""
 }
 

--- a/tui/internal/tui/codex_model_probe.go
+++ b/tui/internal/tui/codex_model_probe.go
@@ -10,6 +10,37 @@ import (
 	"time"
 )
 
+// freshCodexAccessToken returns an access token guaranteed not to be stale
+// for the eligibility probe. readCodexTokenFile has no expiry check, so a
+// token that was valid at TUI startup but has since expired (the TUI only
+// refreshes once, at launch, in ValidateCodexAuthOnStartup) would otherwise
+// be sent to /responses as-is, draw a 401, and be misreported as an
+// ineligible account/model — a false negative for a perfectly valid Codex
+// credential. The actual expiry check, refresh, and write-back are owned by
+// ensureFreshCodexTokens (oauth.go) — the same helper the startup validator
+// uses — so this function only translates that outcome into a probeStatus:
+//   - refreshed or already-fresh -> probeOK with the token to use.
+//   - ErrCodexAuthRevoked (refresh_token rejected server-side) -> a hard
+//     probeAuthError; a dead grant must still block Save.
+//   - ErrCodexAuthTransient (network/5xx/timeout/write failure) ->
+//     probeOverloaded. A known-stale token must never be sent to /responses
+//     and have its resulting 401 misread as deterministic ineligibility.
+//     probeOverloaded already maps to validityRetryable in
+//     checkCodexModelValidityCmdForSource (model_validity.go), so Save
+//     proceeds with a warning instead of blocking on an operational hiccup
+//     that says nothing about the account or model.
+func freshCodexAccessToken(path string, tokens CodexTokens) (string, probeStatus, string) {
+	fresh, err := ensureFreshCodexTokens(path, tokens)
+	switch err {
+	case nil:
+		return fresh.AccessToken, probeOK, ""
+	case ErrCodexAuthRevoked:
+		return "", probeAuthError, "Codex OAuth credential was revoked — re-authenticate"
+	default: // ErrCodexAuthTransient
+		return "", probeOverloaded, "Codex OAuth token refresh did not complete — try again"
+	}
+}
+
 // probeCodexModel is the eligibility probe for the ChatGPT-backed Codex
 // providers. It intentionally does not use the models catalogue: that only
 // proves token reachability, not that this model/account can serve a real
@@ -65,7 +96,12 @@ func probeCodexModel(provider, model, baseURL, globalDir, authRef string) (probe
 			lastStatus, lastDetail = probeAuthError, "Codex OAuth credential is missing or unusable"
 			continue
 		}
-		status, detail := probeCodexResponses(path, tokens.AccessToken, model, baseURL)
+		accessToken, status, detail := freshCodexAccessToken(path, tokens)
+		if status != probeOK {
+			lastStatus, lastDetail = status, detail
+			continue
+		}
+		status, detail = probeCodexResponses(path, accessToken, model, baseURL)
 		if status == probeOK {
 			return status, ""
 		}

--- a/tui/internal/tui/model_validity_test.go
+++ b/tui/internal/tui/model_validity_test.go
@@ -18,12 +18,36 @@ import (
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
 
+// writeCodexProbeToken writes a token bundle that is not due for refresh
+// (expires_at far in the future), matching what a real, currently-valid
+// Codex credential looks like on disk — every real writer (OAuth exchange,
+// refreshCodexTokens) always sets expires_at, so a token file with none is
+// not a state ensureFreshCodexTokens needs to special-case.
 func writeCodexProbeToken(t *testing.T, path, access string) {
+	t.Helper()
+	writeCodexProbeTokenWithExpiry(t, path, access, "refresh", 4102444800) // 2100-01-01
+}
+
+// setCodexTokenURLForTest points codexTokenURL (oauth.go) at a test server
+// for the duration of the test and returns a restore func. Keeps
+// refreshCodexTokens testable without ever contacting auth.openai.com.
+func setCodexTokenURLForTest(url string) (restore func()) {
+	prev := codexTokenURL
+	codexTokenURL = url
+	return func() { codexTokenURL = prev }
+}
+
+// writeCodexProbeTokenWithExpiry writes a token bundle with an explicit
+// expires_at (unix seconds), simulating an on-disk token that is expired or
+// about to expire — the state a valid Codex account is in when the TUI has
+// been open past the kernel's normal startup refresh.
+func writeCodexProbeTokenWithExpiry(t *testing.T, path, access, refresh string, expiresAt int64) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(fmt.Sprintf(`{"access_token":%q,"refresh_token":"refresh"}`, access)), 0o600); err != nil {
+	body := fmt.Sprintf(`{"access_token":%q,"refresh_token":%q,"expires_at":%d}`, access, refresh, expiresAt)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -52,6 +76,146 @@ func TestCodexModelValidityUsesResponsesAndSelectedAccount(t *testing.T) {
 	}
 	if gotAuth != "Bearer selected-access" || gotModel != "gpt-test" {
 		t.Fatalf("request auth/model = %q/%q", gotAuth, gotModel)
+	}
+}
+
+// TestCodexModelValidityRefreshesExpiredAccessTokenBeforeProbing exercises
+// the proven false-negative code path (not a claim about what the specific
+// reported screenshot's token state actually was): a working ChatGPT-backed
+// Codex account whose on-disk access_token has expired. Before this fix,
+// readCodexTokenFile had no expiry check — unlike the kernel's
+// CodexTokenManager.get_access_token, which refreshes before every use — so
+// probeCodexModel sent the stale token straight to /responses, got a 401,
+// and reported the account/model as ineligible even though the
+// refresh_token is valid and a refreshed access_token is accepted.
+func TestCodexModelValidityRefreshesExpiredAccessTokenBeforeProbing(t *testing.T) {
+	const freshAccess = "fresh-access-token"
+	var tokenCalls, responsesCalls int32
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenCalls, 1)
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse refresh form: %v", err)
+		}
+		if got := r.FormValue("refresh_token"); got != "stale-refresh" {
+			t.Fatalf("refresh_token = %q, want stale-refresh", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"access_token":%q,"refresh_token":"stale-refresh","expires_in":3600}`, freshAccess)
+	}))
+	defer tokenSrv.Close()
+	restoreTokenURL := setCodexTokenURLForTest(tokenSrv.URL)
+	defer restoreTokenURL()
+
+	responsesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&responsesCalls, 1)
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+freshAccess {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid token"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"response","output":[]}`))
+	}))
+	defer responsesSrv.Close()
+
+	globalDir := t.TempDir()
+	path := filepath.Join(globalDir, "codex-auth.json")
+	writeCodexProbeTokenWithExpiry(t, path, "stale-access", "stale-refresh", 1) // already expired
+
+	status, detail := probeCodexModel("codex", "gpt-5.6-sol", responsesSrv.URL, globalDir, "")
+	if status != probeOK || detail != "" {
+		t.Fatalf("probe = %v, %q; want OK after refreshing the expired token", status, detail)
+	}
+	if atomic.LoadInt32(&tokenCalls) != 1 {
+		t.Fatalf("token refresh calls = %d, want 1", tokenCalls)
+	}
+	if atomic.LoadInt32(&responsesCalls) != 1 {
+		t.Fatalf("responses calls = %d, want 1", responsesCalls)
+	}
+
+	refreshed, ok := readCodexTokenFile(path)
+	if !ok || refreshed.AccessToken != freshAccess {
+		t.Fatalf("on-disk token not updated with refreshed access_token: %+v (ok=%v)", refreshed, ok)
+	}
+}
+
+// TestCodexModelValidityRevokedRefreshStaysAuthError proves a genuinely
+// revoked account (refresh rejected with 401/403) still fails closed as a
+// deterministic auth error, not silently passed.
+func TestCodexModelValidityRevokedRefreshStaysAuthError(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer tokenSrv.Close()
+	restoreTokenURL := setCodexTokenURLForTest(tokenSrv.URL)
+	defer restoreTokenURL()
+
+	responsesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("must not reach the Responses endpoint with a token known to be unrefreshable")
+	}))
+	defer responsesSrv.Close()
+
+	globalDir := t.TempDir()
+	path := filepath.Join(globalDir, "codex-auth.json")
+	writeCodexProbeTokenWithExpiry(t, path, "stale-access", "revoked-refresh", 1)
+
+	status, detail := probeCodexModel("codex", "gpt-5.6-sol", responsesSrv.URL, globalDir, "")
+	if status != probeAuthError {
+		t.Fatalf("probe = %v, %q; want probeAuthError for a revoked refresh grant", status, detail)
+	}
+}
+
+// TestCodexModelValidityTransientRefreshFailureIsRetryableNotAuthError
+// proves the other half of the false-negative fix: when a token is due for
+// refresh but the refresh itself fails for a reason unrelated to the grant
+// (network error here), the probe must NOT fall back to sending the
+// known-stale access token to /responses and let its 401 be misread as
+// deterministic ineligibility. It must report an operational, retryable
+// outcome (probeOverloaded, which checkCodexModelValidityCmdForSource maps
+// to validityRetryable) so Save can proceed with a warning instead of
+// blocking on a problem that says nothing about the account or model.
+func TestCodexModelValidityTransientRefreshFailureIsRetryableNotAuthError(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a network-adjacent failure: close the connection without
+		// a response, which surfaces to refreshCodexTokens as a non-nil,
+		// non-HTTP-status error (client.PostForm returns an error), the same
+		// class of failure as a DNS/timeout/connection-reset.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("test server does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		conn.Close()
+	}))
+	defer tokenSrv.Close()
+	restoreTokenURL := setCodexTokenURLForTest(tokenSrv.URL)
+	defer restoreTokenURL()
+
+	responsesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("must not reach the Responses endpoint with a token known to be stale after a failed refresh")
+	}))
+	defer responsesSrv.Close()
+
+	globalDir := t.TempDir()
+	path := filepath.Join(globalDir, "codex-auth.json")
+	writeCodexProbeTokenWithExpiry(t, path, "stale-access", "still-good-refresh", 1)
+
+	status, detail := probeCodexModel("codex", "gpt-5.6-sol", responsesSrv.URL, globalDir, "")
+	if status != probeOverloaded {
+		t.Fatalf("probe = %v, %q; want probeOverloaded (retryable) for a transient refresh failure, not a hard auth error", status, detail)
+	}
+
+	// The on-disk token must be untouched: a transient failure must not
+	// overwrite a possibly-still-valid refresh_token with anything.
+	unchanged, ok := readCodexTokenFile(path)
+	if !ok || unchanged.AccessToken != "stale-access" {
+		t.Fatalf("on-disk token was modified by a failed refresh: %+v (ok=%v)", unchanged, ok)
 	}
 }
 

--- a/tui/internal/tui/oauth.go
+++ b/tui/internal/tui/oauth.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,14 @@ import (
 // 5xx, timeout) which leave the local tokens untouched.
 var ErrCodexAuthRevoked = errors.New("codex refresh token rejected — re-authenticate")
 
+// ErrCodexAuthTransient is returned by ensureFreshCodexTokens when a
+// refresh was needed but could not be completed for a reason unrelated to
+// the grant itself (network error, timeout, 5xx from auth.openai.com, or a
+// failure persisting the refreshed bundle back to disk). The stored
+// refresh_token is presumed still good — callers must not treat this the
+// same as ErrCodexAuthRevoked.
+var ErrCodexAuthTransient = errors.New("codex token refresh did not complete — try again")
+
 // ErrCodexAuthCancelled is delivered in CodexOAuthDoneMsg.Err when the
 // caller cancels the OAuth flow via the supplied context (user pressed
 // Del/Backspace on the Codex 凭据 row, or navigated away). Handlers use
@@ -33,10 +42,10 @@ var ErrCodexAuthRevoked = errors.New("codex refresh token rejected — re-authen
 var ErrCodexAuthCancelled = errors.New("codex oauth cancelled")
 
 const (
-	codexClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
-	codexAuthIssuerURL = "https://auth.openai.com"
-	codexAuthURL       = codexAuthIssuerURL + "/oauth/authorize"
-	codexTokenURL      = codexAuthIssuerURL + "/oauth/token"
+	codexClientID        = "app_EMoamEEZ73f0CkXaXp7hrann"
+	codexAuthIssuerURL   = "https://auth.openai.com"
+	codexAuthURL         = codexAuthIssuerURL + "/oauth/authorize"
+	codexTokenURLDefault = codexAuthIssuerURL + "/oauth/token"
 	// codexScope must include the connector scopes — without them the
 	// authorize page rejects the request immediately. Matches the official
 	// Codex CLI scope string.
@@ -58,6 +67,13 @@ const (
 	oauthTimeout      = 5 * time.Minute
 	deviceAuthTimeout = 15 * time.Minute
 )
+
+// codexTokenURL is the live OAuth token endpoint. It is a var (not the
+// codexTokenURLDefault const directly) solely so tests can redirect
+// refreshCodexTokens at a local httptest server (see
+// setCodexTokenURLForTest in model_validity_test.go); production code never
+// reassigns it.
+var codexTokenURL = codexTokenURLDefault
 
 // CodexTokens holds the token bundle written to disk.
 type CodexTokens struct {
@@ -703,4 +719,73 @@ func refreshCodexTokens(refreshToken string, existing CodexTokens) (*CodexTokens
 		merged.Email = email
 	}
 	return &merged, nil
+}
+
+// codexRefreshBufferSeconds is the shared staleness window: a token within
+// this many seconds of expiry is refreshed rather than used as-is. Used by
+// every caller of ensureFreshCodexTokens (TUI startup validation and the
+// save-time Codex eligibility probe) so they agree on what "fresh" means.
+const codexRefreshBufferSeconds = 300
+
+// ensureFreshCodexTokens is the single owning-layer helper for "make sure
+// this on-disk Codex token bundle is not stale, refreshing and persisting
+// it if needed." It is the one place that checks expires_at, calls
+// refreshCodexTokens, and does the atomic (.tmp + rename) write-back —
+// callers must not reimplement any part of this. Behavior is exactly
+// validateOneCodexAuthFile's pre-extraction refresh logic (same buffer,
+// same expiry comparison, same write-back), generalized to a second caller.
+//
+// tokens is the already-parsed bundle for path (callers already read the
+// file to get here). Returns:
+//   - (tokens, nil) unchanged when the access token is not within
+//     codexRefreshBufferSeconds of ExpiresAt (this also covers ExpiresAt ==
+//     0 as "due for refresh", same as before this helper existed — every
+//     real token file from the OAuth/refresh flow sets a positive
+//     expires_at, so this only matters for a hand-built/malformed file).
+//   - (refreshed tokens, nil) after a successful refresh; the file at path
+//     has already been updated atomically (0600, tmp+rename) so every other
+//     reader in this process sees the fresh bundle immediately.
+//   - (tokens, ErrCodexAuthRevoked) when auth.openai.com rejected the
+//     refresh_token (401/403) — the grant is dead; the caller must hard-fail
+//     and point the user at re-login. The file is left untouched.
+//   - (tokens, ErrCodexAuthTransient) on any other refresh failure (network,
+//     timeout, 5xx, or a failure writing the refreshed bundle back to disk)
+//     — the refresh_token is presumed still good; the caller must not treat
+//     this as a deterministic failure of the account/model/credential.
+//
+// In every non-nil-error case the returned tokens are the caller's original
+// (possibly stale) input — callers that can tolerate a stale token (none do
+// today; see ErrCodexAuthTransient's doc) may still use AccessToken from it,
+// but the intended handling is to surface the error, not the token.
+func ensureFreshCodexTokens(path string, tokens CodexTokens) (CodexTokens, error) {
+	if tokens.ExpiresAt > time.Now().Unix()+codexRefreshBufferSeconds {
+		return tokens, nil
+	}
+	if strings.TrimSpace(tokens.RefreshToken) == "" {
+		return tokens, nil
+	}
+	fresh, err := refreshCodexTokens(tokens.RefreshToken, tokens)
+	if err != nil {
+		if err == ErrCodexAuthRevoked {
+			return tokens, ErrCodexAuthRevoked
+		}
+		return tokens, ErrCodexAuthTransient
+	}
+	out, err := json.MarshalIndent(fresh, "", "  ")
+	if err != nil {
+		return tokens, ErrCodexAuthTransient
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, out, 0o600); err != nil {
+		return tokens, ErrCodexAuthTransient
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		// Matches the pre-extraction startup behavior (validateOneCodexAuthFile):
+		// a failed rename means tmpPath is orphaned, so it is removed rather
+		// than left behind. This is the same net filesystem effect as before
+		// this helper was shared — not a new deletion path.
+		os.Remove(tmpPath)
+		return tokens, ErrCodexAuthTransient
+	}
+	return *fresh, nil
 }

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -75,12 +75,13 @@ var capFieldNames = map[editorField]string{
 }
 
 // editorFieldOrder is the rendering order of fields. The cursor walks
-// this slice; section headers render between transitions. Only truly
-// optional/provider-conditional capabilities appear as editable rows.
+// this slice; section headers render between transitions. web_search
+// and vision are default/always-included tools (not user-selectable
+// capabilities) and are rendered read-only in the mandatory section
+// below, so they do not appear here.
 var editorFieldOrder = []editorField{
 	feName, feSummary, feTier, feGains, feLoses,
 	feProvider, feModel, feServiceTier, feThinking, feAPICompat, feWireAPI, feBaseURL, feAPIKey,
-	feCapWebSearch, feCapVision,
 	feSave,
 }
 
@@ -1656,23 +1657,20 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 	rows = append(rows, row(feAPIKey, m.row(feAPIKey, lbl("api_key"), m.fieldString(feAPIKey), width-4)))
 	rows = append(rows, plain(""))
 	// Always-included capabilities — kernel intrinsics plus the core
-	// floor injected by apply_core_defaults at runtime. The editor lists
-	// them for awareness; users cannot toggle them off via the preset
-	// manifest (the kernel's explicit-disable channel is the only way).
+	// floor injected by apply_core_defaults at runtime, plus web_search
+	// and vision, which are default/always-included tools rather than
+	// user-selectable capabilities. The editor lists them for awareness;
+	// users cannot toggle them off via the preset manifest (the kernel's
+	// explicit-disable channel is the only way).
 	rows = append(rows, plain(m.sectionHeader(i18n.T("preset_editor.section_mandatory"))))
 	alwaysIncludedRows := []string{
 		"email", "psyche", "soul", "system",
 		"knowledge", "skills", "shell",
 		"avatar", "daemon", "mcp", "file",
+		"web_search", "vision",
 	}
 	for _, capName := range alwaysIncludedRows {
 		rows = append(rows, plain(m.mandatoryCapRow(capName, width-4)))
-	}
-	rows = append(rows, plain(""))
-	rows = append(rows, plain(m.sectionHeader(i18n.T("preset_editor.section_capabilities"))))
-	for _, capName := range optionalCapabilities {
-		f := capFieldFor(capName)
-		rows = append(rows, row(f, m.capRow(f, capName, width-4)))
 	}
 	rows = append(rows, plain(""))
 	rows = append(rows, row(feSave, m.renderSaveButton()))

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -891,10 +891,147 @@ func TestPresetEditorViewShowsCoreAsInformational(t *testing.T) {
 			t.Fatalf("view missing always-included capability %q; view:\n%s", capName, view)
 		}
 	}
+	// web_search and vision are default/always-included tools, not
+	// user-selectable capabilities: they render in the same informational
+	// (non-interactive) section as the kernel core floor above.
 	for _, capName := range []string{"web_search", "vision"} {
 		if !strings.Contains(view, capName) {
-			t.Fatalf("view missing optional capability %q; view:\n%s", capName, view)
+			t.Fatalf("view missing always-included tool name %q; view:\n%s", capName, view)
 		}
+	}
+}
+
+// TestPresetEditorWebSearchAndVisionAreNotFocusableFields is the regression
+// test for the fixed-capability-providers change: web_search and vision
+// must not appear as cursor-navigable/editable rows. They're rendered
+// read-only via mandatoryCapRow alongside the other always-included tools.
+func TestPresetEditorWebSearchAndVisionAreNotFocusableFields(t *testing.T) {
+	for _, f := range []editorField{feCapWebSearch, feCapVision} {
+		for _, got := range editorFieldOrder {
+			if got == f {
+				t.Fatalf("capability field %v must not be in editorFieldOrder %#v", f, editorFieldOrder)
+			}
+		}
+	}
+}
+
+// TestPresetEditorWebSearchAndVisionViewHasNoCheckboxOrProviderNames
+// asserts the web_search/vision rows in the live editor view render
+// exactly like the other always-included tools (plain "[✓] name  desc"
+// via mandatoryCapRow) with no radio strip of provider options — those
+// are the fixed/default tool routes, not user choices. Scoped to just
+// those two row lines, since provider names like "minimax"/"gemini"
+// legitimately appear elsewhere in the view (the LLM provider/model
+// rows and their radio strips).
+func TestPresetEditorWebSearchAndVisionViewHasNoCheckboxOrProviderNames(t *testing.T) {
+	p := testPresetEditorPreset()
+	caps := p.Manifest["capabilities"].(map[string]interface{})
+	caps["web_search"] = map[string]interface{}{"provider": "zhipu"}
+	caps["vision"] = map[string]interface{}{"provider": "gemini"}
+
+	m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+	view := m.View()
+
+	for _, capName := range []string{"web_search", "vision"} {
+		line := findLineContaining(t, view, capName)
+		if !strings.Contains(line, "[✓]") {
+			t.Fatalf("%s row must render the informational [✓] marker; got: %q", capName, line)
+		}
+		if strings.Contains(line, "[ ]") {
+			t.Fatalf("%s row must not render an unchecked/toggleable checkbox; got: %q", capName, line)
+		}
+		if strings.Contains(line, "●") || strings.Contains(line, "○") {
+			t.Fatalf("%s row must not render a provider radio strip; got: %q", capName, line)
+		}
+		for _, providerName := range []string{"duckduckgo", "zhipu", "gemini", "inherit"} {
+			if strings.Contains(line, providerName) {
+				t.Fatalf("%s row must not display provider name %q; got: %q", capName, providerName, line)
+			}
+		}
+	}
+}
+
+func findLineContaining(t *testing.T, view, substr string) string {
+	t.Helper()
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	t.Fatalf("view has no line containing %q", substr)
+	return ""
+}
+
+// TestPresetEditorCursorCannotLandOnWebSearchOrVision walks the entire
+// cursor range via Down and confirms it never lands on the removed
+// feCapWebSearch/feCapVision positions — keyboard navigation cannot
+// focus these rows.
+func TestPresetEditorCursorCannotLandOnWebSearchOrVision(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+
+	for i := 0; i < len(editorFieldOrder)+5; i++ {
+		f := editorFieldOrder[m.cursor]
+		if f == feCapWebSearch || f == feCapVision {
+			t.Fatalf("cursor landed on removed capability field %v at step %d", f, i)
+		}
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+}
+
+// TestPresetEditorCommitPreservesExistingCapabilityValuesByteForValue
+// ensures saving an existing preset with old init.json-style capability
+// values (including a non-default web_search provider) round-trips them
+// unchanged. The editor's field-list change must not normalize, rewrite,
+// or migrate values it no longer exposes as editable UI.
+func TestPresetEditorCommitPreservesExistingCapabilityValuesByteForValue(t *testing.T) {
+	p := testPresetEditorPreset()
+	caps := p.Manifest["capabilities"].(map[string]interface{})
+	caps["web_search"] = map[string]interface{}{"provider": "zhipu"}
+	caps["vision"] = map[string]interface{}{"provider": "gemini", "api_key_env": "GEMINI_API_KEY"}
+
+	m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+	m = withValidModelValidity(m)
+
+	_, cmd := m.commit()
+	msg := cmd()
+	commit, ok := msg.(PresetEditorCommitMsg)
+	if !ok {
+		t.Fatalf("commit cmd returned %T, want PresetEditorCommitMsg", msg)
+	}
+	gotCaps, ok := commit.Preset.Manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("committed capabilities missing/wrong type: %T", commit.Preset.Manifest["capabilities"])
+	}
+	if !reflect.DeepEqual(gotCaps["web_search"], caps["web_search"]) {
+		t.Fatalf("web_search capability changed on save: got %#v, want %#v", gotCaps["web_search"], caps["web_search"])
+	}
+	if !reflect.DeepEqual(gotCaps["vision"], caps["vision"]) {
+		t.Fatalf("vision capability changed on save: got %#v, want %#v", gotCaps["vision"], caps["vision"])
+	}
+}
+
+// TestPresetEditorSaveNotBlockedByCapabilityState confirms the save gate
+// (modelValidity) is unaffected by web_search/vision capability presence
+// or absence — capability state must never block Save/Next. The only
+// save gate is the independent base-LLM model availability check.
+func TestPresetEditorSaveNotBlockedByCapabilityState(t *testing.T) {
+	p := testPresetEditorPreset()
+	caps := p.Manifest["capabilities"].(map[string]interface{})
+	delete(caps, "web_search")
+	delete(caps, "vision")
+
+	m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+	m = withValidModelValidity(m)
+
+	_, cmd := m.commit()
+	if cmd == nil {
+		t.Fatalf("commit returned nil cmd with no capabilities present and a valid model")
+	}
+	msg := cmd()
+	if _, ok := msg.(PresetEditorCommitMsg); !ok {
+		t.Fatalf("commit cmd returned %T, want PresetEditorCommitMsg (save must not be blocked by missing capabilities)", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- move **Web Search** and **Vision** into the existing **Always Included** list
- remove their enablement/provider controls and provider names from the preset editor
- keep existing capability-map values byte-for-value so old `init.json` files and runtime/kernel behavior remain unchanged
- refresh a stale Codex OAuth token before the save-time model eligibility probe, sharing the same refresh/persistence owner as startup validation
- keep malformed/revoked credentials fail-closed, while treating transient refresh/write failures as operational/retryable instead of falsely declaring the account/model unavailable

## Why

The capability rows exposed implementation details and unnecessary choices for built-in tools. Separately, the save-time Codex probe could read a token that had expired after TUI startup and turn the resulting 401 into `model failed the availability check`, even though the stored refresh grant was still valid.

This fixes the proven false-negative path without claiming every availability failure has that cause and without changing kernel/runtime provider behavior.

## Validation

- `go test -count=1 ./internal/tui` (parent) — PASS
- `go vet ./internal/tui` (parent) — PASS
- `go build ./...` (parent) — PASS
- `go test ./...` (worker) — PASS
- `go vet ./...` (worker) — PASS
- `go build ./...` (worker) — PASS
- `git diff --check` — PASS

Focused regressions cover expired-token refresh/writeback, revoked refresh hard failure, transient refresh retryability without stale-token probing, Always Included rendering, and old capability-map round-trip.

## Scope

TUI only. No kernel/runtime migration, no old-config normalization, no provider fallback change, and no blog/release-page work.
