### PR TITLE
feat(tui): persist direct unread cursors

### DIFF
--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -19,6 +19,9 @@ related_files:
   - tui/internal/fs/mail_test.go
   - tui/internal/fs/direct_mail.go
   - tui/internal/fs/direct_mail_test.go
+  - tui/internal/fs/direct_unread.go
+  - tui/internal/fs/direct_unread_test.go
+  - tui/internal/fs/direct_unread_transactionality_test.go
   - tui/internal/fs/network.go
   - tui/internal/fs/network_test.go
   - tui/internal/fs/session.go
@@ -51,7 +54,7 @@ maintenance: |
 
 ## What this is
 
-The TUI's filesystem window into an agent working directory (`<project>/.lingtai/<agent>/`). Agent state — manifest, heartbeat, mail, token ledger, location, network topology, chat history — is read through this package. The kernel owns agent state; the TUI's narrow writes are signal files, human outbox/location, and its derived human `logs/session.jsonl` replay cache.
+The TUI's filesystem window into an agent working directory (`<project>/.lingtai/<agent>/`). Agent state — manifest, heartbeat, mail, token ledger, location, network topology, chat history — is read through this package. The kernel owns agent state; the TUI's narrow writes are signal files, human outbox/location, its derived human `logs/session.jsonl` replay cache, and the separately owned project-local direct-unread cursor file `<project>/.lingtai/.tui-asset/direct-unread.json`.
 
 ## Components
 
@@ -99,6 +102,10 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 | **direct_mail.go** | | |
 | `DirectTarget` / `DirectThreadKey` / `AddressFingerprint` | `tui/internal/fs/direct_mail.go:9-38` | target carries canonical project + target directories, durable manifest AgentID, and current route; thread identity hashes `(project, agent_id)`, while the address fingerprint is route-only |
 | `NormalizeMailEndpoints` / `IsDirectMail` | `tui/internal/fs/direct_mail.go:40-149` | keeps lenient deduplication for topology, but direct membership requires one valid raw recipient, empty CC, distinct endpoints, exact current addresses, and matching supplied inbound `identity.agent_id` |
+| **direct_unread.go** | | |
+| `DirectUnreadStore` / `OpenDirectUnreadStore` | `tui/internal/fs/direct_unread.go:17-90` | mutex-protected owner of project-local `<project>/.lingtai/.tui-asset/direct-unread.json`; version-1 state keys exact `DirectThreadKey` identity, stores literal `agent_id`, and baselines only caller-supplied accepted mail |
+| `SyncTargets` / `UnreadCount` / `MarkSeen` | `tui/internal/fs/direct_unread.go:94-208` | adds but never prunes stable keys, counts IDs after a parsed-time cursor (including unseen IDs at its instant), and atomically saves copy-on-write monotonic advances before publishing memory |
+| `saveDirectUnreadState` / direct cursor resolver | `tui/internal/fs/direct_unread.go:254-390` | serializes indented version-1 JSON plus newline, self-creates the TUI state parent, uses `writeJSONAtomic`, and accepts only strict incoming direct mail with RFC3339Nano timestamps and exact nonblank stable IDs |
 | **ledger.go** | | |
 | `ReadLedger(dir)` | `tui/internal/fs/ledger.go:17` | reads `delegates/ledger.jsonl` → `[]AvatarEdge` + child dirs |
 | **location.go** | | |
@@ -145,7 +152,7 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 - **Called by `tui/internal/inventory/`** — running-agent inventory enriches process rows with `.agent.json`, heartbeat, status PID, lock, admin, IM identity, and orchestrator-role metadata.
 - **Reads from agent working directories** — `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/*/`, `logs/log.sqlite` (molt/session-boundary and diagnostic indexes, never canonical session replay authority), `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
 - **Writes signal files** (the only agent-owned files the TUI writes): `.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`, `.refresh`/`.refresh.taken`.
-- **Writes human-owned/derived state** — local `WriteMail` writes recipient inbox + sender sent, or `human/mailbox/outbox/<mailbox-id>/` for pseudo-agent sends; remote addresses fail before any mailbox write. Only a complete `MainAggregateWriter` changes `human/logs/session.jsonl` (`tui/internal/fs/session.go:315-382`).
+- **Writes human-owned/derived state** — local `WriteMail` writes recipient inbox + sender sent, or `human/mailbox/outbox/<mailbox-id>/` for pseudo-agent sends; remote addresses fail before any mailbox write. Only a complete `MainAggregateWriter` changes `human/logs/session.jsonl` (`tui/internal/fs/session.go:315-382`). Separately, `DirectUnreadStore` alone reads/writes its TUI-owned `<project>/.lingtai/.tui-asset/direct-unread.json` cursor state (`tui/internal/fs/direct_unread.go:48-90,254-266`); it is not agent, migration, or session state.
 - **Calls `ipinfo.io`** — `ResolveLocation` makes an HTTP call; `UpdateHumanLocation` caches result in human's `.agent.json`.
 
 ## Composition
@@ -156,8 +163,8 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 
 ## State
 
-- **Reads**: `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/inbox/*`, `mailbox/sent/*`, `logs/log.sqlite` (additive index), `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
-- **Writes**: signal files (`.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`), human `mailbox/outbox/*`, human `.agent.json` location field, and the TUI-derived human `logs/session.jsonl` replay cache only from `MainAggregateWriter` persist/append paths.
+- **Reads**: `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/inbox/*`, `mailbox/sent/*`, `logs/log.sqlite` (additive index), `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`, and TUI-owned `<project>/.lingtai/.tui-asset/direct-unread.json`.
+- **Writes**: signal files (`.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`), human `mailbox/outbox/*`, human `.agent.json` location field, the TUI-derived human `logs/session.jsonl` replay cache only from `MainAggregateWriter` persist/append paths, and `DirectUnreadStore`'s separate TUI-owned `<project>/.lingtai/.tui-asset/direct-unread.json`.
 
 ## Notes
 
@@ -166,6 +173,7 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 - **`Delivered` is transient.** `MailMessage.Delivered` is `json:"-"` — set by `MailCache.Refresh()` based on which folder the message was found in. Outbox → false; inbox/sent → true.
 - **`MailCache` refresh and snapshot boundaries differ.** `Refresh()` returns a new cache without mutating the receiver, while `Clone()` is the explicit deep-copy boundary for accepted publication: nested recipient, attachment, and identity graphs cannot alias the live producer, and nil shapes are preserved.
 - **Direct mail identity boundary.** `DirectTarget` separates stable identity (canonical project directory + manifest `agent_id`) from current routing (target directory + address); `DirectThreadKey` hashes only the stable pair, and `AddressFingerprint` is route-only. `NormalizeMailEndpoints` remains deliberately lenient for topology edges. `IsDirectMail` instead validates one raw recipient, rejects any CC, malformed/multi-entry envelope, empty/equal endpoints, or cross-address record, and on incoming mail requires any supplied nonblank `identity.agent_id` to match literally while allowing exact-address fallback for legacy mail without that field.
+- **Durable direct unread boundary.** `DirectUnreadStore` is the sole owner of the self-created TUI state file `<project>/.lingtai/.tui-asset/direct-unread.json`, schema version 1; it never reads or migrates historical rail state. Each `DirectThreadKey` entry retains exact `agent_id` and a monotonic parsed-time cursor of sorted unique effective IDs at that instant, so route/directory changes do not reset it and absent inventory entries are not pruned (`tui/internal/fs/direct_unread.go:17-34,46-90,93-135,288-390`). This state is not `SessionCache`/`session.jsonl` and has no migration ownership.
 - **Session persistence role.** `MainAggregateWriter` is the only role authorized to mutate the compatibility aggregate `human/logs/session.jsonl`; zero-safe `NoPersist` is enforced inside both rewrite and append primitives. `complete` describes whether the in-memory history window can safely replace or extend a complete derived file—it is not write authorization.
 - **Session cache reconstruction.** `RebuildFromSources` is idempotent — it re-ingests all mail + events + inquiries from offset 0, sorts by timestamp, and requests a role-gated `session.jsonl` rewrite; `RebuildFromSourcesInMemory` performs the same read/merge without filesystem writes for detached generation-gated work. Canonical `logs/events.jsonl` owns session content and completeness: the additive SQLite log's source identity and endpoint offsets do not prove interior continuity, so they are not used to declare a replay complete. Every path retains the last complete-record boundary it actually consumed, so trailing partial records and concurrent appends are retried by `Refresh` rather than leaked, duplicated, or skipped.
 - **Windowed reconstruction and count metadata.** `RebuildFromSourcesWindowedInMemory` retains only the newest requested parser-produced session-event content window while loading mail/inquiries in full. `mail_page_size` directly owns that initial window and every later Ctrl+U increment. Empty/missing/wrong-type text rows do not spend content slots, while hidden `llm_call` and zero-token `llm_response` grouping carriers still do. The content path captures the canonical JSONL source/horizon but never runs a full-history aggregate. `ExactHistoryStats` is one async metadata task per activation/source/horizon: same-horizon Ctrl+U caches reuse it, while a genuinely newer horizon supersedes the old task. Accepted stats are cache/identity/generation/current-horizon-gated, reused by older-page caches, and incremented for parser-proven EOF refresh rows. JSONL content is read backward from EOF; top-level count/window metadata uses a structural fixed-buffer fast path across arbitrarily long string/nested payloads, enforces the same 10,000-container limit as `encoding/json`, and falls back to canonical one-record decoding whenever a bounded key/type/number lexeme or parser edge is declined. A cut legacy group retains only its nearest hidden `llm_response` marker. Increasing windows rescan the same canonical horizon, include every session row regardless of SQLite sparsity, and become complete only after reaching byte offset zero; parser-proven offsets, stable sort, and the shared completeness gate on both persistence and incremental disk append keep that convergence honest.

--- a/tui/internal/fs/direct_unread.go
+++ b/tui/internal/fs/direct_unread.go
@@ -1,0 +1,27 @@
+package fs
+
+// DirectUnreadStore is a compile-only RED scaffold for durable direct-thread
+// unread state. It intentionally owns no functional state yet.
+type DirectUnreadStore struct{}
+
+// OpenDirectUnreadStore is a compile-only RED scaffold. Persistence and
+// baselining deliberately do not exist yet.
+func OpenDirectUnreadStore(projectDirectory, humanAddress string, targets []DirectTarget, accepted []MailMessage) (*DirectUnreadStore, error) {
+	return &DirectUnreadStore{}, nil
+}
+
+// SyncTargets is a compile-only RED scaffold. It deliberately does nothing.
+func (s *DirectUnreadStore) SyncTargets(targets []DirectTarget, accepted []MailMessage) error {
+	return nil
+}
+
+// UnreadCount is a compile-only RED scaffold. It deliberately reports no unread
+// messages until the durable-state implementation is added.
+func (s *DirectUnreadStore) UnreadCount(target DirectTarget, accepted []MailMessage) (int, error) {
+	return 0, nil
+}
+
+// MarkSeen is a compile-only RED scaffold. It deliberately does nothing.
+func (s *DirectUnreadStore) MarkSeen(target DirectTarget, accepted []MailMessage) error {
+	return nil
+}

--- a/tui/internal/fs/direct_unread.go
+++ b/tui/internal/fs/direct_unread.go
@@ -1,27 +1,407 @@
 package fs
 
-// DirectUnreadStore is a compile-only RED scaffold for durable direct-thread
-// unread state. It intentionally owns no functional state yet.
-type DirectUnreadStore struct{}
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
 
-// OpenDirectUnreadStore is a compile-only RED scaffold. Persistence and
-// baselining deliberately do not exist yet.
+const directUnreadStateVersion = 1
+
+// DirectUnreadStore owns one project's durable direct-thread unread cursors.
+type DirectUnreadStore struct {
+	mu               sync.RWMutex
+	projectDirectory string
+	humanAddress     string
+	statePath        string
+	state            directUnreadState
+}
+
+type directUnreadState struct {
+	Version int                           `json:"version"`
+	Threads map[string]directUnreadThread `json:"threads"`
+}
+
+type directUnreadThread struct {
+	AgentID         string   `json:"agent_id"`
+	ReceivedAt      string   `json:"received_at"`
+	IDsAtReceivedAt []string `json:"ids_at_received_at"`
+}
+
+type directUnreadCursor struct {
+	receivedAt time.Time
+	ids        []string
+}
+
+type directUnreadMessage struct {
+	id string
+	at time.Time
+}
+
+// OpenDirectUnreadStore opens version-1 state and baselines any missing,
+// corrupt, unsupported, or target-invalid cursor from accepted direct mail.
 func OpenDirectUnreadStore(projectDirectory, humanAddress string, targets []DirectTarget, accepted []MailMessage) (*DirectUnreadStore, error) {
-	return &DirectUnreadStore{}, nil
+	if strings.TrimSpace(projectDirectory) == "" || strings.TrimSpace(humanAddress) == "" {
+		return nil, fmt.Errorf("direct unread project directory or human address is empty")
+	}
+	if err := validateDirectUnreadTargets(projectDirectory, targets); err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(projectDirectory, ".lingtai", ".tui-asset", "direct-unread.json")
+	state, fresh, err := readDirectUnreadState(path)
+	if err != nil {
+		return nil, err
+	}
+	changed := fresh
+	if state.Threads == nil {
+		state.Threads, changed = make(map[string]directUnreadThread), true
+	}
+	next := cloneDirectUnreadState(state)
+	needsBaseline := make([]DirectTarget, 0, len(targets))
+	for _, target := range targets {
+		key := DirectThreadKey(target)
+		thread, exists := next.Threads[key]
+		_, valid := directUnreadCursorForThread(thread)
+		if !exists || thread.AgentID != target.AgentID || !valid {
+			needsBaseline = append(needsBaseline, target)
+		}
+	}
+	if len(needsBaseline) != 0 {
+		baselines, err := directUnreadBaselines(needsBaseline, accepted, humanAddress)
+		if err != nil {
+			return nil, err
+		}
+		for _, target := range needsBaseline {
+			next.Threads[DirectThreadKey(target)] = directUnreadThreadForCursor(target.AgentID, baselines[DirectThreadKey(target)])
+		}
+		changed = true
+	}
+	if changed {
+		if err := saveDirectUnreadState(path, next); err != nil {
+			return nil, err
+		}
+	}
+	return &DirectUnreadStore{projectDirectory: projectDirectory, humanAddress: humanAddress, statePath: path, state: cloneDirectUnreadState(next)}, nil
 }
 
-// SyncTargets is a compile-only RED scaffold. It deliberately does nothing.
+// SyncTargets adds and baselines genuinely new stable keys; it never prunes.
 func (s *DirectUnreadStore) SyncTargets(targets []DirectTarget, accepted []MailMessage) error {
+	if s == nil {
+		return fmt.Errorf("sync direct unread targets: nil store")
+	}
+	if err := validateDirectUnreadTargets(s.projectDirectory, targets); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	newTargets := make([]DirectTarget, 0, len(targets))
+	for _, target := range targets {
+		key := DirectThreadKey(target)
+		thread, exists := s.state.Threads[key]
+		if !exists {
+			newTargets = append(newTargets, target)
+			continue
+		}
+		if thread.AgentID != target.AgentID {
+			return fmt.Errorf("sync direct unread target %q: inconsistent agent ID", key)
+		}
+		if _, valid := directUnreadCursorForThread(thread); !valid {
+			return fmt.Errorf("sync direct unread target %q: invalid stored boundary", key)
+		}
+	}
+	if len(newTargets) == 0 {
+		return nil
+	}
+	baselines, err := directUnreadBaselines(newTargets, accepted, s.humanAddress)
+	if err != nil {
+		return err
+	}
+	next := cloneDirectUnreadState(s.state)
+	for _, target := range newTargets {
+		next.Threads[DirectThreadKey(target)] = directUnreadThreadForCursor(target.AgentID, baselines[DirectThreadKey(target)])
+	}
+	if err := saveDirectUnreadState(s.statePath, next); err != nil {
+		return err
+	}
+	s.state = cloneDirectUnreadState(next)
 	return nil
 }
 
-// UnreadCount is a compile-only RED scaffold. It deliberately reports no unread
-// messages until the durable-state implementation is added.
+// UnreadCount counts unique accepted incoming direct messages after the cursor.
 func (s *DirectUnreadStore) UnreadCount(target DirectTarget, accepted []MailMessage) (int, error) {
-	return 0, nil
+	if s == nil {
+		return 0, fmt.Errorf("count direct unread: nil store")
+	}
+	if err := validateDirectUnreadTarget(s.projectDirectory, target); err != nil {
+		return 0, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	thread, err := s.threadForTargetLocked(target)
+	if err != nil {
+		return 0, err
+	}
+	cursor, valid := directUnreadCursorForThread(thread)
+	if !valid {
+		return 0, fmt.Errorf("count direct unread target %q: invalid stored boundary", DirectThreadKey(target))
+	}
+	messages, err := resolveDirectUnreadMessages(accepted, s.humanAddress, target)
+	if err != nil {
+		return 0, err
+	}
+	seen := make(map[string]struct{}, len(cursor.ids))
+	for _, id := range cursor.ids {
+		seen[id] = struct{}{}
+	}
+	count := 0
+	for _, message := range messages {
+		if message.at.After(cursor.receivedAt) || (message.at.Equal(cursor.receivedAt) && !containsDirectUnreadID(seen, message.id)) {
+			count++
+		}
+	}
+	return count, nil
 }
 
-// MarkSeen is a compile-only RED scaffold. It deliberately does nothing.
+// MarkSeen advances a target cursor monotonically from accepted direct mail.
 func (s *DirectUnreadStore) MarkSeen(target DirectTarget, accepted []MailMessage) error {
+	if s == nil {
+		return fmt.Errorf("mark direct unread seen: nil store")
+	}
+	if err := validateDirectUnreadTarget(s.projectDirectory, target); err != nil {
+		return err
+	}
+	messages, err := resolveDirectUnreadMessages(accepted, s.humanAddress, target)
+	if err != nil {
+		return err
+	}
+	candidate := directUnreadCursorForMessages(messages)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	thread, err := s.threadForTargetLocked(target)
+	if err != nil {
+		return err
+	}
+	current, valid := directUnreadCursorForThread(thread)
+	if !valid {
+		return fmt.Errorf("mark direct unread target %q: invalid stored boundary", DirectThreadKey(target))
+	}
+	nextCursor, changed := advanceDirectUnreadCursor(current, candidate)
+	if !changed {
+		return nil
+	}
+	next := cloneDirectUnreadState(s.state)
+	next.Threads[DirectThreadKey(target)] = directUnreadThreadForCursor(target.AgentID, nextCursor)
+	if err := saveDirectUnreadState(s.statePath, next); err != nil {
+		return err
+	}
+	s.state = cloneDirectUnreadState(next)
 	return nil
+}
+
+func validateDirectUnreadTargets(projectDirectory string, targets []DirectTarget) error {
+	keys := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		if err := validateDirectUnreadTarget(projectDirectory, target); err != nil {
+			return err
+		}
+		key := DirectThreadKey(target)
+		if _, duplicate := keys[key]; duplicate {
+			return fmt.Errorf("direct unread targets contain duplicate key %q", key)
+		}
+		keys[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateDirectUnreadTarget(projectDirectory string, target DirectTarget) error {
+	if target.ProjectDirectory != projectDirectory {
+		return fmt.Errorf("direct unread target project %q does not match store project %q", target.ProjectDirectory, projectDirectory)
+	}
+	if DirectThreadKey(target) == "" {
+		return fmt.Errorf("direct unread target has no stable project-Agent key")
+	}
+	return nil
+}
+
+func readDirectUnreadState(path string) (directUnreadState, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return newDirectUnreadState(), true, nil
+		}
+		return directUnreadState{}, false, fmt.Errorf("read direct unread state: %w", err)
+	}
+	var state directUnreadState
+	if json.Unmarshal(data, &state) != nil || state.Version != directUnreadStateVersion {
+		return newDirectUnreadState(), true, nil
+	}
+	return state, false, nil
+}
+
+func newDirectUnreadState() directUnreadState {
+	return directUnreadState{Version: directUnreadStateVersion, Threads: make(map[string]directUnreadThread)}
+}
+
+func saveDirectUnreadState(path string, state directUnreadState) error {
+	data, err := json.MarshalIndent(cloneDirectUnreadState(state), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal direct unread state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create direct unread state parent: %w", err)
+	}
+	if err := writeJSONAtomic(path, data); err != nil {
+		return fmt.Errorf("write direct unread state: %w", err)
+	}
+	return nil
+}
+
+func cloneDirectUnreadState(state directUnreadState) directUnreadState {
+	out := directUnreadState{Version: state.Version}
+	if state.Threads == nil {
+		return out
+	}
+	out.Threads = make(map[string]directUnreadThread, len(state.Threads))
+	for key, thread := range state.Threads {
+		out.Threads[key] = directUnreadThread{AgentID: thread.AgentID, ReceivedAt: thread.ReceivedAt, IDsAtReceivedAt: cloneDirectUnreadIDs(thread.IDsAtReceivedAt)}
+	}
+	return out
+}
+
+func cloneDirectUnreadIDs(ids []string) []string {
+	if ids == nil {
+		return nil
+	}
+	return append([]string{}, ids...)
+}
+
+func directUnreadCursorForThread(thread directUnreadThread) (directUnreadCursor, bool) {
+	if thread.IDsAtReceivedAt == nil {
+		return directUnreadCursor{}, false
+	}
+	receivedAt, err := time.Parse(time.RFC3339Nano, thread.ReceivedAt)
+	if err != nil || (len(thread.IDsAtReceivedAt) == 0 && !receivedAt.IsZero()) {
+		return directUnreadCursor{}, false
+	}
+	for index, id := range thread.IDsAtReceivedAt {
+		if strings.TrimSpace(id) == "" || (index > 0 && thread.IDsAtReceivedAt[index-1] >= id) {
+			return directUnreadCursor{}, false
+		}
+	}
+	return directUnreadCursor{receivedAt: receivedAt, ids: cloneDirectUnreadIDs(thread.IDsAtReceivedAt)}, true
+}
+
+func directUnreadThreadForCursor(agentID string, cursor directUnreadCursor) directUnreadThread {
+	return directUnreadThread{AgentID: agentID, ReceivedAt: cursor.receivedAt.UTC().Format(time.RFC3339Nano), IDsAtReceivedAt: cloneDirectUnreadIDs(cursor.ids)}
+}
+
+func directUnreadBaselines(targets []DirectTarget, accepted []MailMessage, humanAddress string) (map[string]directUnreadCursor, error) {
+	baselines := make(map[string]directUnreadCursor, len(targets))
+	for _, target := range targets {
+		messages, err := resolveDirectUnreadMessages(accepted, humanAddress, target)
+		if err != nil {
+			return nil, err
+		}
+		baselines[DirectThreadKey(target)] = directUnreadCursorForMessages(messages)
+	}
+	return baselines, nil
+}
+
+func resolveDirectUnreadMessages(accepted []MailMessage, humanAddress string, target DirectTarget) ([]directUnreadMessage, error) {
+	byID := make(map[string]time.Time)
+	messages := make([]directUnreadMessage, 0, len(accepted))
+	for _, msg := range accepted {
+		if !IsDirectMail(msg, humanAddress, target) || strings.TrimSpace(msg.From) != strings.TrimSpace(target.Address) {
+			continue
+		}
+		receivedAt, err := time.Parse(time.RFC3339Nano, msg.ReceivedAt)
+		if err != nil {
+			return nil, fmt.Errorf("resolve direct unread message: invalid received_at %q: %w", msg.ReceivedAt, err)
+		}
+		id := msg.MailboxID
+		if strings.TrimSpace(id) == "" {
+			id = msg.ID
+		}
+		if strings.TrimSpace(id) == "" {
+			return nil, fmt.Errorf("resolve direct unread message: missing stable message ID")
+		}
+		if prior, exists := byID[id]; exists {
+			if !prior.Equal(receivedAt) {
+				return nil, fmt.Errorf("resolve direct unread message: stable message ID %q has conflicting received_at", id)
+			}
+			continue
+		}
+		byID[id] = receivedAt
+		messages = append(messages, directUnreadMessage{id: id, at: receivedAt})
+	}
+	return messages, nil
+}
+
+func directUnreadCursorForMessages(messages []directUnreadMessage) directUnreadCursor {
+	max, ids := time.Time{}, make(map[string]struct{})
+	for _, message := range messages {
+		if message.at.After(max) {
+			max, ids = message.at, map[string]struct{}{message.id: {}}
+		} else if message.at.Equal(max) {
+			ids[message.id] = struct{}{}
+		}
+	}
+	atMax := make([]string, 0, len(ids))
+	for id := range ids {
+		atMax = append(atMax, id)
+	}
+	sort.Strings(atMax)
+	return directUnreadCursor{receivedAt: max, ids: atMax}
+}
+
+func advanceDirectUnreadCursor(current, candidate directUnreadCursor) (directUnreadCursor, bool) {
+	if candidate.receivedAt.After(current.receivedAt) {
+		return candidate, true
+	}
+	if candidate.receivedAt.Before(current.receivedAt) {
+		return current, false
+	}
+	ids := make(map[string]struct{}, len(current.ids)+len(candidate.ids))
+	for _, id := range current.ids {
+		ids[id] = struct{}{}
+	}
+	for _, id := range candidate.ids {
+		ids[id] = struct{}{}
+	}
+	merged := make([]string, 0, len(ids))
+	for id := range ids {
+		merged = append(merged, id)
+	}
+	sort.Strings(merged)
+	if len(merged) == len(current.ids) {
+		return current, false
+	}
+	return directUnreadCursor{receivedAt: current.receivedAt, ids: merged}, true
+}
+
+func containsDirectUnreadID(ids map[string]struct{}, id string) bool {
+	_, found := ids[id]
+	return found
+}
+
+func (s *DirectUnreadStore) threadForTargetLocked(target DirectTarget) (directUnreadThread, error) {
+	key := DirectThreadKey(target)
+	thread, exists := s.state.Threads[key]
+	if !exists {
+		return directUnreadThread{}, fmt.Errorf("direct unread target %q is not synchronized", key)
+	}
+	if thread.AgentID != target.AgentID {
+		return directUnreadThread{}, fmt.Errorf("direct unread target %q has inconsistent agent ID", key)
+	}
+	return thread, nil
 }

--- a/tui/internal/fs/direct_unread_test.go
+++ b/tui/internal/fs/direct_unread_test.go
@@ -1,0 +1,375 @@
+package fs
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const directUnreadHuman = "project/human"
+
+func directUnreadTarget(project, directory, agentID, address string) DirectTarget {
+	return DirectTarget{
+		ProjectDirectory: project,
+		Directory:        filepath.Join(project, ".lingtai", directory),
+		AgentID:          agentID,
+		Address:          address,
+	}
+}
+
+func directUnreadIncoming(target DirectTarget, mailboxID, legacyID, receivedAt string) MailMessage {
+	return MailMessage{
+		MailboxID:  mailboxID,
+		ID:         legacyID,
+		From:       target.Address,
+		To:         directUnreadHuman,
+		ReceivedAt: receivedAt,
+		Identity:   map[string]interface{}{"agent_id": target.AgentID},
+	}
+}
+
+func directUnreadStatePath(project string) string {
+	return filepath.Join(project, ".lingtai", ".tui-asset", "direct-unread.json")
+}
+
+func writeDirectUnreadState(t *testing.T, project string, contents []byte) string {
+	t.Helper()
+	path := directUnreadStatePath(project)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll state parent: %v", err)
+	}
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatalf("WriteFile state: %v", err)
+	}
+	return path
+}
+
+func mustOpenDirectUnreadStore(t *testing.T, project string, targets []DirectTarget, accepted []MailMessage) *DirectUnreadStore {
+	t.Helper()
+	store, err := OpenDirectUnreadStore(project, directUnreadHuman, targets, accepted)
+	if err != nil {
+		t.Fatalf("OpenDirectUnreadStore: %v", err)
+	}
+	if store == nil {
+		t.Fatal("OpenDirectUnreadStore returned nil store")
+	}
+	return store
+}
+
+func assertDirectUnreadCount(t *testing.T, store *DirectUnreadStore, target DirectTarget, accepted []MailMessage, want int) {
+	t.Helper()
+	got, err := store.UnreadCount(target, accepted)
+	if err != nil {
+		t.Errorf("UnreadCount: %v", err)
+		return
+	}
+	if got != want {
+		t.Errorf("UnreadCount = %d, want %d", got, want)
+	}
+}
+
+func TestDirectUnreadSameTimestampLateIDAndRestart(t *testing.T) {
+	project := t.TempDir()
+	target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+	const instant = "2026-07-22T14:44:00.123456789Z"
+
+	messageA := directUnreadIncoming(target, "mailbox-A", "legacy-A", instant)
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{messageA})
+	if got, err := store.UnreadCount(target, []MailMessage{messageA}); err != nil || got != 0 {
+		t.Fatalf("baseline accepted history UnreadCount = %d, %v; want 0, nil", got, err)
+	}
+
+	messageB := directUnreadIncoming(target, "mailbox-B", "legacy-B", instant)
+	acceptedAB := []MailMessage{messageA, messageB}
+	if got, err := store.UnreadCount(target, acceptedAB); err != nil {
+		t.Fatalf("UnreadCount after same-timestamp late ID: %v", err)
+	} else if got != 1 {
+		t.Fatalf("same-timestamp late ID unread count: got %d want 1", got)
+	}
+
+	if err := store.MarkSeen(target, acceptedAB); err != nil {
+		t.Fatalf("MarkSeen: %v", err)
+	}
+	reopened := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, acceptedAB)
+	messageC := directUnreadIncoming(target, "mailbox-C", "legacy-C", instant)
+	assertDirectUnreadCount(t, reopened, target, []MailMessage{messageA, messageB, messageC}, 1)
+}
+
+func TestDirectUnreadStableAgentIDSurvivesRouteRenameAndSeparatesProjectsAndIDs(t *testing.T) {
+	project := t.TempDir()
+	original := directUnreadTarget(project, "agent-old", "agent-id-a", "project/agent-old")
+	oldMail := directUnreadIncoming(original, "old", "old", "2026-07-22T14:44:00Z")
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{original}, []MailMessage{oldMail})
+	if err := store.MarkSeen(original, []MailMessage{oldMail}); err != nil {
+		t.Fatalf("MarkSeen old route: %v", err)
+	}
+
+	renamed := directUnreadTarget(project, "agent-new", original.AgentID, "project/agent-new")
+	if err := store.SyncTargets([]DirectTarget{renamed}, []MailMessage{oldMail}); err != nil {
+		t.Fatalf("SyncTargets renamed route: %v", err)
+	}
+	newRouteMail := directUnreadIncoming(renamed, "new-route", "new-route", "2026-07-22T14:45:00Z")
+	assertDirectUnreadCount(t, store, renamed, []MailMessage{oldMail, newRouteMail}, 1)
+
+	otherID := directUnreadTarget(project, "agent-b", "agent-id-b", "project/agent-b")
+	if err := store.SyncTargets([]DirectTarget{renamed, otherID}, nil); err != nil {
+		t.Fatalf("SyncTargets other stable ID: %v", err)
+	}
+	otherIDMail := directUnreadIncoming(otherID, "other-id", "other-id", "2026-07-22T14:46:00Z")
+	assertDirectUnreadCount(t, store, otherID, []MailMessage{otherIDMail}, 1)
+	assertDirectUnreadCount(t, store, renamed, []MailMessage{otherIDMail}, 0)
+
+	otherProject := t.TempDir()
+	otherProjectTarget := directUnreadTarget(otherProject, "agent-new", renamed.AgentID, renamed.Address)
+	otherStore := mustOpenDirectUnreadStore(t, otherProject, []DirectTarget{otherProjectTarget}, nil)
+	otherProjectMail := directUnreadIncoming(otherProjectTarget, "other-project", "other-project", "2026-07-22T14:47:00Z")
+	assertDirectUnreadCount(t, otherStore, otherProjectTarget, []MailMessage{otherProjectMail}, 1)
+}
+
+func TestDirectUnreadPersistsExactAgentIDAndRebaselinesMismatchedIntegrity(t *testing.T) {
+	project := t.TempDir()
+	target := directUnreadTarget(project, "agent-a", " agent-id-a ", "project/agent-a")
+	key := DirectThreadKey(target)
+	if key == "" {
+		t.Fatal("DirectThreadKey rejected a nonblank literal AgentID")
+	}
+
+	mismatched := map[string]interface{}{
+		"version": 1,
+		"threads": map[string]interface{}{
+			key: map[string]interface{}{
+				"agent_id":           "different-agent-id",
+				"received_at":        "2026-07-22T14:44:00Z",
+				"ids_at_received_at": []string{"old"},
+			},
+		},
+	}
+	encoded, err := json.Marshal(mismatched)
+	if err != nil {
+		t.Fatalf("Marshal mismatched state: %v", err)
+	}
+	writeDirectUnreadState(t, project, encoded)
+
+	baseline := directUnreadIncoming(target, "baseline", "baseline", "2026-07-22T14:45:00Z")
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{baseline})
+	assertDirectUnreadCount(t, store, target, []MailMessage{baseline}, 0)
+
+	persisted, err := os.ReadFile(directUnreadStatePath(project))
+	if err != nil {
+		t.Fatalf("ReadFile rebased state: %v", err)
+	}
+	var decoded struct {
+		Version int `json:"version"`
+		Threads map[string]struct {
+			AgentID string `json:"agent_id"`
+		} `json:"threads"`
+	}
+	if err := json.Unmarshal(persisted, &decoded); err != nil {
+		t.Fatalf("Unmarshal rebased state: %v", err)
+	}
+	if decoded.Version != 1 {
+		t.Fatalf("persisted version = %d, want 1", decoded.Version)
+	}
+	entry, ok := decoded.Threads[key]
+	if !ok {
+		t.Fatalf("persisted threads missing stable key %q: %#v", key, decoded.Threads)
+	}
+	if entry.AgentID != target.AgentID {
+		t.Fatalf("persisted agent_id = %q, want exact literal %q", entry.AgentID, target.AgentID)
+	}
+}
+
+func TestDirectUnreadBaselinesMissingMalformedAndUnsupportedStateButReturnsReadFailures(t *testing.T) {
+	stateCases := []struct {
+		name     string
+		contents []byte
+	}{
+		{name: "missing"},
+		{name: "malformed JSON", contents: []byte("{not JSON")},
+		{name: "unsupported version", contents: []byte(`{"version":999,"threads":{}}`)},
+	}
+
+	for _, tc := range stateCases {
+		t.Run(tc.name, func(t *testing.T) {
+			project := t.TempDir()
+			target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+			if tc.contents != nil {
+				writeDirectUnreadState(t, project, tc.contents)
+			}
+			history := directUnreadIncoming(target, "history", "history", "2026-07-22T14:44:00Z")
+			store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{history})
+			assertDirectUnreadCount(t, store, target, []MailMessage{history}, 0)
+			late := directUnreadIncoming(target, "late", "late", "2026-07-22T14:45:00Z")
+			assertDirectUnreadCount(t, store, target, []MailMessage{history, late}, 1)
+		})
+	}
+
+	t.Run("non IsNotExist state read failure is returned", func(t *testing.T) {
+		project := t.TempDir()
+		if err := os.MkdirAll(directUnreadStatePath(project), 0o755); err != nil {
+			t.Fatalf("MkdirAll state-path directory blocker: %v", err)
+		}
+		target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+		store, err := OpenDirectUnreadStore(project, directUnreadHuman, []DirectTarget{target}, nil)
+		if err == nil {
+			t.Fatalf("OpenDirectUnreadStore returned store %#v without surfacing a state-path directory read failure", store)
+		}
+	})
+}
+
+func TestDirectUnreadCountsOnlyStrictIncomingDirectMail(t *testing.T) {
+	project := t.TempDir()
+	target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, nil)
+	const instant = "2026-07-22T14:44:00Z"
+
+	valid := directUnreadIncoming(target, "valid", "valid", instant)
+	outgoing := valid
+	outgoing.MailboxID, outgoing.ID = "outgoing", "outgoing"
+	outgoing.From, outgoing.To = directUnreadHuman, target.Address
+	group := valid
+	group.MailboxID, group.ID = "group", "group"
+	group.To = []string{directUnreadHuman, "project/other"}
+	cc := valid
+	cc.MailboxID, cc.ID = "cc", "cc"
+	cc.CC = []string{"project/other"}
+	identityConflict := valid
+	identityConflict.MailboxID, identityConflict.ID = "conflict", "conflict"
+	identityConflict.Identity = map[string]interface{}{"agent_id": "other-agent-id"}
+
+	for _, tc := range []struct {
+		name string
+		mail MailMessage
+		want int
+	}{
+		{name: "valid strict incoming", mail: valid, want: 1},
+		{name: "outgoing", mail: outgoing, want: 0},
+		{name: "group", mail: group, want: 0},
+		{name: "CC", mail: cc, want: 0},
+		{name: "identity conflict", mail: identityConflict, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertDirectUnreadCount(t, store, target, []MailMessage{tc.mail}, tc.want)
+		})
+	}
+}
+
+func TestDirectUnreadRejectsUnresolvedIncomingWithoutChangingBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mail func(DirectTarget) MailMessage
+	}{
+		{
+			name: "invalid timestamp",
+			mail: func(target DirectTarget) MailMessage {
+				return directUnreadIncoming(target, "invalid-time", "invalid-time", "not-rfc3339")
+			},
+		},
+		{
+			name: "blank mailbox and legacy IDs",
+			mail: func(target DirectTarget) MailMessage {
+				return directUnreadIncoming(target, " ", "", "2026-07-22T14:45:00Z")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := t.TempDir()
+			writeDirectUnreadState(t, project, []byte(`{"version":1,"threads":{}}`))
+			target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+			baseline := directUnreadIncoming(target, "baseline", "baseline", "2026-07-22T14:44:00Z")
+			store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{baseline})
+			before, err := os.ReadFile(directUnreadStatePath(project))
+			if err != nil {
+				t.Fatalf("ReadFile before MarkSeen: %v", err)
+			}
+			unresolved := tc.mail(target)
+			if _, err := store.UnreadCount(target, []MailMessage{baseline, unresolved}); err == nil {
+				t.Error("UnreadCount accepted unresolved incoming mail instead of returning an error")
+			}
+			if err := store.MarkSeen(target, []MailMessage{baseline, unresolved}); err == nil {
+				t.Error("MarkSeen accepted unresolved incoming mail instead of returning an error")
+			}
+			after, err := os.ReadFile(directUnreadStatePath(project))
+			if err != nil {
+				t.Fatalf("ReadFile after MarkSeen: %v", err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("MarkSeen changed state bytes for unresolved mail:\nbefore=%q\nafter=%q", before, after)
+			}
+		})
+	}
+}
+
+func TestDirectUnreadUsesMailboxIDThenLegacyIDAndParsedTime(t *testing.T) {
+	t.Run("same timestamp uses the effective ID set", func(t *testing.T) {
+		project := t.TempDir()
+		target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+		const instant = "2026-07-22T14:44:00.123456789Z"
+		baseline := directUnreadIncoming(target, "mailbox-A", "legacy-A", instant)
+		store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{baseline})
+
+		duplicateMailbox := directUnreadIncoming(target, "mailbox-A", "different-legacy", instant)
+		mailboxPreferred := directUnreadIncoming(target, "mailbox-B", "legacy-A", instant)
+		legacyFallback := directUnreadIncoming(target, "", "legacy-only", instant)
+		assertDirectUnreadCount(t, store, target, []MailMessage{baseline, duplicateMailbox, mailboxPreferred, legacyFallback}, 2)
+	})
+
+	t.Run("timestamps are parsed rather than lexicographically compared", func(t *testing.T) {
+		project := t.TempDir()
+		target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+		// The baseline's local date sorts after the later message's local date,
+		// but 23:45Z is fifteen minutes after 00:30+01:00 (23:30Z).
+		baseline := directUnreadIncoming(target, "early", "early", "2026-01-01T00:30:00+01:00")
+		store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{baseline})
+		later := directUnreadIncoming(target, "later", "later", "2025-12-31T23:45:00Z")
+		assertDirectUnreadCount(t, store, target, []MailMessage{baseline, later}, 1)
+	})
+}
+
+func TestDirectUnreadSyncRejectsInvalidKeysAtomicallyAddsAndDoesNotPrune(t *testing.T) {
+	project := t.TempDir()
+	writeDirectUnreadState(t, project, []byte(`{"version":1,"threads":{}}`))
+	targetA := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{targetA}, nil)
+	before, err := os.ReadFile(directUnreadStatePath(project))
+	if err != nil {
+		t.Fatalf("ReadFile before invalid sync: %v", err)
+	}
+
+	blank := targetA
+	blank.AgentID = " \t"
+	if err := store.SyncTargets([]DirectTarget{targetA, blank}, nil); err == nil {
+		t.Error("SyncTargets accepted a blank stable AgentID")
+	}
+	afterBlank, err := os.ReadFile(directUnreadStatePath(project))
+	if err != nil {
+		t.Fatalf("ReadFile after blank sync: %v", err)
+	}
+	if !bytes.Equal(afterBlank, before) {
+		t.Error("blank-key SyncTargets changed persisted bytes")
+	}
+
+	duplicate := targetA
+	duplicate.Address = "project/agent-a-renamed"
+	if err := store.SyncTargets([]DirectTarget{targetA, duplicate}, nil); err == nil {
+		t.Error("SyncTargets accepted duplicate stable thread keys")
+	}
+	afterDuplicate, err := os.ReadFile(directUnreadStatePath(project))
+	if err != nil {
+		t.Fatalf("ReadFile after duplicate sync: %v", err)
+	}
+	if !bytes.Equal(afterDuplicate, before) {
+		t.Error("duplicate-key SyncTargets changed persisted bytes")
+	}
+
+	targetB := directUnreadTarget(project, "agent-b", "agent-id-b", "project/agent-b")
+	if err := store.SyncTargets([]DirectTarget{targetB}, nil); err != nil {
+		t.Fatalf("SyncTargets new stable key: %v", err)
+	}
+	mailForA := directUnreadIncoming(targetA, "after-absence", "after-absence", "2026-07-22T14:45:00Z")
+	mailForB := directUnreadIncoming(targetB, "after-add", "after-add", "2026-07-22T14:46:00Z")
+	assertDirectUnreadCount(t, store, targetA, []MailMessage{mailForA}, 1)
+	assertDirectUnreadCount(t, store, targetB, []MailMessage{mailForB}, 1)
+}

--- a/tui/internal/fs/direct_unread_test.go
+++ b/tui/internal/fs/direct_unread_test.go
@@ -181,6 +181,22 @@ func TestDirectUnreadPersistsExactAgentIDAndRebaselinesMismatchedIntegrity(t *te
 	}
 }
 
+func TestDirectUnreadOpenDoesNotRebaselineExistingStableThread(t *testing.T) {
+	project := t.TempDir()
+	target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+	baseline := directUnreadIncoming(target, "baseline", "baseline", "2026-07-22T14:44:00Z")
+	_ = mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{baseline})
+
+	unresolved := directUnreadIncoming(target, "invalid-time", "invalid-time", "not-rfc3339")
+	reopened, err := OpenDirectUnreadStore(project, directUnreadHuman, []DirectTarget{target}, []MailMessage{baseline, unresolved})
+	if err != nil {
+		t.Fatalf("reopen existing stable thread re-evaluated current accepted mail: %v", err)
+	}
+	if _, err := reopened.UnreadCount(target, []MailMessage{baseline, unresolved}); err == nil {
+		t.Fatal("UnreadCount accepted unresolved current mail after a successful no-rebaseline reopen")
+	}
+}
+
 func TestDirectUnreadBaselinesMissingMalformedAndUnsupportedStateButReturnsReadFailures(t *testing.T) {
 	stateCases := []struct {
 		name     string

--- a/tui/internal/fs/direct_unread_transactionality_test.go
+++ b/tui/internal/fs/direct_unread_transactionality_test.go
@@ -1,0 +1,89 @@
+package fs
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestDirectUnreadMarkSeenIsMonotonicAndUnionsSameTimestampIDs(t *testing.T) {
+	project := t.TempDir()
+	target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, nil)
+
+	latest := directUnreadIncoming(target, "latest", "latest", "2026-07-22T14:46:00Z")
+	if err := store.MarkSeen(target, []MailMessage{latest}); err != nil {
+		t.Fatalf("MarkSeen latest: %v", err)
+	}
+	older := directUnreadIncoming(target, "older", "older", "2026-07-22T14:45:00Z")
+	if err := store.MarkSeen(target, []MailMessage{older}); err != nil {
+		t.Fatalf("MarkSeen older: %v", err)
+	}
+	assertDirectUnreadCount(t, store, target, []MailMessage{latest}, 0)
+
+	const instant = "2026-07-22T14:47:00.123456789Z"
+	messageA := directUnreadIncoming(target, "mailbox-A", "legacy-A", instant)
+	if err := store.MarkSeen(target, []MailMessage{messageA}); err != nil {
+		t.Fatalf("MarkSeen first same-time ID: %v", err)
+	}
+	messageB := directUnreadIncoming(target, "mailbox-B", "legacy-B", instant)
+	if err := store.MarkSeen(target, []MailMessage{messageA, messageB}); err != nil {
+		t.Fatalf("MarkSeen second same-time ID: %v", err)
+	}
+	messageC := directUnreadIncoming(target, "mailbox-C", "legacy-C", instant)
+	assertDirectUnreadCount(t, store, target, []MailMessage{messageA, messageB, messageC}, 1)
+}
+
+func TestDirectUnreadCopyOnWriteSaveFailureKeepsMemoryAndBytes(t *testing.T) {
+	project := t.TempDir()
+	writeDirectUnreadState(t, project, []byte(`{"version":1,"threads":{}}`))
+	target := directUnreadTarget(project, "agent-a", "agent-id-a", "project/agent-a")
+	baseline := directUnreadIncoming(target, "baseline", "baseline", "2026-07-22T14:44:00Z")
+	store := mustOpenDirectUnreadStore(t, project, []DirectTarget{target}, []MailMessage{baseline})
+
+	late := directUnreadIncoming(target, "late", "late", "2026-07-22T14:45:00Z")
+	assertDirectUnreadCount(t, store, target, []MailMessage{baseline, late}, 1)
+	statePath := directUnreadStatePath(project)
+	before, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile state before failed save: %v", err)
+	}
+
+	// writeJSONAtomic, the established JSON helper, writes statePath+".tmp" in
+	// the same directory. A directory at that path makes each attempted save fail
+	// without modifying the current durable file.
+	if err := os.Mkdir(statePath+".tmp", 0o755); err != nil {
+		t.Fatalf("Mkdir failing temp path: %v", err)
+	}
+	if err := store.MarkSeen(target, []MailMessage{baseline, late}); err == nil {
+		t.Error("MarkSeen succeeded despite deterministic state save failure")
+	}
+	afterMark, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile state after failed MarkSeen: %v", err)
+	}
+	if !bytes.Equal(afterMark, before) {
+		t.Fatalf("failed MarkSeen changed persisted bytes:\nbefore=%q\nafter=%q", before, afterMark)
+	}
+	assertDirectUnreadCount(t, store, target, []MailMessage{baseline, late}, 1)
+
+	newTarget := directUnreadTarget(project, "agent-b", "agent-id-b", "project/agent-b")
+	if err := store.SyncTargets([]DirectTarget{target, newTarget}, []MailMessage{baseline, late}); err == nil {
+		t.Error("SyncTargets succeeded despite deterministic state save failure")
+	}
+	afterSync, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile state after failed SyncTargets: %v", err)
+	}
+	if !bytes.Equal(afterSync, before) {
+		t.Fatalf("failed SyncTargets changed persisted bytes:\nbefore=%q\nafter=%q", before, afterSync)
+	}
+
+	if err := os.Remove(statePath + ".tmp"); err != nil {
+		t.Fatalf("Remove failing temp path: %v", err)
+	}
+	newMail := directUnreadIncoming(newTarget, "new", "new", "2026-07-22T14:46:00Z")
+	if _, err := store.UnreadCount(newTarget, []MailMessage{newMail}); err == nil {
+		t.Error("failed SyncTargets published the new target in memory")
+	}
+}

--- a/tui/internal/tui/mail_snapshot.go
+++ b/tui/internal/tui/mail_snapshot.go
@@ -21,3 +21,9 @@ func (s acceptedMailSnapshot) cacheCopy(humanDir string) fs.MailCache {
 	}
 	return s.cache.Clone()
 }
+
+// messagesForUnread is a compile-only RED scaffold. It intentionally exposes
+// no accepted messages until the detached unread accessor is implemented.
+func (s acceptedMailSnapshot) messagesForUnread(humanDir string) []fs.MailMessage {
+	return nil
+}

--- a/tui/internal/tui/mail_snapshot.go
+++ b/tui/internal/tui/mail_snapshot.go
@@ -22,8 +22,8 @@ func (s acceptedMailSnapshot) cacheCopy(humanDir string) fs.MailCache {
 	return s.cache.Clone()
 }
 
-// messagesForUnread is a compile-only RED scaffold. It intentionally exposes
-// no accepted messages until the detached unread accessor is implemented.
+// messagesForUnread returns a fresh accepted-snapshot message slice for unread
+// consumers; cacheCopy keeps both not-ready and returned data detached.
 func (s acceptedMailSnapshot) messagesForUnread(humanDir string) []fs.MailMessage {
-	return nil
+	return s.cacheCopy(humanDir).Messages
 }

--- a/tui/internal/tui/mail_snapshot_unread_test.go
+++ b/tui/internal/tui/mail_snapshot_unread_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/anthropics/lingtai-tui/internal/fs"
+)
+
+func TestAcceptedMailSnapshotMessagesForUnreadReadinessAndDetachment(t *testing.T) {
+	producer := fs.MailCache{Messages: []fs.MailMessage{{
+		MailboxID:   "mailbox-1",
+		ID:          "legacy-1",
+		From:        "project/agent-a",
+		To:          []interface{}{"project/human", map[string]interface{}{"route": []interface{}{"original-route"}}},
+		CC:          []string{"original-cc"},
+		Attachments: []string{"original.txt"},
+		Identity: map[string]interface{}{
+			"agent_id": "agent-id-a",
+			"nested": map[string]interface{}{
+				"labels": []interface{}{"original-label"},
+			},
+		},
+	}}}
+
+	notReady := acceptedMailSnapshot{cache: producer}
+	if got := notReady.messagesForUnread("/human"); len(got) != 0 {
+		t.Fatalf("messagesForUnread before readiness = %#v, want empty", got)
+	}
+
+	accepted := newAcceptedMailSnapshot(producer)
+	// The accepted snapshot must not retain references into the producer cache.
+	producer.Messages[0].CC[0] = "producer-mutated-cc"
+	producer.Messages[0].Attachments[0] = "producer-mutated.txt"
+	producer.Messages[0].To.([]interface{})[1].(map[string]interface{})["route"].([]interface{})[0] = "producer-mutated-route"
+	producer.Messages[0].Identity["nested"].(map[string]interface{})["labels"].([]interface{})[0] = "producer-mutated-label"
+
+	got := accepted.messagesForUnread("/human")
+	if len(got) != 1 {
+		t.Fatalf("messagesForUnread after readiness len = %d, want 1", len(got))
+	}
+	if got[0].CC[0] != "original-cc" || got[0].Attachments[0] != "original.txt" ||
+		got[0].To.([]interface{})[1].(map[string]interface{})["route"].([]interface{})[0] != "original-route" ||
+		got[0].Identity["nested"].(map[string]interface{})["labels"].([]interface{})[0] != "original-label" {
+		t.Fatalf("messagesForUnread observed later producer mutation: %#v", got[0])
+	}
+
+	// The returned messages must also be recursively detached from the accepted
+	// snapshot and from a later unread accessor result.
+	got[0].CC[0] = "returned-mutated-cc"
+	got[0].Attachments[0] = "returned-mutated.txt"
+	got[0].To.([]interface{})[1].(map[string]interface{})["route"].([]interface{})[0] = "returned-mutated-route"
+	got[0].Identity["nested"].(map[string]interface{})["labels"].([]interface{})[0] = "returned-mutated-label"
+
+	again := accepted.messagesForUnread("/human")
+	if len(again) != 1 {
+		t.Fatalf("second messagesForUnread len = %d, want 1", len(again))
+	}
+	if again[0].CC[0] != "original-cc" || again[0].Attachments[0] != "original.txt" ||
+		again[0].To.([]interface{})[1].(map[string]interface{})["route"].([]interface{})[0] != "original-route" ||
+		again[0].Identity["nested"].(map[string]interface{})["labels"].([]interface{})[0] != "original-label" {
+		t.Fatalf("messagesForUnread returned an aliased message graph: %#v", again[0])
+	}
+}


### PR DESCRIPTION
## Summary

- add a versioned durable direct-unread cursor store keyed by stable project and exact AgentID identity
- preserve late same-timestamp mail with parsed-time ordering plus the effective-ID set at the cursor boundary
- make target sync and MarkSeen atomic, monotonic and copy-on-write across persistence failures
- expose detached accepted-snapshot mail for later unread computation without adding visible sidebar behavior

Part of #645. This foundation does **not** add a rail, badges, direct-agent switching, commands, visible UI, ProjectMailStore ownership, or a second mailbox owner.

## Contract and failure policy

- thread identity survives route/display rename and remains distinct across projects and AgentIDs;
- mailbox ID is authoritative with legacy message ID fallback;
- only strict incoming direct mail counts—outgoing, group/CC and identity-conflicting mail do not;
- unresolved incoming mail fails closed without changing bytes or memory;
- cursor state parses timestamps and unions IDs at the cursor timestamp, so later arrivals at the same time remain unread;
- missing, malformed and unsupported state rebaseline safely, but real non-IsNotExist read failures surface;
- target sync validates the entire input before mutation, adds without pruning, rejects blank/duplicate stable keys, and remains copy-on-write when saving fails;
- MarkSeen is monotonic and a failed save publishes neither memory nor bytes;
- unread inputs come from a detached accepted mailbox snapshot only after readiness.

## Test-first evidence

The first commit `5cee2e54` contains the contract tests before implementation. On post-#663 canonical main, this exact command exited 1 under ordinary test execution:

```sh
go test ./internal/fs ./internal/tui -run 'DirectUnread|AcceptedMailSnapshotMessagesForUnread' -count=1 -v
```

The intended cursor, stable-identity, rebaseline/error, strict-classification, unresolved-input, atomic-sync, monotonic/transactionality and accepted-snapshot readiness assertions failed; this was not syntax, imports, dependencies or environment. Exact RED log: `workspace/reviews/issue-645-u-replayed-red-20260723.txt`.

The final head turns the same suite green.

## Exact accepted replay

- canonical base: `14564f50589aa6133893cc2bbe9f9f811422f313`
- exact head: `a005825756cf9a0581a5d0d02da5a131065668ed`
- exact tree: `c00625e43859d379527e27f4282e6f68ddf60a32`
- scope: 2 commits, 6 files, +968/-4
- original accepted range `00a72ed6..50e2d207` and replayed range have the identical aggregate stable patch-id `de00062828e13deaf22afc8b566148ec2f7545ec`

This preserves the accepted RED→implementation chronology directly atop merged #663 rather than reviving the broader old persistence drafts.

## Exact-head validation

```sh
git diff --check 14564f50...a0058257
go test ./internal/fs ./internal/tui -run 'DirectUnread|AcceptedMailSnapshotMessagesForUnread' -count=1 -v
go test ./internal/fs ./internal/tui -count=1
go test -race ./internal/fs ./internal/tui -run 'DirectUnread|AcceptedMailSnapshotMessagesForUnread' -count=1
go test -p=1 ./... -count=1
go vet ./...
```

Focused durable-unread tests, affected fs/TUI packages, focused race, all 14 module packages serially, vet, patch equivalence, exact head/tree and final clean worktree passed. Exact log: `workspace/reviews/issue-645-u-replayed-exact-head-validation-20260723.txt`.

## Independent exact-head review

- **Claude Opus 4.8 / high: PASS.** It verified stable identity and cursor ordering, strict incoming classification, rebaseline versus read-error behavior, copy-on-write save-before-publish atomicity, monotonic/non-pruning operations, accepted-snapshot detachment, citations and narrow scope. Its only notes were nonblocking: an unreachable hand-crafted cursor shape and the intentional batch fail-closed granularity.
- **Codex gpt-5.6-sol / xhigh: PASS.** It independently verified the same exact head/tree and all durable contracts. Its only nonblocking note was chronology: one additional regression test arrived with the implementation commit, while the first commit still preserves the authentic broad contract RED suite.

Both independent reviewers PASS exact head `a005825756cf9a0581a5d0d02da5a131065668ed`.

## Cleanup and rollback

There is no compatibility bridge, new dependency, visible UI, second mailbox owner or data migration beyond the new versioned unread-state file. Reverting the eventual squash commit removes the unused foundation; existing mail data is unchanged.
