### PR TITLE
test(tui): initialize first-run save regression fixture

### DIFF
--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/anthropics/lingtai-tui/i18n"
@@ -897,6 +898,15 @@ func TestFirstRunAgentPresetsNext_AdvancesWithoutLiveCodexProbe(t *testing.T) {
 		presetDefaultIdx: 0,
 		presetCfgCursor:  2, // row 0, Back 1, Next 2
 		cursor:           0,
+		nameInput:        textinput.New(),
+		dirInput:         textinput.New(),
+		ctxLimitInput:    textinput.New(),
+		soulDelayInput:   textinput.New(),
+		maxRpmInput:      textinput.New(),
+		maxAedInput:      textinput.New(),
+		covenantInput:    textinput.New(),
+		soulFlowInput:    textinput.New(),
+		commentInput:     textinput.New(),
 	}
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})


### PR DESCRIPTION
## What changed

Initialize the downstream first-run text inputs in the Codex no-live-probe regression added by #722. The product transition correctly advances from preset selection to the runtime/name page; the original minimal struct fixture left that next page's inputs as zero-value models and panicked after the assertion target had already been crossed.

Production code is unchanged.

## Validation

- `gofmt` clean
- `git diff --check` clean
- `go test -work ./internal/tui -run '^TestFirstRunAgentPresetsNext_AdvancesWithoutLiveCodexProbe$' -count=1` → PASS (`0.574s`) under the no-unlink sandbox
- Jason's live preset Save test for #722 passed separately
