### PR TITLE
fix(tui): keep self-update help side-effect free

### DIFF
--- a/tui/main.go
+++ b/tui/main.go
@@ -28,15 +28,27 @@ import (
 // version is set at build time via -ldflags "-X main.version=v0.4.2"
 var version = "dev"
 
+func isSubcommandHelpArg(arg string) bool {
+	return arg == "--help" || arg == "-h" || arg == "help"
+}
+
+func dispatchSelfUpdate(args []string, showHelp func(), runSelfUpdate func()) {
+	if len(args) > 0 && isSubcommandHelpArg(args[0]) {
+		showHelp()
+		return
+	}
+	runSelfUpdate()
+}
+
 func dispatchDoctor(args []string, showHelp func(), runDoctor func()) {
-	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+	if len(args) > 0 && isSubcommandHelpArg(args[0]) {
 		showHelp()
 		return
 	}
 	runDoctor()
 }
 
-func printDoctorHelp() {
+func printSubcommandHelp() {
 	printWelcomeInfo()
 	fmt.Println()
 	printHelp()
@@ -85,11 +97,11 @@ func main() {
 			return
 		}
 		if arg == "self-update" {
-			selfUpdateMain()
+			dispatchSelfUpdate(os.Args[2:], printSubcommandHelp, selfUpdateMain)
 			return
 		}
 		if arg == "doctor" {
-			dispatchDoctor(os.Args[2:], printDoctorHelp, doctorMain)
+			dispatchDoctor(os.Args[2:], printSubcommandHelp, doctorMain)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\nRun 'lingtai-tui --help' for usage.\n", arg)

--- a/tui/main_doctor_test.go
+++ b/tui/main_doctor_test.go
@@ -12,6 +12,7 @@ func TestDispatchDoctor(t *testing.T) {
 		{name: "no arguments runs doctor", wantDoctor: true},
 		{name: "help flag shows help", args: []string{"--help"}, wantHelp: true},
 		{name: "short help flag shows help", args: []string{"-h"}, wantHelp: true},
+		{name: "help command shows help", args: []string{"help"}, wantHelp: true},
 		{name: "ordinary argument preserves doctor path", args: []string{"--force"}, wantDoctor: true},
 	}
 
@@ -29,6 +30,39 @@ func TestDispatchDoctor(t *testing.T) {
 			}
 			if got := doctorCalls == 1; got != tt.wantDoctor {
 				t.Fatalf("doctor calls = %d, want doctor called = %t", doctorCalls, tt.wantDoctor)
+			}
+		})
+	}
+}
+
+func TestDispatchSelfUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantHelp       bool
+		wantSelfUpdate bool
+	}{
+		{name: "no arguments runs self-update", wantSelfUpdate: true},
+		{name: "help flag shows help", args: []string{"--help"}, wantHelp: true},
+		{name: "short help flag shows help", args: []string{"-h"}, wantHelp: true},
+		{name: "help command shows help", args: []string{"help"}, wantHelp: true},
+		{name: "ordinary argument preserves self-update path", args: []string{"--force"}, wantSelfUpdate: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var helpCalls, selfUpdateCalls int
+
+			dispatchSelfUpdate(tt.args,
+				func() { helpCalls++ },
+				func() { selfUpdateCalls++ },
+			)
+
+			if got := helpCalls == 1; got != tt.wantHelp {
+				t.Fatalf("help calls = %d, want help called = %t", helpCalls, tt.wantHelp)
+			}
+			if got := selfUpdateCalls == 1; got != tt.wantSelfUpdate {
+				t.Fatalf("self-update calls = %d, want self-update called = %t", selfUpdateCalls, tt.wantSelfUpdate)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add a side-effect-free dispatch guard for `lingtai-tui self-update --help`, `-h`, and `help` before the real updater entrypoint is invoked.
- Share the same subcommand-help argument helper with `doctor`, including a new `doctor help` regression case.
- Keep ordinary `lingtai-tui self-update` / non-help args routed to the real updater entrypoint.

## Why
`lingtai-tui self-update --help` previously reached the real self-update path instead of printing help only, so asking for help could perform a Homebrew/native update. Help flags must be safe and side-effect-free.

## Validation
- `cd tui && go test . -run 'TestDispatch(Doctor|SelfUpdate)$' -count=1` ✅
- `cd tui && make build` ✅
- `git diff --check` ✅
- `cd tui && go test ./...` ⚠️ exits 1 due an unrelated/pre-existing `internal/tui` panic:
  - failing test: `TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider`
  - panic path: `cursor.(*Model).Blink` / `textinput.(*Model).Focus` / `FirstRunModel.enterAgentNameDir`
  - location: `tui/internal/tui/firstrun.go:4229`, called by `tui/internal/tui/firstrun_test.go:865`
  - this PR touches only `tui/main.go` and `tui/main_doctor_test.go`; `tui/internal/tui/firstrun.go` and `firstrun_test.go` are unchanged.

## Side-effect boundary
No real `lingtai-tui self-update`, installed runtime update, kernel update, doctor update, config/account/model change, hotpatch, merge, or deploy was performed while validating this PR.
