### PR TITLE
refactor(preset): remove unused compatibility shims

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -86,7 +86,7 @@ const (
 	// from embedded data on every launch.
 	SourceTemplate
 	// SourceSaved means the preset lives under presets/saved/. User-
-	// owned; never touched by Bootstrap/SeedMissingBuiltins.
+	// owned; never touched by Bootstrap/RefreshTemplates.
 	SourceSaved
 )
 
@@ -462,17 +462,6 @@ func Delete(name string) error {
 	}
 	return err
 }
-
-// EnsureDefault is now a no-op kept for callers that haven't been
-// updated. Templates are unconditionally rewritten by RefreshTemplates
-// on every Bootstrap, and saved presets are user territory — there is
-// nothing to "ensure default" anymore.
-func EnsureDefault() error { return nil }
-
-// SeedMissingBuiltins is replaced by RefreshTemplates. Kept as a thin
-// alias so old callers (lingtai-claude-code, codex-plugin) that import
-// the preset package don't break on upgrade.
-func SeedMissingBuiltins() error { return RefreshTemplates() }
 
 // RefreshTemplates rewrites templates/ from BuiltinPresets() wholesale.
 // Called from Bootstrap on every TUI launch. Deletes any *.json file


### PR DESCRIPTION
## Summary

Remove two exported preset compatibility shims with no live callers:

- `EnsureDefault` — literal no-op
- `SeedMissingBuiltins` — pass-through to `RefreshTemplates`

The same one-file change replaces the stale `SourceSaved` comment reference with the real owner, `RefreshTemplates`.

## Why removal is safe

The old comment claimed compatibility for external `lingtai-claude-code` / `codex-plugin` callers, but `tui/internal/preset` cannot be imported outside the `tui` module under Go's `internal/` rule. Repo-wide checks find no live caller, reflection path, plugin bridge, retention contract, or real external Go consumer. All preset bootstrap/template refresh behavior remains unchanged.

## Scope and validation

- 1 file, 1 insertion / 12 deletions
- `gofmt -l internal/preset/preset.go`: clean
- `go vet ./internal/preset/...`: pass
- `go test ./internal/preset/...`: pass
- `go build ./...`: pass
- `git diff --check`: pass
- independent exact-diff Claude Opus 5 review: **APPROVE**, no blockers
