### PR TITLE
refactor(tui): remove write-only visit target state

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -109,9 +109,6 @@ type App struct {
 	visitOriginalMail       MailModel
 	visitOriginalProjects   ProjectsModel
 	visitOriginalView       appView
-	visitTargetProjectDir   string
-	visitTargetAgentDir     string
-	visitTargetAgentName    string
 	doubleEscArmed          bool
 	doubleEscFirstAt        time.Time
 }
@@ -1763,9 +1760,6 @@ func (a App) enterVisitedAgent(msg ProjectsAgentSelectedMsg) (App, tea.Cmd) {
 	a.projectDir = filepath.Join(r.Project, ".lingtai")
 	a.orchDir = r.AgentDir
 	a.orchName = firstNonEmpty(r.AgentName, r.Agent)
-	a.visitTargetProjectDir = a.projectDir
-	a.visitTargetAgentDir = a.orchDir
-	a.visitTargetAgentName = a.orchName
 	a.currentView = appViewMail
 	a.selectMode = false
 	a.doubleEscArmed = false
@@ -1791,9 +1785,6 @@ func (a App) returnFromVisit() (App, tea.Cmd) {
 	a.visitOriginalOrchDir = ""
 	a.visitOriginalOrchName = ""
 	a.visitOriginalView = appViewMail
-	a.visitTargetProjectDir = ""
-	a.visitTargetAgentDir = ""
-	a.visitTargetAgentName = ""
 	a.doubleEscArmed = false
 	resumeCmd := a.resumeMailModel(restored)
 	if a.currentView == appViewProjects {


### PR DESCRIPTION
## Summary

- remove the three private `visitTarget*` fields from `App`
- remove their three writes in `enterVisitedAgent` and three clears in `returnFromVisit`
- preserve every `visitOriginal*` save/restore path and all live project/agent navigation state

On first-parent/mainline history these fields were introduced write-only in `e9560c74` and have no consumers. A lone read existed only on the abandoned pre-squash development branch and was removed before the squash reached mainline.

## Validation

- `git diff --check`
- zero repo-wide `visitTarget` occurrences after the change
- `gofmt -l internal/tui/app.go`
- `go vet ./internal/tui/...`
- focused visit/return tests: parent 5 passed; independent Opus 5 review 40 passed
- `go build ./...`
- explicit Sonnet implementation review and independent Opus 5 exact-diff final: APPROVE / no blockers

The full `go test ./internal/tui/...` currently has an unrelated `TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider` cursor-blink nil-pointer panic, reproduced unchanged on pristine base.

No merge is requested or authorized by this PR creation.
