### PR TITLE
refactor(recipe): remove retired fresh-start residue

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -657,8 +657,6 @@
   "recipe.swap_hint": "Changing from '%s' to '%s'. How should this apply?",
   "recipe.swap_inplace": "Swap in place",
   "recipe.swap_inplace_desc": "Update the comment file and queue a new greet. Existing network preserved.",
-  "recipe.swap_fresh": "Fresh start (wipe .lingtai/ and reconfigure)",
-  "recipe.swap_fresh_desc": "Destroy the current network and start over with the new recipe. Irreversible.",
   "recipe.swap_cancel": "Cancel",
   "recipe.swap_nirvana_hint": "To start fresh with a new recipe and wipe current history, use /nirvana.",
   "recipe.preview_greet": "greet.md",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -652,8 +652,6 @@
   "recipe.swap_hint": "由 '%s' 至 '%s'，如何施之？",
   "recipe.swap_inplace": "就地更替",
   "recipe.swap_inplace_desc": "更 comment 之文，排新问候。现网犹存。",
-  "recipe.swap_fresh": "重开（净 .lingtai/ 而再设之）",
-  "recipe.swap_fresh_desc": "灭今网，以新仪重始。不可复。",
   "recipe.swap_cancel": "止",
   "recipe.swap_nirvana_hint": "欲以新功法重来而除旧史，行 /nirvana。",
   "recipe.preview_greet": "greet.md",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -652,8 +652,6 @@
   "recipe.swap_hint": "从 '%s' 切换到 '%s'。如何应用？",
   "recipe.swap_inplace": "就地替换",
   "recipe.swap_inplace_desc": "更新 comment 文件并排队新的问候。保留现有网络。",
-  "recipe.swap_fresh": "重新开始（清除 .lingtai/ 并重新配置）",
-  "recipe.swap_fresh_desc": "销毁当前网络并用新配方重新开始。不可逆。",
   "recipe.swap_cancel": "取消",
   "recipe.swap_nirvana_hint": "若要以新配方重来并清除当前历史，请使用 /nirvana。",
   "recipe.preview_greet": "greet.md",

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -618,15 +618,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, tea.Batch(a.mail.Init(), a.sendSize())
 
-	case RecipeFreshStartMsg:
-		a.pendingRecipe = msg.Recipe
-		a.pendingCustomDir = msg.CustomDir
-		a.nirvanaCleanupPending = false
-		a.nirvanaCleanupStarted = false
-		a.currentView = appViewNirvana
-		a.nirvana = NewNirvanaModel(a.projectDir)
-		return a, tea.Batch(a.nirvana.Init(), a.sendSize())
-
 	case NirvanaDoneMsg:
 		// Nirvana complete: .lingtai/ wiped, go to first-run.
 		// Re-init project to recreate the human folder so agents can
@@ -1846,15 +1837,6 @@ func (a App) visitEscEligible() bool {
 		!a.mail.agentRail.focused &&
 		!a.mail.showEditorWarn &&
 		!a.mail.input.IsPaletteActive()
-}
-
-// RecipeFreshStartMsg is emitted from stepRecipeSwapConfirm when the user
-// chooses "Fresh start (wipe .lingtai/ and reconfigure)". The app routes
-// this to NirvanaModel and stores the recipe so post-nirvana first-run
-// can pre-select it.
-type RecipeFreshStartMsg struct {
-	Recipe    string
-	CustomDir string
 }
 
 type refreshDoneMsg struct {

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -378,7 +378,7 @@ type FirstRunModel struct {
 	// Swap-confirm state (stepRecipeSwapConfirm — wired in Task 9)
 	pendingRecipeName string
 	pendingCustomDir  string
-	swapConfirmIdx    int // 0=swap, 1=fresh, 2=cancel
+	swapConfirmIdx    int // 0=swap, 1=cancel
 
 	// purpose is the typed discriminator visible to Update/Init. Normal and
 	// draft flows pass their purpose directly into the shared constructor;
@@ -4700,7 +4700,6 @@ func (m FirstRunModel) viewRecipeSwapConfirm() string {
 	var b strings.Builder
 
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAgent)
-	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorSuspended)
 
 	b.WriteString("\n  " + titleStyle.Render(i18n.T("recipe.swap_title")) + "\n\n")
 	b.WriteString("  " + i18n.TF("recipe.swap_hint", m.currentRecipe, m.pendingRecipeName) + "\n\n")
@@ -4708,11 +4707,10 @@ func (m FirstRunModel) viewRecipeSwapConfirm() string {
 	type option struct {
 		label string
 		desc  string
-		warn  bool
 	}
 	opts := []option{
-		{i18n.T("recipe.swap_inplace"), i18n.T("recipe.swap_inplace_desc"), false},
-		{i18n.T("recipe.swap_cancel"), "", false},
+		{i18n.T("recipe.swap_inplace"), i18n.T("recipe.swap_inplace_desc")},
+		{i18n.T("recipe.swap_cancel"), ""},
 	}
 
 	for i, opt := range opts {
@@ -4720,13 +4718,7 @@ func (m FirstRunModel) viewRecipeSwapConfirm() string {
 		labelStyle := lipgloss.NewStyle().Foreground(ColorText)
 		if i == m.swapConfirmIdx {
 			cursor = "> "
-			if opt.warn {
-				labelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorSuspended)
-			} else {
-				labelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
-			}
-		} else if opt.warn {
-			labelStyle = warnStyle
+			labelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
 		}
 		b.WriteString(cursor + labelStyle.Render(opt.label) + "\n")
 		if opt.desc != "" {


### PR DESCRIPTION
## Summary

- remove the unconstructed `RecipeFreshStartMsg` handler/type left after the Fresh-start recipe option was retired
- remove the now-unreachable warning styling from the two remaining swap-confirm options and correct the stale index comment to `0=swap, 1=cancel`
- remove the unused `recipe.swap_fresh` / `recipe.swap_fresh_desc` keys symmetrically from all three locales
- preserve the live `/nirvana` replacement path, `NirvanaDoneMsg`, post-nirvana pending/preselected recipe plumbing, and every `recipe.swap_nirvana_hint`

Commit `d4961c15` deliberately removed the Fresh-start option in favor of `/nirvana`; this PR only removes residue from that decided product change. It does not restore or alter the option.

## Validation

- exact dead-symbol search: zero `RecipeFreshStartMsg` / `recipe.swap_fresh*` occurrences
- all three locale JSON files parse and retain identical 830-key sets
- `gofmt -l`, `git diff --check`
- `go test ./i18n/...`
- focused `Recipe|SwapConfirm` tests
- `go vet ./...`
- `go build ./...`
- explicit Sonnet implementation review and independent Opus 5 exact-diff final: APPROVE / no blockers
- Opus focused `Recipe|Swap|Nirvana|I18n|Locale|Parity` gate passed

The full `go test ./internal/tui/...` still has the unrelated preset cursor-blink nil-pointer panic; both Sonnet and Opus reproduced it unchanged on pristine base.

No merge is requested or authorized by this PR creation.
