### PR TITLE
refactor(tui): remove zero-caller UI helpers

### DIFF
--- a/tui/internal/inventory/ANATOMY.md
+++ b/tui/internal/inventory/ANATOMY.md
@@ -38,7 +38,7 @@ maintenance: |
 | `enrichRecord`, `RoleFor`, `enterability` | `tui/internal/inventory/inventory.go:220-295` | Read `.agent.json` and `.status.json`, derive role/admin/IM/heartbeat/lock plus lifecycle/molt/live-context state, and mark unreadable, human, phantom, pathless, or non-admin records as non-enterable with a typed reason and optional detail; only valid orchestrator/admin records are enterable. |
 | `collapseByAgentDir` | `tui/internal/inventory/inventory.go:297-320` | Collapses duplicate visible processes for the same agent dir, preferring the PID currently advertised in `.status.json` when available. |
 | `sortRecords` / `groupRecords` | `tui/internal/inventory/inventory.go:346-397` | Deterministic project, role, display-name, path, PID sorting and project grouping. |
-| `SummarizeIMIdentities`, `SummarizeAdmin`, `HumanUptimeFromEtime`, `HeartbeatLabel` | `tui/internal/inventory/inventory.go:455-602` | Small rendering helpers shared by CLI and TUI callers without importing either package. |
+| `SummarizeIMIdentities`, `SummarizeAdmin`, `HumanUptimeFromEtime` | `tui/internal/inventory/inventory.go:455-565` | Small rendering helpers shared by CLI and TUI callers without importing either package. |
 
 ## Connections
 

--- a/tui/internal/inventory/inventory.go
+++ b/tui/internal/inventory/inventory.go
@@ -589,14 +589,3 @@ func parseEtimeSeconds(etime string) (int, bool) {
 	}
 	return days*24*60*60 + secs, true
 }
-
-func HeartbeatLabel(h fs.HeartbeatStatus) string {
-	switch {
-	case h.Fresh:
-		return "fresh"
-	case h.Exists:
-		return "stale"
-	default:
-		return "missing"
-	}
-}

--- a/tui/internal/processscan/check.go
+++ b/tui/internal/processscan/check.go
@@ -301,10 +301,6 @@ func findAgentProcessesWindows(abs string) []AgentProcess {
 	return ParseWMICOutput(string(out), abs)
 }
 
-func FindWindowsAgentProcesses(abs string) []AgentProcess {
-	return findAgentProcessesWindows(abs)
-}
-
 func windowsAgentProcessOutput() ([]byte, error) {
 	out, err := exec.Command(
 		"wmic",

--- a/tui/internal/tui/auto_refresh.go
+++ b/tui/internal/tui/auto_refresh.go
@@ -35,10 +35,6 @@ func autoRefreshTick() tea.Cmd {
 	return tea.Every(autoRefreshInterval, func(t time.Time) tea.Msg { return autoRefreshTickMsg(t) })
 }
 
-func autoRefreshCtrlRMsg() tea.KeyPressMsg {
-	return tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}
-}
-
 // autoRefreshActiveView reloads only the kanban/props view. Other Ctrl+R-
 // reloadable screens (/mailbox, /system, /daemons, markdown viewers, pickers,
 // and editors) are intentionally excluded from the 1s auto-refresh loop because

--- a/tui/internal/tui/input.go
+++ b/tui/internal/tui/input.go
@@ -296,10 +296,6 @@ func (m InputModel) AtMaxHeight() bool {
 	return m.textarea.Height() >= m.textarea.MaxHeight
 }
 
-func (m InputModel) ScrollOffset() int {
-	return m.textarea.ScrollYOffset()
-}
-
 func (m InputModel) ScrollPercent() float64 {
 	return m.textarea.ScrollPercent()
 }

--- a/tui/internal/tui/mailbox_entries.go
+++ b/tui/internal/tui/mailbox_entries.go
@@ -271,52 +271,6 @@ func scanInternalMailbox(dir, source string) []parsedMail {
 	return mails
 }
 
-func scanImapMailbox(dir, account string) []parsedMail {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var mails []parsedMail
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		msgPath := filepath.Join(dir, entry.Name(), "message.json")
-		data, err := os.ReadFile(msgPath)
-		if err != nil {
-			continue
-		}
-		var msg mailMessage
-		if json.Unmarshal(data, &msg) != nil {
-			continue
-		}
-
-		from := msg.From
-		if msg.FromAddress != "" && msg.FromAddress != msg.From {
-			from = msg.From + " <" + msg.FromAddress + ">"
-		}
-
-		// Parse IMAP date (RFC 2822 style)
-		t, _ := time.Parse("Mon, 02 Jan 2006 15:04:05 -0700", msg.Date)
-
-		atts := parseAttachments(msg.Attachments)
-		if len(atts) == 0 {
-			atts = parseAttachments(msg.Files)
-		}
-
-		mails = append(mails, parsedMail{
-			From:        from,
-			To:          account,
-			Subject:     msg.Subject,
-			Body:        msg.Message,
-			Time:        t,
-			Attachments: atts,
-			Source:      "imap:" + account,
-		})
-	}
-	return mails
-}
-
 func isTextAttachment(contentType, filename string) bool {
 	if strings.HasPrefix(contentType, "text/") {
 		return true

--- a/tui/internal/tui/notification.go
+++ b/tui/internal/tui/notification.go
@@ -159,17 +159,6 @@ func notificationTitle(agentDir string) string {
 	return fmt.Sprintf("%s — %s", base, filepath.Base(agentDir))
 }
 
-func (m NotificationModel) blockWrapWidth() int {
-	wrapWidth := m.width - 8
-	if wrapWidth < 40 {
-		return 40
-	}
-	if wrapWidth > 120 {
-		return 120
-	}
-	return wrapWidth
-}
-
 // renderNotificationSnapshot formats a single NotificationBlockSnapshot for display.
 // It shows the event identity, modern metadata sections, the full raw meta block,
 // global _notification_guidance, and each channel's actual payload from the
@@ -289,13 +278,6 @@ func notificationMarkdownMapBlock(s sqlitelog.NotificationBlockSnapshot, cursor,
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# %s\n\n", notificationSnapshotMarkdownTitle(s, cursor, total, label))
 	notificationWriteMarkdownMapSection(&sb, label, value)
-	return sb.String()
-}
-
-func notificationMarkdownAnyBlock(s sqlitelog.NotificationBlockSnapshot, cursor, total int, label string, value interface{}) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "# %s\n\n", notificationSnapshotMarkdownTitle(s, cursor, total, label))
-	notificationWriteMarkdownAnySection(&sb, label, value)
 	return sb.String()
 }
 

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -1748,11 +1748,6 @@ func clonePresetForEditor(p preset.Preset) preset.Preset {
 	return out
 }
 
-func asBool(v interface{}) bool {
-	b, _ := v.(bool)
-	return b
-}
-
 func asExtra(extra map[string]interface{}, key string) string {
 	if extra == nil {
 		return ""

--- a/tui/upgrade.go
+++ b/tui/upgrade.go
@@ -44,7 +44,6 @@ type startupTUIUpgradeOptions struct {
 	GlobalDir           string
 	SourceInstallScript string
 
-	CheckTUIUpgrade                 func(string) string
 	FindOtherTUIProcesses           func() []runningTUIProcess
 	PrepareOtherTUIProcessesUpgrade func([]runningTUIProcess) (func() error, error)
 }
@@ -61,9 +60,6 @@ func (o *startupTUIUpgradeOptions) setDefaults() {
 	}
 	if o.Runner == nil {
 		o.Runner = streamingCommandRunner{stdout: os.Stdout, stderr: os.Stderr}
-	}
-	if o.CheckTUIUpgrade == nil {
-		o.CheckTUIUpgrade = config.CheckTUIUpgrade
 	}
 	if o.FindOtherTUIProcesses == nil {
 		o.FindOtherTUIProcesses = findOtherTUIProcesses


### PR DESCRIPTION
## Summary

- remove eight zero-caller TUI/UI helper functions or methods across the app, inventory, and process-scan packages
- remove the `startupTUIUpgradeOptions.CheckTUIUpgrade` field/default that was read and assigned but never invoked
- update the one inventory Anatomy row that explicitly cited the removed `HeartbeatLabel`; keep the Portal filesystem half of T05 out of this PR

## Why this is safe

Each removed helper had no caller on the base tree. The higher-risk cases were checked beyond a simple call grep:

- no interface declares `ScrollOffset() int`; the lowercase reflected `agentRail.scrollOffset` field is a distinct live symbol
- exported `HeartbeatLabel` and `FindWindowsAgentProcesses` live below Go `internal/`, and no permitted same-module consumer references them
- `scanImapMailbox` has no registry/function-value dispatch; `buildMailboxEntries` calls the surviving `scanInternalMailbox` exactly three times, while live IMAP integration is owned by the MCP addon
- the upgrade field was only nil-checked/defaulted; assigning `config.CheckTUIUpgrade` stored a function value with no side effect, and no production or test path invoked or set that field

The distinct live `main.go` `CheckTUIUpgradeFunc`, `config.CheckTUIUpgrade`, `MailModel.orchAddr`/`pollRate`, Windows `findAgentProcessesWindows`, and all surviving sibling helpers are unchanged.

## Validation

- focused internal/tui tests for auto-refresh, input, notification, preset-editor, and mailbox behavior — passed
- full `./internal/inventory/...` and `./internal/processscan/...` tests — passed
- 18 focused root upgrade/startup/preflight tests — passed
- `go vet ./...` and `go build ./...` — passed
- Windows processscan test cross-compile and full Windows build — passed
- all changed Go files are gofmt-clean; `git diff --check` — clean
- explicit Claude Opus final review: **APPROVE WITH NON-BLOCKING NOTES**, no blockers

`go test ./internal/tui/` still has the one previously base-reproduced cursor-blink panic in `TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider`; base and this branch each have exactly the same one failure. Seven unrelated module-wide gofmt findings are also present on base and untouched.

Deleting `scanImapMailbox` leaves a harmless, now-unreachable `"imap:"` presentation-label branch in `mailbox_entries.go`. It was outside this candidate's authorized symbol list and is deliberately left for a separate follow-up rather than widening this proportional PR. The Portal filesystem `session.go` half of T05 is likewise reserved for its own later PR.
