### PR TITLE
docs(tui): correct bundled dev-guide to drop retired project-migration mechanism

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
@@ -139,7 +139,6 @@ never convert a refusal or uncertainty into cleanup pressure.
 
 - **Screens / UI models:** `tui/internal/tui/` — one file per screen (Bubble Tea convention)
 - **Presets:** `tui/internal/preset/` — `preset.go` (~1900 lines) handles load/save/list
-- **Migrations:** `tui/internal/migrate/` — append a new `m<NNN>_<name>.go` file
 - **Filesystem access:** `tui/internal/fs/` — read-only window into agent working directories
 - **Subprocess launch:** `tui/internal/process/` — how agents are spawned
 - **i18n:** `tui/i18n/` — en/zh/wen JSON tables
@@ -152,17 +151,6 @@ make build                    # builds to tui/bin/lingtai-tui
 make cross-compile            # all platforms
 go test ./...                 # run tests
 ```
-
-### Adding a migration
-
-1. Create `tui/internal/migrate/m<NNN>_<name>.go` exporting `func migrate<Name>(lingtaiDir string) error`.
-2. Register in `migrate.go`: append to the `migrations` slice, bump `CurrentVersion`.
-3. **Also bump `CurrentVersion` in `portal/internal/migrate/migrate.go`** — TUI and portal share the `meta.json` version space.
-4. If it touches shared on-disk state (init.json schema, preset paths), implement it in both packages with identical logic.
-5. If it's TUI-only, add a no-op stub `Fn: func(_ string) error { return nil }` in the portal registry to preserve the version slot.
-
-Version collisions and the `data version N is newer than this binary supports`
-failure have their own recovery checklist in `reference/gotchas/SKILL.md`.
 
 ### Adding a new screen
 
@@ -178,7 +166,6 @@ failure have their own recovery checklist in `reference/gotchas/SKILL.md`.
 - **API handlers:** `portal/internal/api/` — `server.go`, `handlers.go`, `replay.go`
 - **Filesystem access:** `portal/internal/fs/` — same shape as TUI's, portal-tailored
 - **Web frontend:** `portal/web/src/` — React 19 + TypeScript + Vite
-- **Migrations:** `portal/internal/migrate/` — shares version space with TUI
 - **i18n:** `portal/i18n/` — independent of TUI's i18n, same three-locale rule
 
 ### Build and test
@@ -197,10 +184,6 @@ Pipeline: `npm install` → `npm run build` (in `web/`) → `go build` (embeds `
 2. `cd portal/web && npm run build` to rebuild the frontend.
 3. `cd portal && make build` to embed it into the Go binary.
 4. Embedding happens at compile time via `//go:embed all:web/dist` in `portal/embed.go`.
-
-### Migrations
-
-Same contract as TUI — see "Adding a migration" above. Portal-only migrations get a no-op stub in the TUI registry.
 
 ## Changing the kernel (`lingtai-kernel/`)
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-guide-gotchas
 description: >
-  Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, dev-mode rebuilds, editable installs, migrations, localization, authorization gates, config conventions, and rebuild-gate test false-passes.
+  Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, editable installs, localization, authorization gates, config conventions, and rebuild-gate test false-passes.
 version: 1.1.0
 last_changed_at: "2026-07-18T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
@@ -39,47 +39,6 @@ ta.SetStyles(themedTextareaStyles())
 
 `themedTextareaStyles()` is in the `tui` package — always apply it. A bare `textarea.New()` ships dark default cursor/focus colors that render as a black smear against the warm LingTai theme.
 
-## Dev-mode rebuild gotcha
-
-A stale TUI or portal binary against a freshly-migrated project fails with:
-
-```
-data version N is newer than this binary supports (M); upgrade lingtai-tui
-data version N is newer than this binary supports (M); upgrade lingtai-portal
-```
-
-**Root cause:** TUI and portal share `.lingtai/meta.json`. Any binary whose compiled migration `CurrentVersion` is below the project's `meta.json` version must refuse to open it, or it might misread or downgrade newer state. This happens even when the feature PR you wanted is already on `main` — another local branch or newer dev binary may have already written a higher data version to that project.
-
-**Preflight before replacing a local dev binary for an existing project:**
-
-```bash
-PROJECT=/path/to/project
-CHECKOUT=/path/to/lingtai-checkout
-
-printf 'project meta version: '
-python3 - <<PY
-import json, pathlib
-meta = pathlib.Path('$PROJECT/.lingtai/meta.json')
-print(json.loads(meta.read_text()).get('version') if meta.exists() else '<none>')
-PY
-
-printf 'tui CurrentVersion: '
-grep -R 'const CurrentVersion' "$CHECKOUT/tui/internal/migrate/migrate.go"
-printf 'portal CurrentVersion: '
-grep -R 'const CurrentVersion' "$CHECKOUT/portal/internal/migrate/migrate.go"
-```
-
-If the project's version exceeds the checkout's `CurrentVersion`, **do not install that binary over the user's active `lingtai-tui`**. Build from a checkout/branch that includes the matching migration, or stop and explain that the requested `main` rebuild cannot safely open that project yet. Never "fix" this by editing `meta.json` downward.
-
-**Fix after any migration bump:** rebuild both binaries from the same checkout:
-
-```bash
-cd ~/Documents/GitHub/lingtai/tui && make build
-cd ~/Documents/GitHub/lingtai/portal && make build
-```
-
-The brew-installed pair normally avoids this because released TUI and portal ship together at the same version. Local dev binaries and one-off test overlays are the dangerous case — always preflight before overwriting an active binary for a real project.
-
 ## Auto-upgrader clobbers editable install
 
 The TUI's auto-upgrader (`tui/internal/config/venv.go:428-437`,
@@ -110,37 +69,6 @@ A successful PR merge does not prove running agents execute the merged code. The
 **Symptom:** a feature present on GitHub is missing at runtime; imports such as `lingtai.mcp_servers` fail; an MCP/addon path still points at an old standalone repo or a detached worktree.
 
 **Fix:** probe the exact Python interpreter the agent uses and print `module.__file__` for `lingtai`, `lingtai.kernel`, and the relevant MCP/addon modules; inspect the git root/HEAD behind those paths; fast-forward or editable-reinstall the intended source; then call `system(action="refresh")` and rerun the probe. Command recipe: `reference/setup/SKILL.md` → "Verify the runtime checkout a running agent actually uses". Discipline: `reference/runtime-self-check/SKILL.md`.
-
-## Migration cross-package contract
-
-TUI and portal share `meta.json` but have separate migration registries. **When adding a TUI migration, you MUST also bump `CurrentVersion` in `portal/internal/migrate/migrate.go`.**
-
-- Migrations touching shared state → implement in both packages with identical logic.
-- TUI-only migrations → add a no-op stub in the portal registry.
-- Otherwise the portal refuses to open any project the TUI has already touched.
-
-### Migration-version / rebuild incident checklist
-
-Follow this whenever you hit `data version N is newer than this binary supports (M)` or suspect a version collision between open branches:
-
-1. **Check the project's stamped version:**
-   ```bash
-   python3 -c "import json,pathlib; print(json.loads(pathlib.Path('.lingtai/meta.json').read_text())['version'])"
-   ```
-
-2. **Check `CurrentVersion` in BOTH packages of the exact checkout being built:**
-   ```bash
-   grep 'const CurrentVersion' tui/internal/migrate/migrate.go portal/internal/migrate/migrate.go
-   ```
-   Both must match. A mismatch means an incomplete bump — the portal refuses any project the TUI has already touched.
-
-3. **After installing or switching dev binaries, launch and smoke-test the target project — not just `--version`.** A binary printing the right version string may still refuse to open a project with a higher `meta.json` version.
-
-4. **Do not install a feature-branch binary that bumps migrations into shared dev projects** unless that migration PR is the intended runtime path or you can roll `main` forward to include it. A single `make build` on the wrong branch contaminates every project it touches.
-
-5. **If two open branches claim the same migration number:** stop — do not build or launch either binary into a shared project. Identify which branch (if any) already migrated real projects to that version. Renumber and combine before any further binary migrates real projects: assign the earlier repair to the lower claimed version, add a combined catch-up at the next free slot, and have the catch-up call the earlier function idempotently. See `tui/internal/migrate/ANATOMY.md` → "Collision-recovery pattern".
-
-6. **Emergency rollback is NOT editing `meta.json` downward.** That corrupts data written by the higher-version migration. The only safe recovery is building and installing a binary whose `CurrentVersion` meets or exceeds the project's current version.
 
 ## Three-locale rule
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -131,17 +131,14 @@ when the portal is in scope.
 ## 3. Rebuild the active TUI from a clean release worktree
 
 To make the running binary reflect `origin/main` (or a release head), rebuild
-from a clean worktree, not a dirty feature branch. After rebuilding either
-binary, rebuild **both** — a stale portal against a freshly migrated project
-fails with `data version N is newer than this binary supports`.
+from a clean worktree, not a dirty feature branch.
 
 ```bash
 REPO=<your-lingtai-checkout>
 git -C "$REPO" fetch origin main --tags --prune
 
-# Build both so TUI and portal stay at the same meta.json version.
 cd "$REPO/tui" && make build
-cd "$REPO/portal" && make build
+cd "$REPO/portal" && make build   # only if the portal is also in scope
 ```
 
 ### Verify the rebuild actually landed on PATH
@@ -287,7 +284,7 @@ not the matched secret.
 ## Related references
 
 - `reference/setup/SKILL.md` — establish or recover editable dev mode and symlinks.
-- `reference/gotchas/SKILL.md` — dev-mode rebuild gotcha, editable-install behaviour.
+- `reference/gotchas/SKILL.md` — editable-install behaviour.
 - `reference/debug-troubleshoot/SKILL.md` — failing networks, MCP boot, preset/path mismatch.
 - `reference/security-audit/SKILL.md` — full secret/permission audit and safe-reporting format.
 - `reference/cache-hit-rate/SKILL.md` — the token-ledger measurement that proves a cache fix took effect.


### PR DESCRIPTION
## Summary

- remove bundled contributor instructions for the retired TUI/Portal project-migration, `CurrentVersion`, lockstep/no-op-stub, and stale-binary refusal mechanism
- remove the matching obsolete dev-mode/migration gotchas while keeping the surviving child description truthful
- keep runtime self-check guidance useful and scope-sensitive: rebuild the active TUI from a clean worktree, build Portal only when it is also in scope, and point readers only at the surviving editable-install gotcha

## Why

The bundled `lingtai-dev-guide` is embedded by the TUI and materialized into users' utility libraries. It was still teaching agents to author and coordinate project-local migrations even though production has no project-migration callers; the owning migration Anatomy retains those packages only as historical/test evidence.

This is a guidance-over-mechanism correction. It does not reactivate migrations or add a compatibility gate.

## Validation

- `cd tui && go test -count=1 ./internal/preset/...`
- `cd tui && go test -count=1 . -run 'TestArchitectureEntryLinks|TestRuntimeControlSurfaceAnatomyRoute|TestProductionHasNoProjectMigrationCallers'`
- YAML frontmatter parse for all three edited skill files
- bundled-guide retired-claim and deleted-heading pointer sweeps
- `git diff --check`

A fresh read-only Opus final re-review approved the exact final diff with no blockers.

## Scope

Only the three bundled `lingtai-dev-guide` references change. The root maintainer guide, bundled router, all code, Anatomy/Contract files, historical migration packages/tests, and `globalmigrate` remain unchanged.
