### PR TITLE
fix(tui): stop exposing ignored max_turns

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -383,7 +383,6 @@
   "props.api_compat": "API compat",
   "props.api_key_env": "API key env",
   "props.context_limit": "Context limit",
-  "props.max_turns": "Max turns",
   "props.max_rpm": "Max RPM",
   "props.streaming": "Streaming",
   "props.no_data": "No agent data",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -378,7 +378,6 @@
   "props.api_compat": "API 兼",
   "props.api_key_env": "钥变量",
   "props.context_limit": "识限",
-  "props.max_turns": "轮限",
   "props.max_rpm": "频限",
   "props.streaming": "流",
   "props.no_data": "无",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -378,7 +378,6 @@
   "props.api_compat": "API 兼容",
   "props.api_key_env": "密钥环境变量",
   "props.context_limit": "上下文上限",
-  "props.max_turns": "最大轮次",
   "props.max_rpm": "每分请求上限",
   "props.streaming": "流式",
   "props.no_data": "无数据",

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1732,10 +1732,6 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	// longer accepts configurable context.molt thresholds or messages (Jason
 	// #4135/#4137/#4140). Existing init.json files that still carry stale keys
 	// are left untouched (no migration); the kernel ignores them.
-	// Per-wake loop budget: every iteration of the LLM/tool-call loop
-	// counts as a turn, not just LLM requests, so tool-heavy work burns
-	// through it quickly. The agent sleeps when the budget is exhausted.
-	manifest["max_turns"] = 500
 	manifest["max_rpm"] = opts.MaxRpm
 	// AED max-attempts: normalize through ClampAedAttempts so a zero-value
 	// AgentOpts (caller didn't set it) still writes a valid default rather

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -480,7 +480,7 @@ func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 		if !ok {
 			t.Fatal("manifest not a map")
 		}
-		for _, key := range []string{"agent_name", "language", "llm", "capabilities", "admin", "streaming", "max_turns"} {
+		for _, key := range []string{"agent_name", "language", "llm", "capabilities", "admin", "streaming"} {
 			if _, exists := manifest[key]; !exists {
 				t.Errorf("manifest missing key %q", key)
 			}
@@ -488,8 +488,8 @@ func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 		if manifest["agent_name"] != "test-agent" {
 			t.Errorf("agent_name = %v, want %q", manifest["agent_name"], "test-agent")
 		}
-		if got, want := manifest["max_turns"], float64(500); got != want {
-			t.Errorf("max_turns = %v, want %v", got, want)
+		if _, exists := manifest["max_turns"]; exists {
+			t.Errorf("manifest should not contain max_turns for a newly generated init.json, got %v", manifest["max_turns"])
 		}
 
 		// Check .agent.json exists

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -540,7 +540,6 @@ func (m PropsModel) renderLeft(maxW int) string {
 	lines = append(lines, "  "+labelStyle.Render(i18n.T("props.soul_flow")+": ")+m.renderSoulFlowValue(raw, valueStyle, labelStyle))
 	renderFields([]propsField{
 		{"molt_count", i18n.T("props.molt_count")},
-		{"max_turns", i18n.T("props.max_turns")},
 		{"max_rpm", i18n.T("props.max_rpm")},
 	})
 

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -53,6 +53,22 @@ func TestPropsRenderLeftShowsStartedAtLocalOffset(t *testing.T) {
 	}
 }
 
+func TestPropsRenderLeftHidesStaleMaxTurnsButShowsMaxRpm(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), []byte(`{"agent_name":"mimo","max_turns":500,"max_rpm":30}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := PropsModel{selectedDir: dir}
+	left := ansi.Strip(m.renderLeft(80))
+	if strings.Contains(left, "Max turns") {
+		t.Fatalf("renderLeft should not render the stale max_turns row:\n%s", left)
+	}
+	if !strings.Contains(left, "Max RPM") || !strings.Contains(left, "30") {
+		t.Fatalf("renderLeft should still render the truthful max_rpm field:\n%s", left)
+	}
+}
+
 func TestPropsRenderRightShowsNetworkCreatedLocalOffset(t *testing.T) {
 	origLocal := time.Local
 	t.Cleanup(func() { time.Local = origLocal })

--- a/tui/scripts/setup-playground.sh
+++ b/tui/scripts/setup-playground.sh
@@ -53,7 +53,6 @@ cat > "$ORCH_DIR/init.json" << INITEOF
       "daemon": {}
     },
     "context_limit": null,
-    "max_turns": 500,
     "admin": {"karma": true},
     "streaming": true
   },


### PR DESCRIPTION
## Summary

- stop writing the ignored agent-manifest `max_turns: 500` default from both TUI-owned new-agent emitters
- stop rendering stale legacy `max_turns` values in Props while preserving the truthful `max_rpm` row
- replace the generated-manifest value assertion with an explicit absence assertion and add a focused stale-hidden / `max_rpm`-visible Props regression
- remove the now-unused `props.max_turns` key from the three TUI locales

## Why

The kernel owns the real emergency turn fuse (10,000) and deliberately ignores legacy agent-manifest `max_turns`. Continuing to emit and display `500` made an inactive compatibility key look like a live per-agent runtime limit.

This change does **not** migrate existing files: setup continues to copy forward an existing stale key, but Props no longer presents it as effective configuration.

## Scope boundaries

- leaves `tui/internal/preset/templates/init.jsonc` and `examples/init.jsonc` untouched; their kernel-canonical synchronization is the separate #743 concern
- leaves the distinct live daemon-run `max_turns` field and tests unchanged
- leaves the three unconsumed Portal locale copies unchanged as a separate product/dead-string surface
- leaves kernel canonical/schema/Telegram display, docs, and all Anatomy/Contract files unchanged

## Validation

- `go test ./internal/preset/... -run '^TestGenerateInitJSON_ProducesValidJSON$' -count=1`
- `go test ./internal/tui/... -run '^TestPropsRenderLeftHidesStaleMaxTurnsButShowsMaxRpm$' -count=1`
- `go test ./internal/preset/... ./i18n/... -count=1`
- `go test ./i18n/... ./internal/tui/... -run 'TestLocaleJSONKeySetsAreComplete' -count=1`
- `go vet ./internal/preset/... ./internal/tui/... ./i18n/...`
- `go build ./...`
- `bash -n tui/scripts/setup-playground.sh`
- parsed all three changed locale files as JSON
- `git diff --check`

The exact reviewed patch is 8 files, `+19/-12`, SHA-256 `72fa4cae7d6b0dd917a6adcf3959e11d46f5bd5a2d4d70c6db8c7425c9346197`. It was re-applied unchanged to fresh current main `895e127f` after the intervening sidebar-only #745/#746 changes, then the full proportional gate above passed again.

## Known unrelated baseline defects

- the full `internal/tui` suite has a pre-existing cursor nil panic in `TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider`; it reproduces on pristine bases before this patch and is not touched here
- `tui/scripts/setup-playground.sh` has pre-existing heredoc/API-key quoting and path-expression defects; this PR only retires its ignored `max_turns` emission and does not broaden into a script repair

Independent final review and the fresh-current-main re-gate found no blockers. This PR is not merged by this workflow.
