### PR TITLE
docs(portal): clarify topology endpoint contents

### DIFF
--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
@@ -2,7 +2,7 @@
 name: portal-guide-topology-and-api
 description: Nested lingtai-portal-guide reference for topology tape frames, replay chunks, portal API endpoints, and the Network JSON response.
 version: 1.0.0
-last_changed_at: "2026-07-18T00:00:00Z"
+last_changed_at: "2026-07-25T15:12:43Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
@@ -34,7 +34,7 @@ All endpoints are served at `http://localhost:<port>`.
 | Endpoint | Method | Response | Description |
 |----------|--------|----------|-------------|
 | `/api/network` | GET | `Network` JSON | Live network state (nodes, edges, stats) |
-| `/api/topology` | GET | JSON array of `TapeFrame` | Full topology tape (can be large) |
+| `/api/topology` | GET | JSON array of `TapeFrame` | Current `topology.jsonl` contents: after reconstruction this is only the last reconstructed frame plus subsequent live snapshots, not the full history |
 | `/api/topology/manifest` | GET | `ReplayManifest` JSON | Chunk metadata for replay |
 | `/api/topology/chunk?start=<hourMs>` | GET | Chunk JSON (optionally gzip-encoded when requested) | Frames for one hour-bucket start time |
 | `/api/topology/progress` | GET | JSON object such as `{ "current": N, "total": M }` (or `{}`) | Reconstruction progress parsed from `reconstruct.progress` |


### PR DESCRIPTION
## Summary

- correct the shipped Portal guide's `/api/topology` row so it describes the current `topology.jsonl` contents rather than a complete historical topology tape
- state the post-reconstruction boundary explicitly: the file starts with the last reconstructed frame and then receives subsequent live snapshots
- update the maintained nested skill's `last_changed_at`

## Why

`NewTopologyHandler` reads the current `topology.jsonl` file and returns its non-empty lines as a JSON array. During reconstruction, `writeReconstructedReplay` writes the complete historical frames into replay chunks and the manifest, then overwrites `topology.jsonl` with only the last reconstructed frame before live recording resumes.

The previous `Full topology tape (can be large)` description therefore overclaimed what the bare endpoint returns after reconstruction.

## Scope

Docs only. This PR does not change the endpoint, route registration, replay implementation, manifest/chunk APIs, runtime behavior, parent skill routing, Anatomy/Contract, or the separately deferred `/api/topology` retirement work.

## Validation

- maintained-skill validator for the parent Portal guide and changed nested child
- `cd tui && go test ./internal/preset -count=1`
- `cd tui && go test ./internal/tui -run '^TestBuildSkillFolderEntries_PortalGuideNestedReferences$' -count=1`
- source-level verification against `portal/internal/api/handlers.go`, `replay.go`, and the reconstruction gate
- exact diff/state/stash checks; `git diff --check`
- explicit Sonnet candidate (`claude-sonnet-5`) followed by fresh independent Opus final review (`claude-opus-5`): `APPROVE_WITH_NONBLOCKING_NOTES`, no blockers

The automated tests prove the nested guide still ships and routes correctly; the wording itself is justified by the source-level behavior review above.
