### PR TITLE
fix(windows): refresh pinned kernel provenance

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1388,6 +1388,13 @@ function Install-MainVenv {
     Write-Info "Installing lingtai from the verified checked-out kernel source path (non-editable local build) ..."
     & $python '-m' 'pip' 'install' $KernelSource | Out-Null
     if ($LASTEXITCODE -ne 0) { Fail "-Latest kernel source install failed (exit $LASTEXITCODE)." }
+    # A reused managed venv can already contain the same LingTai version with a
+    # stale editable/local direct_url.json. The dependency-resolving install
+    # above may then report the requirement satisfied without replacing that
+    # root package. Reinstall only LingTai itself from this exact checked-out
+    # source so provenance is deterministic while preserving resolved deps.
+    & $python '-m' 'pip' 'install' '--force-reinstall' '--no-deps' $KernelSource | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "-Latest pinned kernel reinstall failed (exit $LASTEXITCODE)." }
     $version = Confirm-KernelImport -VenvPython $python -ExpectedVersion '' -VenvDir $venvDir -KernelSource $KernelSource
     return @{ KernelSource='main'; KernelVersion=$version; KernelProvider='github'; KernelCommit=$KernelSha }
 }


### PR DESCRIPTION
Jason's real -Latest run reached kernel installation but a reused managed venv kept stale same-version `direct_url.json` and corrupt old metadata, so verification reported `DIRECT_URL_WRONG_SOURCE`.

After the ordinary dependency-resolving local-source install, reinstall only the LingTai root package with `--force-reinstall --no-deps` from the exact checked-out kernel path. This preserves the dependency set and deterministically refreshes PEP 610 provenance without deleting/recreating the managed venv.