### PR TITLE
fix(tui): parse Codex pool weights exactly

### DIFF
--- a/tui/internal/tui/codex_pool_store.go
+++ b/tui/internal/tui/codex_pool_store.go
@@ -1,10 +1,14 @@
 package tui
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"math"
+	"math/big"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -78,6 +82,75 @@ type codexPoolAccount struct {
 	Path    string `json:"path"`
 	Weight  int    `json:"weight"`
 	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+var errCodexPoolInvalidWeight = errors.New("invalid codex pool account weight")
+
+// UnmarshalJSON preserves the pool's missing-weight default without routing
+// numeric acceptance through float64. Plain integer spellings retain their
+// exact native-int value (including 0/negative); decimal/exponent spellings are
+// accepted only when their exact value is a positive native int.
+func (a *codexPoolAccount) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Path    string          `json:"path"`
+		Weight  json.RawMessage `json:"weight"`
+		Enabled *bool           `json:"enabled,omitempty"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	weight, err := parseCodexPoolWeight(wire.Weight)
+	if err != nil {
+		return err
+	}
+	*a = codexPoolAccount{Path: wire.Path, Weight: weight, Enabled: wire.Enabled}
+	return nil
+}
+
+func parseCodexPoolWeight(raw json.RawMessage) (int, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return 1, nil
+	}
+	// Only a JSON number token may carry a weight. The enclosing account decode
+	// already guarantees that RawMessage contains one complete JSON value.
+	if c := trimmed[0]; c != '-' && (c < '0' || c > '9') {
+		return 0, errCodexPoolInvalidWeight
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	dec.UseNumber()
+	var num json.Number
+	if err := dec.Decode(&num); err != nil {
+		return 0, errCodexPoolInvalidWeight
+	}
+	s := num.String()
+	if !strings.ContainsAny(s, ".eE") {
+		value, err := strconv.ParseInt(s, 10, strconv.IntSize)
+		if err != nil {
+			return 0, errCodexPoolInvalidWeight
+		}
+		return int(value), nil
+	}
+
+	// ParseFloat is reject-only: it prevents unbounded exact expansion for huge
+	// exponents. Acceptance below is decided solely by big.Rat's exact value.
+	if f, err := strconv.ParseFloat(s, 64); err != nil || math.IsInf(f, 0) || math.IsNaN(f) {
+		return 0, errCodexPoolInvalidWeight
+	}
+	exact, ok := new(big.Rat).SetString(s)
+	if !ok || !exact.IsInt() || exact.Sign() <= 0 {
+		return 0, errCodexPoolInvalidWeight
+	}
+	value := exact.Num()
+	if !value.IsInt64() {
+		return 0, errCodexPoolInvalidWeight
+	}
+	n := value.Int64()
+	if n > int64(^uint(0)>>1) {
+		return 0, errCodexPoolInvalidWeight
+	}
+	return int(n), nil
 }
 
 // codexPool is the on-disk pool file shape. Models (v2) classifies accounts by

--- a/tui/internal/tui/codex_pool_store_test.go
+++ b/tui/internal/tui/codex_pool_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -151,6 +152,139 @@ func TestLoadCodexPool_MalformedFileErrors(t *testing.T) {
 	}
 	if _, err := loadCodexPool(dir); err == nil {
 		t.Fatal("malformed pool file should return a parse error")
+	}
+}
+
+func TestCodexPoolAccountWeightDecoding_FlatAndClassified(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	type weightCase struct {
+		name    string
+		literal string
+		want    int64
+		valid   bool
+	}
+	cases := []weightCase{
+		{name: "missing", want: 1, valid: true},
+		{name: "plain-positive", literal: "3", want: 3, valid: true},
+		{name: "plain-zero", literal: "0", want: 0, valid: true},
+		{name: "plain-negative", literal: "-3", want: -3, valid: true},
+		{name: "decimal-positive", literal: "1.0", want: 1, valid: true},
+		{name: "decimal-trailing-zeros", literal: "1.000000000000000000000000", want: 1, valid: true},
+		{name: "exponent-positive", literal: "2e0", want: 2, valid: true},
+		{name: "scaled-decimal-exponent", literal: "2.50e1", want: 25, valid: true},
+		{name: "negative-exponent-still-integral", literal: "10e-1", want: 1, valid: true},
+		{name: "fraction", literal: "1.5"},
+		{name: "fractional-exponent", literal: "15e-1"},
+		{name: "decimal-zero", literal: "0.0"},
+		{name: "negative-decimal", literal: "-2.0"},
+		{name: "negative-exponent", literal: "-2e0"},
+		{name: "string", literal: `"2"`},
+		{name: "bool", literal: "true"},
+		{name: "null", literal: "null"},
+		{name: "malformed-object", literal: "{}"},
+		{name: "malformed-array", literal: "[2]"},
+		{name: "plain-overflow", literal: "9223372036854775808"},
+		{name: "exponent-overflow", literal: "1e100"},
+		{name: "huge-exponent-rejected-before-expansion", literal: "1e309"},
+	}
+	if strconv.IntSize == 64 {
+		cases = append(cases,
+			weightCase{name: "above-float64-integer-precision", literal: "9007199254740993.0", want: 9007199254740993, valid: true},
+			weightCase{name: "native-int-max-decimal", literal: "9223372036854775807.0", want: 9223372036854775807, valid: true},
+		)
+	}
+
+	entries := make([]string, 0, len(cases))
+	for _, tc := range cases {
+		weight := ""
+		if tc.literal != "" {
+			weight = `,"weight":` + tc.literal
+		}
+		entries = append(entries, `{"path":"codex-auth/`+tc.name+`.json"`+weight+`}`)
+	}
+	accounts := strings.Join(entries, ",")
+
+	for _, classified := range []bool{false, true} {
+		dir := t.TempDir()
+		var raw string
+		if classified {
+			raw = `{"version":2,"models":{"gpt-test":[` + accounts + `]}}`
+		} else {
+			raw = `{"version":1,"accounts":[` + accounts + `]}`
+		}
+		if err := os.WriteFile(codexPoolPath(dir), []byte(raw), 0o644); err != nil {
+			t.Fatalf("classified=%v seed pool: %v", classified, err)
+		}
+
+		pool, err := loadCodexPool(dir)
+		if err != nil {
+			t.Fatalf("classified=%v load pool: %v", classified, err)
+		}
+		var got []codexPoolAccount
+		if classified {
+			got = (*pool.Models)["gpt-test"]
+		} else {
+			got = pool.Accounts
+		}
+		wantDropped := 0
+		for _, tc := range cases {
+			if !tc.valid && tc.literal != "" {
+				wantDropped++
+			}
+		}
+		if pool.DroppedEntries != wantDropped {
+			t.Errorf("classified=%v dropped=%d, want %d (got=%#v)", classified, pool.DroppedEntries, wantDropped, got)
+		}
+		if len(got) != len(cases)-wantDropped {
+			t.Fatalf("classified=%v decoded accounts=%d, want %d (got=%#v)", classified, len(got), len(cases)-wantDropped, got)
+		}
+		for _, tc := range cases {
+			if !tc.valid {
+				continue
+			}
+			path := "codex-auth/" + tc.name + ".json"
+			var found *codexPoolAccount
+			for i := range got {
+				if got[i].Path == path {
+					found = &got[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Errorf("classified=%v valid account %q was dropped", classified, path)
+				continue
+			}
+			if int64(found.Weight) != tc.want {
+				t.Errorf("classified=%v %q weight=%d, want %d", classified, tc.literal, found.Weight, tc.want)
+			}
+		}
+	}
+}
+
+func TestCodexPoolAccountWeightWriterRoundTrip_PreservesZeroAndNegative(t *testing.T) {
+	t.Setenv("LINGTAI_TUI_DIR", "")
+	dir := t.TempDir()
+	raw := []byte(`{"version":1,"accounts":[{"path":"codex-auth/zero.json","weight":0},{"path":"codex-auth/negative.json","weight":-3}]}`)
+	if err := os.WriteFile(codexPoolPath(dir), raw, 0o644); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	pool, err := loadCodexPool(dir)
+	if err != nil {
+		t.Fatalf("load pool: %v", err)
+	}
+	if err := saveCodexPool(dir, pool); err != nil {
+		t.Fatalf("save pool: %v", err)
+	}
+	written, err := os.ReadFile(codexPoolPath(dir))
+	if err != nil {
+		t.Fatalf("read saved pool: %v", err)
+	}
+	body := string(written)
+	if !strings.Contains(body, `"weight": 0`) || !strings.Contains(body, `"weight": -3`) {
+		t.Errorf("saved pool did not preserve canonical zero/negative integers: %s", body)
+	}
+	if len(pool.Accounts) != 2 || pool.Accounts[0].Weight != 0 || pool.Accounts[1].Weight != -3 {
+		t.Errorf("loaded weights = %#v, want 0 and -3", pool.Accounts)
 	}
 }
 


### PR DESCRIPTION
## Summary

- default an omitted Codex pool account `weight` to `1`;
- preserve plain native-integer JSON values exactly, including explicit `0` and negative values;
- accept decimal/exponent spellings only when they represent an exact positive integral value within the host `int` range, without float64 rounding;
- reject fractional, non-number, non-positive decimal/exponent, and overflow values through the existing dropped-entry path;
- use the same account decoder for flat v1 and model-classified v2 pools, while keeping canonical integer writes and existing membership/eligibility/edit behavior;
- add focused regression coverage, including 64-bit precision boundaries and 32-bit test compilation.

## Why

This is the weight-parsing-only follow-up invited when #709 was closed. The earlier PR mixed two findings: its live preflight portion was superseded by #722, while the weight-parsing mismatch remained valid.

The TUI previously decoded an omitted `weight` as Go's zero value and rejected ordinary integral numeric spellings such as `1.0` and `2e0`. A float64-based fix would also silently round large integer values. This change gives the TUI exact, bounded numeric behavior without reviving the superseded preflight work.

## Scope

- TUI only; no kernel change.
- Exactly two files: `codex_pool_store.go` and focused tests.
- No preflight/provider network behavior, auth handling, preset logic, or dependency change.

## Validation

- `gofmt` and `git diff --check`
- `go test ./internal/tui -run 'CodexPool' -count=1`
- repeated `CodexPool` slice 5x during implementation review
- `go vet ./internal/tui`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test -exec=/usr/bin/true ./internal/tui -run '^$' -count=1`
- independent Sol review: initial `HOLD` found a 32-bit test-only compile defect; the exact two-line fix was independently rechecked as `READY_FOR_PR` with no remaining blocker/material/minor finding

The broader `internal/tui` package still has an unrelated `TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider` cursor nil panic. The same targeted panic reproduces on an untouched base worktree, and neither changed file appears in that stack.

Follow-up to #709.
