### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/kernel-release.json
+++ b/kernel-release.json
@@ -1,5 +1,5 @@
 {
   "schema": "lingtai.tui.kernel-pin/v1",
-  "kernel_tag": "v0.18.1",
+  "kernel_tag": "v0.19.0",
   "comment": "Repo-owned pin: the kernel release tag a TUI release binds into its bundle manifest. Bump this deliberately in the same PR/commit that intends to ship a new kernel version with the next TUI release; the release workflow never resolves 'latest kernel' on its own. See RELEASING.md."
 }


### PR DESCRIPTION
## Summary

- point the TUI/Portal release manifest at kernel `v0.19.0`
- prepare the already-scoped TUI/Portal `v0.12.0` release candidate
- keep the candidate diff to the single expected `kernel-release.json` line

## Validation

- `make -C tui build` — PASS
- `make -C tui cross-compile` — PASS
- `make -C portal build` — PASS
- `make -C portal cross-compile` — PASS
- `go -C portal test ./...` after the required frontend build — PASS
- `go -C tui test ./... -skip '^(TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider|TestFirstRunAgentPresetsNext_AdvancesWithoutLiveCodexProbe)$'` — PASS
- the two excluded cursor nodes each reproduce the same `cursor.(*Model).Blink` nil panic at `firstrun.go:4236` on exact base `8c0d2c22` and on this candidate; they are recorded as inherited current-main debt, not PASS
- 10 produced build artifacts hashed in the task-local PRECHECK receipt

## Limits

- Windows artifacts were cross-compiled only. Per Jason Telegram `11734`, no Windows/WSL execution was run or claimed.
- No tag, release, upload, Homebrew mutation, website deploy, or merge is part of this PR.
