### PR TITLE
fix(install): accept all platform wheel names in kernel manifest validator

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -777,8 +777,13 @@ function Confirm-KernelManifest {
             # Validate the filename shape BEFORE it is ever used in a
             # download URL or Join-Path -- a malformed/adversarial filename
             # (path separators, traversal) is rejected here rather than
-            # relying on downstream code to handle it safely.
-            if ([string]::IsNullOrEmpty($art.filename) -or $art.filename -notmatch '^lingtai-[0-9A-Za-z_.+!-]+-(cp3(1[1-3]))-\1-win_amd64\.whl$') {
+            # relying on downstream code to handle it safely. This is a SAFETY
+            # check, not a platform gate: the kernel release manifest carries
+            # win_amd64, macosx_*, and manylinux_* wheels together, and every
+            # one must pass. Windows-only selection happens later in
+            # Select-KernelWheel, which matches the venv's exact
+            # cp311/312/313-win_amd64 tag.
+            if ([string]::IsNullOrEmpty($art.filename) -or $art.filename -notmatch '^lingtai-[0-9A-Za-z_.+!-]+-(cp3(1[1-3]))-\1-[0-9A-Za-z_.+-]+\.whl$') {
                 Fail "invalid kernel release manifest: wheel artifact has an invalid filename '$($art.filename)'"
             }
             if ($art.sha256 -notmatch '^[0-9a-f]{64}$') {


### PR DESCRIPTION
## What & why

Real Windows installs fail with: `error: invalid kernel release manifest: wheel artifact has an invalid filename 'lingtai-0.19.0-cp311-cp311-macosx_10_12_x86_64.whl'`.

The kernel release manifest legitimately carries win_amd64, macosx_*, and manylinux_* wheels together. `Confirm-KernelManifest` validates EVERY wheel artifact, but its filename regex hard-coded `-win_amd64\.whl$` — so the first non-Windows wheel in the manifest (e.g. `macosx_10_12_x86_64`) failed the whole manifest, even though the Windows wheel the install actually needs is present and exact.

This also blocks every Windows installer contract suite run in CI (Windows Installer Smoke has been red for days on this same check).

## Change (install.ps1 only, +7/-2)

The wheel-filename validation is now a SAFETY check only (no path separators/traversal, sane components), matching the comment's stated purpose. Platform selection is deliberately NOT done here — `Select-KernelWheel` already matches the venv's exact `cp311/312/313-win_amd64` tag later.

## Validation

- Regex accepts every real wheel in the v0.19.0 kernel manifest (macosx_10_12_x86_64, macosx_11_0_arm64, manylinux_2_17_*_aarch64/x86_64, win_amd64).
- `Select-KernelWheel` still finds exactly one `cp311-cp311-win_amd64` wheel.
- PowerShell parser: 0 errors.
