### PR TITLE
fix(install): pause on success so the window does not vanish after the download

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2207,6 +2207,18 @@ function Invoke-Main {
 
 try {
     Invoke-Main
+    # Same transient-console problem as the failure path: when launched by
+    # double-click / shortcut / Start-Process / `curl | iex`, `exit 0` closes the
+    # window the instant the install finishes. On a fast machine steps 3-7
+    # complete in under a second after the big download, so the window vanishing
+    # right after the download reads as a crash ("闪退") even though the
+    # install succeeded. Only pause for a real interactive console; piped/
+    # automated invocations stay non-blocking.
+    if ($Host.Name -eq 'ConsoleHost' -and -not [Console]::IsOutputRedirected) {
+        Write-Host ""
+        Write-Host "Installation complete. Press Enter to close this window..." -ForegroundColor DarkGray
+        [void][Console]::ReadLine()
+    }
     exit 0
 } catch {
     # The specific fail-loud message was already emitted to the error stream by


### PR DESCRIPTION
## What & why

Users launching install.ps1 from a transient console (double-click / shortcut / `curl | iex`) still see the window vanish right after the big zip download. On a fast machine, steps 3-7 complete in under a second once the archive is downloaded, then `exit 0` closes the console — so a **successful** install reads as a crash ("闪退").

The previous fix (#773) only paused on the failure path; the success path had no pause.

## Change (install.ps1 only, +12)

Add the same interactive pause on the success path before `exit 0`: `Installation complete. Press Enter to close this window...` — only when running in a real interactive console (ConsoleHost + stdout not redirected), so piped/automated invocations stay non-blocking.

## Validation

- PowerShell parser: 0 errors.
- Behavior identical to the failure-path pause (same guard, opposite message).
