### PR TITLE
feat(tui): render LingTai-protocol tool calls as tool.action_name

### DIFF
--- a/tui/internal/fs/session.go
+++ b/tui/internal/fs/session.go
@@ -1980,6 +1980,13 @@ func extractSessionEventText(entry map[string]interface{}, eventType string) str
 		args, _ := entry["tool_args"].(string)
 		if args == "" {
 			if argsMap, ok := entry["tool_args"].(map[string]interface{}); ok {
+				// LingTai tool protocol (LTP v2): args carry an explicit
+				// "action" field. Render the tool as tool.action_name instead
+				// of the full args JSON, and change nothing else about the
+				// tool_call display (timestamp, color, truncation, body layout).
+				if action, ok := argsMap["action"].(string); ok && action != "" {
+					return fmt.Sprintf("%s.%s", name, action)
+				}
 				data, _ := json.Marshal(argsMap)
 				args = string(data)
 			}

--- a/tui/internal/fs/tool_call_render_test.go
+++ b/tui/internal/fs/tool_call_render_test.go
@@ -1,0 +1,77 @@
+package fs
+
+import (
+	"testing"
+)
+
+// TestExtractSessionEventTextToolCallLTP renders LingTai-protocol tool calls as
+// tool.action_name when the args carry an explicit action field, and leaves
+// every other tool_call shape untouched.
+func TestExtractSessionEventTextToolCallLTP(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]interface{}
+		want string
+	}{
+		{
+			name: "ltp-v2-args-with-action",
+			raw: map[string]interface{}{
+				"tool_name": "shell",
+				"tool_args": map[string]interface{}{
+					"action": "run",
+					"input":  map[string]interface{}{"command": "ls"},
+				},
+			},
+			want: "shell.run",
+		},
+		{
+			name: "ltp-v2-nested-args-with-action",
+			raw: map[string]interface{}{
+				"tool_name": "file",
+				"tool_args": map[string]interface{}{
+					"action": "read",
+					"input":  map[string]interface{}{"file_path": "/tmp/x"},
+				},
+			},
+			want: "file.read",
+		},
+		{
+			name: "non-ltp-map-args-without-action",
+			raw: map[string]interface{}{
+				"tool_name": "web",
+				"tool_args": map[string]interface{}{
+					"query": "hello",
+				},
+			},
+			want: `web({"query":"hello"})`,
+		},
+		{
+			name: "string-args-pass-through",
+			raw: map[string]interface{}{
+				"tool_name": "bash",
+				"tool_args": "echo hi",
+			},
+			want: "bash(echo hi)",
+		},
+		{
+			name: "empty-action-keeps-json",
+			raw: map[string]interface{}{
+				"tool_name": "shell",
+				"tool_args": map[string]interface{}{
+					"action": "",
+					"input":  map[string]interface{}{"command": "ls"},
+				},
+			},
+			want: `shell({"action":"","input":{"command":"ls"}})`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSessionEventText(tt.raw, "tool_call")
+			if got != tt.want {
+				t.Errorf("extractSessionEventText(tool_call) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Simple TUI rendering change: when a tool_call's args follow the **LingTai tool protocol** (LTP v2) — i.e. the args object carries an explicit \"action"\ field — render the tool as **\	ool.action_name\** (e.g. \shell.run\, \ile.read\) instead of the full args JSON. Nothing else about the tool_call display changes.

## Motivation

The kernel emits every built-in tool call with an explicit \ction\ field in \	ool_args\ (e.g. \{"action": "run", "input": {...}}\). Showing \[tool_call] shell({"action":"run","input":{"async":false,"command":"..."}})\ buries the actual action. \[tool_call] shell.run\ is the meaningful signal at a glance.

## Change

In \	ui/internal/fs/session.go\ \xtractSessionEventText\ \	ool_call\ case:
- If \	ool_args\ is a map with a non-empty \ction\ string → return \
ame.action\.
- Otherwise → existing behavior unchanged (map args JSON-serialized as \
ame({...})\, string args pass through as \
ame(args)\).

Timestamp, color, truncation, and body-layout behavior are untouched.

## Tests

New \	ui/internal/fs/tool_call_render_test.go\ covers: LTP args with action (\shell.run\ / \ile.read\), non-LTP map args (unchanged JSON), string args (pass through), and empty-action (falls back to JSON). All pass; full \internal/fs\ suite has no new failures (one pre-existing Windows file-lock test failure unrelated to this change).