### PR TITLE
fix(tui): make codex OAuth tests pass and stop polluting home on Windows

### DIFF
--- a/tui/internal/tui/codex_auth_active_test.go
+++ b/tui/internal/tui/codex_auth_active_test.go
@@ -8,15 +8,16 @@ import (
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
 
-// withTempCodexHome points $HOME at a fresh temp dir so preset.List/Save (which
-// resolve presets/saved under os.UserHomeDir) and codexAuthRefForPath (which
-// home-shortens absolute paths) operate against the temp tree, never the real
-// user's presets or credentials. Returns the temp home and the matching
-// globalDir (~/.lingtai-tui) the production code passes around.
+// withTempCodexHome points the user home at a fresh temp dir so preset.List/Save
+// (which resolve presets/saved under os.UserHomeDir) and codexAuthRefForPath
+// (which home-shortens absolute paths) operate against the temp tree, never the
+// real user's presets or credentials. The redirect goes through setTestHome so
+// it also covers Windows, where os.UserHomeDir reads USERPROFILE and ignores
+// HOME entirely. Returns the temp home and the matching globalDir
+// (~/.lingtai-tui) the production code passes around.
 func withTempCodexHome(t *testing.T) (home, globalDir string) {
 	t.Helper()
-	home = t.TempDir()
-	t.Setenv("HOME", home)
+	home = tempTestHome(t)
 	globalDir = filepath.Join(home, ".lingtai-tui")
 	if err := os.MkdirAll(globalDir, 0o755); err != nil {
 		t.Fatalf("mkdir globalDir: %v", err)

--- a/tui/internal/tui/codex_auth_store_test.go
+++ b/tui/internal/tui/codex_auth_store_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -164,8 +165,18 @@ func TestSaveCodexCredentialLabelPreservesTokensAndClears(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat token file: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("token file mode = %o, want 0600", info.Mode().Perm())
+	// The intent is "saveCodexCredentialLabel rewrites the file without widening
+	// its permissions". Windows has no POSIX permission bits: access is governed
+	// by ACLs, os.WriteFile's mode argument only decides read-only vs writable,
+	// and Go reports 0666 for any writable file. Assert the restrictive 0600 on
+	// the platforms that can actually enforce it, and the value Windows really
+	// produces there, so the check stays meaningful instead of always failing.
+	wantPerm := os.FileMode(0o600)
+	if runtime.GOOS == "windows" {
+		wantPerm = 0o666
+	}
+	if info.Mode().Perm() != wantPerm {
+		t.Fatalf("token file mode = %o, want %o", info.Mode().Perm(), wantPerm)
 	}
 
 	if _, err := saveCodexCredentialLabel(path, "   "); err != nil {

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/anthropics/lingtai-tui/i18n"
@@ -860,6 +861,13 @@ func TestPresetKeyNext_AdvancesWithoutLiveProbeForAPIKeyProvider(t *testing.T) {
 			},
 		},
 		presetKeyInput: keyInput,
+		// Pressing Next advances into enterCapabilities → enterAgentNameDir,
+		// which focuses nameInput and blurs dirInput. A zero-value
+		// textinput.Model has a nil cursor context, so Focus() panics; the
+		// production constructor builds both with textinput.New(). Mirror it
+		// here rather than leaving the literal half-initialized.
+		nameInput: textinput.New(),
+		dirInput:  textinput.New(),
 	}
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -897,6 +905,10 @@ func TestFirstRunAgentPresetsNext_AdvancesWithoutLiveCodexProbe(t *testing.T) {
 		presetDefaultIdx: 0,
 		presetCfgCursor:  2, // row 0, Back 1, Next 2
 		cursor:           0,
+		// Same reason as above: advancing runs enterAgentNameDir, which focuses
+		// nameInput — a zero-value textinput.Model would panic there.
+		nameInput: textinput.New(),
+		dirInput:  textinput.New(),
 	}
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -961,7 +973,7 @@ func TestPresetEditorCommit_KeySaveErrorSurfacesAndDoesNotSavePreset(t *testing.
 	// to preset.Save, it would write under ~/.lingtai-tui/presets/saved.
 	// Point HOME at a temp dir so we can assert nothing was written there.
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	m := FirstRunModel{
 		step:         stepPickPreset,
 		globalDir:    dir,

--- a/tui/internal/tui/launcher_test.go
+++ b/tui/internal/tui/launcher_test.go
@@ -121,7 +121,7 @@ func TestProbeNoProjectPure_FailsClosedOnNonNotExistError(t *testing.T) {
 // never mkdirs ~/.lingtai-tui, in contrast to GlobalDir/EnsureGlobalDir.
 func TestGlobalDirPath_NeverCreatesDirectory(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 
 	path, err := config.GlobalDirPath()
 	if err != nil {
@@ -223,7 +223,7 @@ func TestListRegisteredProjects_NeverPrunes(t *testing.T) {
 // test (and every earlier one) proves both.
 func TestLauncherRootModel_CreateEntryDoesNotTouchExistingConfigFile(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	globalDir := filepath.Join(home, ".lingtai-tui")
 	if err := os.MkdirAll(globalDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -285,7 +285,7 @@ func TestLauncherRootModel_CreateEntryDoesNotTouchExistingConfigFile(t *testing.
 func buildDraftModel(t *testing.T) (FirstRunModel, string, string) {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	projectRoot := t.TempDir()
 	globalDir := filepath.Join(home, ".lingtai-tui")
 	draft := NewProjectDraft(projectRoot)
@@ -340,7 +340,7 @@ func TestLauncherPrelude_ThemeLanguageDoNotPersist(t *testing.T) {
 		_ = i18n.SetLang("en")
 	})
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	projectRoot := t.TempDir()
 	globalDir := filepath.Join(home, ".lingtai-tui")
 
@@ -444,7 +444,7 @@ func TestDraftFirstRun_PresetEditorCommitDoesNotPersist(t *testing.T) {
 // byte-for-byte while a localized "blocked" status is shown.
 func TestDraftFirstRun_DeleteKeyNeverDeletesSavedPreset(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 
 	savedPreset := preset.Preset{
 		Name: "my-saved-preset",
@@ -675,7 +675,7 @@ func TestDraftFirstRun_EmptyPresetEditorKeyDoesNotDeleteSharedKey(t *testing.T) 
 // a synthetic direct field mutation).
 func TestDraftFirstRun_CodexDeleteBlockedForPreExistingAuth(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	globalDir := filepath.Join(home, ".lingtai-tui")
 	if err := os.MkdirAll(globalDir, 0o755); err != nil {
 		t.Fatalf("mkdir globalDir: %v", err)
@@ -1057,7 +1057,7 @@ func TestDraftFirstRun_BackButtonAtEntryStepEmitsCancelMsg(t *testing.T) {
 // to the decision page, and discard/reset the old draft."
 func TestLauncherRootModel_CancelReturnsToChooseAndDiscardsDraft(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	projectRoot := t.TempDir()
 	globalDir := filepath.Join(home, ".lingtai-tui")
 
@@ -1145,7 +1145,7 @@ func TestLauncherRootModel_AppliesPersistedThemeAndLanguageAndKeepsPreludeChoice
 	})
 
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	projectRoot := t.TempDir()
 	globalDir := filepath.Join(home, ".lingtai-tui")
 	if err := os.MkdirAll(globalDir, 0o755); err != nil {
@@ -1619,7 +1619,7 @@ func TestLauncherWelcomeScreen_MatchesCanonicalFirstRunWelcome(t *testing.T) {
 		SetThemeByName(DefaultThemeName)
 		_ = i18n.SetLang("en")
 	})
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t, t.TempDir())
 	projectRoot := filepath.Join(t.TempDir(), strings.Repeat("long-project-segment-", 8))
 	m := NewLauncherRootModel(projectRoot, filepath.Join(t.TempDir(), ".lingtai-tui"), "")
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
@@ -1699,7 +1699,7 @@ func TestLauncherStagingRootViewReservesFooter(t *testing.T) {
 		SetThemeByName(DefaultThemeName)
 		_ = i18n.SetLang("en")
 	})
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t, t.TempDir())
 	stagingRoot := t.TempDir()
 	longPath := filepath.Join(stagingRoot, strings.Repeat("路径-", 24)+"e\u0301-final")
 	longError := strings.Repeat("discard-error-", 24) + "权限 denied"
@@ -1751,7 +1751,7 @@ func assertLauncherScreenWidth(t *testing.T, content string, width int) {
 // root preserve the no-write guarantee while covering the real handoff.
 func TestLauncherRootModel_CreateReviewCtrlCRecordsCancel(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	projectRoot := t.TempDir()
 	globalDir := filepath.Join(home, ".lingtai-tui")
 
@@ -1789,7 +1789,7 @@ func TestLauncherRootModel_CreateReviewCtrlCRecordsCancel(t *testing.T) {
 // contract at the production dispatcher boundary: Esc backs one level,
 // while q and Ctrl+C cancel from every launcher-owned browsing screen.
 func TestLauncherKeyboardContract_ThroughRootUpdate(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t, t.TempDir())
 	newRoot := func() LauncherRootModel {
 		m := NewLauncherRootModel(t.TempDir(), filepath.Join(t.TempDir(), ".lingtai-tui"), "")
 		m.width, m.height = 80, 24

--- a/tui/internal/tui/login_test.go
+++ b/tui/internal/tui/login_test.go
@@ -71,7 +71,7 @@ func TestLoginModel_DelTwoPressDeletesCodex(t *testing.T) {
 
 func TestCodexOAuthImpactMessageCountsSavedPresetsOnly(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	savedDir := filepath.Join(preset.PresetsDir(), "saved")
 	templateDir := filepath.Join(preset.PresetsDir(), "templates")
 	if err := os.MkdirAll(savedDir, 0o755); err != nil {

--- a/tui/internal/tui/project_create_test.go
+++ b/tui/internal/tui/project_create_test.go
@@ -46,7 +46,7 @@ func newTestDraft(t *testing.T) (*ProjectDraft, string) {
 func testCreateOptions(t *testing.T, expectedProjectRoot string) CreateOptions {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	return CreateOptions{
 		GlobalDir:           filepath.Join(home, ".lingtai-tui"),
 		ExpectedProjectRoot: expectedProjectRoot,

--- a/tui/internal/tui/recipe_draft_test.go
+++ b/tui/internal/tui/recipe_draft_test.go
@@ -138,6 +138,10 @@ func TestRunProjectCreate_AppliesEmbeddedRecipeWithoutGlobalBootstrap(t *testing
 }
 
 func TestRecipePreviewDoesNotSubstituteEmbeddedForMissingDiskRecipe(t *testing.T) {
+	// preset.Bootstrap ignores globalDir when refreshing templates: it writes to
+	// os.UserHomeDir()/.lingtai-tui/presets/templates. Without this redirect the
+	// test drops 12 template files into the developer's real home on every run.
+	setTestHome(t, t.TempDir())
 	globalDir := filepath.Join(t.TempDir(), "global")
 	if err := preset.Bootstrap(globalDir); err != nil {
 		t.Fatalf("bootstrap disk recipes: %v", err)

--- a/tui/internal/tui/recipe_draft_test.go
+++ b/tui/internal/tui/recipe_draft_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewDraftFirstRunModel_FreshHomeShowsEmbeddedRecipesWithoutWrites(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	globalDir := filepath.Join(home, ".lingtai-tui")
 	baseDir := filepath.Join(t.TempDir(), ".lingtai")
 

--- a/tui/internal/tui/testhome_test.go
+++ b/tui/internal/tui/testhome_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// setTestHome redirects the user's home directory to dir for the duration of
+// the test, on every platform.
+//
+// t.Setenv("HOME", dir) alone is NOT enough. The code under test resolves the
+// home directory through os.UserHomeDir() — preset.PresetsDir/SavedDir,
+// config.GlobalDirPath, and codexAuthRefForPath all do — and os.UserHomeDir is
+// platform-specific:
+//
+//   - unix/darwin: $HOME
+//   - windows:     $USERPROFILE ($HOME is never consulted)
+//   - plan9:       $home
+//
+// So on Windows a HOME-only redirect is a silent no-op: every test in the
+// package reads and writes the *real* %USERPROFILE%\.lingtai-tui tree, which
+// both pollutes the developer's own presets/credentials and makes tests clobber
+// each other's state (leftover saved presets break count and consensus
+// assertions in later tests). Setting the platform's actual variables keeps the
+// redirect honest everywhere.
+//
+// t.Setenv is used throughout, so the values are restored automatically and the
+// calling test must not be parallel.
+func setTestHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("USERPROFILE", dir)
+		// os.UserHomeDir itself only reads USERPROFILE, but os/user and plenty
+		// of spawned tooling still consult HOMEDRIVE+HOMEPATH. Keep them
+		// consistent so no resolution order escapes the temp tree.
+		vol := filepath.VolumeName(dir)
+		t.Setenv("HOMEDRIVE", vol)
+		t.Setenv("HOMEPATH", strings.TrimPrefix(dir, vol))
+	case "plan9":
+		t.Setenv("home", dir)
+	}
+}
+
+// tempTestHome creates a fresh temp dir and points the user home at it via
+// setTestHome, returning the directory.
+func tempTestHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	setTestHome(t, dir)
+	return dir
+}


### PR DESCRIPTION
## Problem\nOn Windows, 8 codex OAuth tests failed: 6 because t.Setenv("HOME") does not affect os.UserHomeDir (Windows reads USERPROFILE), which both failed and polluted the real ~/.lingtai-tui/presets; 1 permission assertion 0666 vs 0600; 1 nil nameInput panic.\n\n## Fix (test-only, 8 files)\n1. New tui/internal/tui/testhome_test.go with platform-aware setTestHome/tempTestHome (HOME unix, USERPROFILE+HOMEDRIVE/HOMEPATH windows, home plan9) — withTempCodexHome and all 17 t.Setenv("HOME") sites in internal/tui route through it.\n2. Platform-aware file-mode assertion in codex_auth_store_test.go (0600 on POSIX, 0666 on Windows).\n3. Fixed nil nameInput/dirInput panic in two FirstRunModel test literals.\n\nVerified: go build OK; codex-scope tests pass; whole package passes except two pre-existing failures caused by repo-wide CRLF churn in the dirty working tree (unrelated, noted in the deliverable); GOOS=windows go vet OK.\n\n## Notes\n- Recommendation B (silent import of official ~/.codex/auth.json) was deliberately skipped: it would need to land in 4 places across 2 packages, and the TUI's rewrite paths would fork or destroy the official format and silently invalidate the user's working codex login (OpenAI rotates refresh tokens). Needs an explicit one-shot import UX instead.\n- Full write-up: /tmp/codex-oauth-fix/DELIVERABLE.md