### PR TITLE
fix(tui): bound slash palette to mail frame

### DIFF
--- a/tui/internal/tui/ANATOMY.md
+++ b/tui/internal/tui/ANATOMY.md
@@ -148,7 +148,7 @@ Screen routing is centralized in the `App` struct (`app.go`), which holds every 
 ### Non-screen shared types and helpers
 
 - **`tui/internal/tui/input.go:28-294`** — `InputModel`. Reusable compose widget with textarea, paste support, and multiline expand. Used by `MailModel`.
-- **`tui/internal/tui/palette.go:28-232`** — `PaletteModel`. Slash-command palette widget (type `/` to trigger, `/help` lists commands). Used by `MailModel` and `SettingsModel`; `DefaultCommands` includes `/notification` and `/goal` (`tui/internal/tui/palette.go:60-61`).
+- **`tui/internal/tui/palette.go:28-321`** — `PaletteModel`. Slash-command palette widget (type `/` to trigger, `/help` lists commands). Used by `MailModel`: Mail supplies child bounds; Palette owns the cursor-following visible window. `DefaultCommands` includes `/notification` and `/goal` (`tui/internal/tui/palette.go:121,123`).
 - **`tui/internal/tui/styles.go:1-471`** — Theme system: `Theme` type, `ActiveTheme()`, `SetThemeByName()`, `Color*` constants, `themedTextareaStyles()`, lipgloss rendering helpers.
 - **`tui/internal/tui/knowledge_entries.go:33-118`** — `buildAgentKnowledgeCatalogEntries`: scans `knowledge/<name>/KNOWLEDGE.md` folders (after a one-time migration of legacy `codex/codex.json` / `knowledge/knowledge.json` stores via `migrateLegacyJSONStores`), converts to `MarkdownEntry` slices for the `KnowledgeModel`.
 - **`tui/internal/tui/mailbox_entries.go:17-321`** — `buildMailboxEntries`: reads per-agent mailbox folders, converts to `MarkdownEntry` slices for the `MailboxModel`.

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -450,10 +450,6 @@ func (m *MailModel) syncViewportHeight() bool {
 	}
 	m.updateInputMaxHeight()
 	inputLines := m.input.LineCount()
-	paletteLines := 0
-	if m.input.IsPaletteActive() {
-		paletteLines = m.palette.LineCount()
-	}
 	// Direct View suppresses Main's history banners and home telemetry, so its
 	// viewport must reclaim exactly those rows while leaving Main state intact.
 	_, direct := m.currentDirectTarget()
@@ -462,6 +458,15 @@ func (m *MailModel) syncViewportHeight() bool {
 	if !direct {
 		bannerLines = m.bannerLineCount()
 		telemetryRow = m.hasHomeTelemetry()
+	}
+	// Size the palette before consuming LineCount. Mail owns the child rectangle
+	// and reserves its fixed chrome plus one mandatory transcript row; Palette
+	// owns which cursor-following command rows fit in the remaining allowance.
+	paletteMaxHeight := m.height - 2 - bannerLines - 1 - mailFooterHeight(0, inputLines, telemetryRow)
+	m.palette.SetSize(m.width, paletteMaxHeight)
+	paletteLines := 0
+	if m.input.IsPaletteActive() {
+		paletteLines = m.palette.LineCount()
 	}
 	if inputLines == m.lastInputLines && paletteLines == m.lastPaletteLines && bannerLines == m.lastBannerLines && telemetryRow == m.lastTelemetryRow {
 		return false
@@ -998,19 +1003,12 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		m.input.SetWidth(msg.Width)
 		m.updateInputMaxHeight()
 		if !m.ready {
-			inputLines := m.input.LineCount()
-			// sep(1) + input(N) + border(1) + status(1)
-			footerHeight := 1 + inputLines + 1 + 1
-			vpHeight := msg.Height - 2 - footerHeight
-			if vpHeight < 1 {
-				vpHeight = 1
-			}
 			m.viewport = viewport.New()
 			m.viewport.SetWidth(msg.Width)
-			m.viewport.SetHeight(vpHeight)
 			m.viewport.SetContent(m.renderMessages(m.visibleMessages()))
-			m.lastInputLines = inputLines
 			m.ready = true
+			m.lastInputLines = -1
+			m.syncViewportHeight()
 		} else if _, direct := m.currentDirectTarget(); direct {
 			if m.viewport.Width() != msg.Width {
 				m.directChat.mainViewportDirty = true
@@ -1567,7 +1565,6 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				// Forward typing to input, then update palette filter
 				var cmd tea.Cmd
 				m.input, cmd = m.input.Update(msg)
-				m.syncViewportHeight()
 				m.maybeShowEditorHint()
 				// Extract filter from input (text after "/")
 				val := m.input.Value()
@@ -1576,6 +1573,7 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				} else {
 					m.palette.SetFilter("")
 				}
+				m.syncViewportHeight()
 				return m, cmd
 			}
 		}
@@ -1708,9 +1706,6 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		// If input is focused, forward keys to input
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
-		if m.syncViewportHeight() && m.viewport.AtBottom() {
-			m.viewport.GotoBottom()
-		}
 		m.maybeShowEditorHint()
 		// Check if slash was typed
 		if m.input.IsPaletteActive() {
@@ -1720,6 +1715,9 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 			} else {
 				m.palette.SetFilter("")
 			}
+		}
+		if m.syncViewportHeight() && m.viewport.AtBottom() {
+			m.viewport.GotoBottom()
 		}
 		return m, cmd
 	}
@@ -2427,11 +2425,11 @@ func (m MailModel) view(showAgentRailExpandControl bool) string {
 		sepWidth = 0
 	}
 	sep := toLabel + strings.Repeat("\u2500", sepWidth)
-	var inputSection string
+	inputSection := m.input.View()
 	if m.input.IsPaletteActive() {
-		inputSection = m.palette.View() + "\n" + m.input.View()
-	} else {
-		inputSection = m.input.View()
+		if paletteView := m.palette.View(); paletteView != "" {
+			inputSection = paletteView + "\n" + inputSection
+		}
 	}
 
 	// Status bar: left = flash or dir path, right = hints

--- a/tui/internal/tui/palette.go
+++ b/tui/internal/tui/palette.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/anthropics/lingtai-tui/i18n"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // PaletteSelectMsg is sent when the user selects a command from the palette.
@@ -26,19 +27,77 @@ type Command struct {
 
 // PaletteModel is the command palette overlay.
 type PaletteModel struct {
-	commands []Command
-	filtered []Command
-	cursor   int
-	filter   string
-	width    int
+	commands    []Command
+	filtered    []Command
+	cursor      int
+	filter      string
+	width       int
+	maxHeight   int
+	windowStart int
+	bounded     bool
 }
 
 func NewPaletteModel() PaletteModel {
 	cmds := DefaultCommands()
 	return PaletteModel{
-		commands: cmds,
-		filtered: cmds,
+		commands:  cmds,
+		filtered:  cmds,
+		maxHeight: len(cmds) + 2,
 	}
+}
+
+// SetSize bounds the palette to the already-budgeted Mail child width and the
+// maximum total palette height, including its two border rows.
+func (m *PaletteModel) SetSize(width, maxHeight int) {
+	m.width = max(0, width)
+	m.maxHeight = max(0, maxHeight)
+	m.bounded = true
+	m.clampWindow()
+}
+
+func (m PaletteModel) visibleCapacity() int {
+	capacity := m.maxHeight - 2
+	if capacity < 0 {
+		return 0
+	}
+	return min(capacity, len(m.filtered))
+}
+
+func (m *PaletteModel) clampWindow() {
+	if len(m.filtered) == 0 {
+		m.cursor = 0
+		m.windowStart = 0
+		return
+	}
+	m.cursor = min(max(m.cursor, 0), len(m.filtered)-1)
+	capacity := m.visibleCapacity()
+	if capacity == 0 {
+		m.windowStart = 0
+		return
+	}
+	maxStart := len(m.filtered) - capacity
+	m.windowStart = min(max(m.windowStart, 0), maxStart)
+	if m.cursor < m.windowStart {
+		m.windowStart = m.cursor
+	} else if m.cursor >= m.windowStart+capacity {
+		m.windowStart = m.cursor - capacity + 1
+	}
+}
+
+func (m PaletteModel) visibleWindow() (int, int) {
+	capacity := m.visibleCapacity()
+	if capacity == 0 {
+		return 0, 0
+	}
+	start := min(max(m.windowStart, 0), len(m.filtered)-capacity)
+	return start, start + capacity
+}
+
+func (m PaletteModel) canRender() bool {
+	if len(m.filtered) == 0 || m.visibleCapacity() == 0 {
+		return false
+	}
+	return !m.bounded || m.width >= 4
 }
 
 // DefaultCommands returns all slash commands.
@@ -124,6 +183,8 @@ func (m *PaletteModel) ExcludeCommands(names ...string) {
 	m.commands = filtered
 	m.filtered = filtered
 	m.cursor = 0
+	m.windowStart = 0
+	m.clampWindow()
 }
 
 func (m PaletteModel) Init() tea.Cmd { return nil }
@@ -136,11 +197,13 @@ func (m PaletteModel) Update(msg tea.Msg) (PaletteModel, tea.Cmd) {
 			if m.cursor > 0 {
 				m.cursor--
 			}
+			m.clampWindow()
 			return m, nil
 		case "down":
 			if m.cursor < len(m.filtered)-1 {
 				m.cursor++
 			}
+			m.clampWindow()
 			return m, nil
 		case "enter":
 			if m.cursor < len(m.filtered) {
@@ -163,6 +226,8 @@ func (m *PaletteModel) SetFilter(filter string) {
 	if filter == "" {
 		m.filtered = m.commands
 		m.cursor = 0
+		m.windowStart = 0
+		m.clampWindow()
 		return
 	}
 
@@ -175,6 +240,8 @@ func (m *PaletteModel) SetFilter(filter string) {
 	if m.cursor >= len(m.filtered) {
 		m.cursor = max(0, len(m.filtered)-1)
 	}
+	m.windowStart = 0
+	m.clampWindow()
 }
 
 // fuzzyMatch checks for substring containment first, then character-sequence matching.
@@ -194,14 +261,15 @@ func fuzzyMatch(cmd, filter string) bool {
 
 // LineCount returns the terminal lines the palette occupies (0 if empty).
 func (m PaletteModel) LineCount() int {
-	if len(m.filtered) == 0 {
+	if !m.canRender() {
 		return 0
 	}
-	return len(m.filtered) + 2 // border top + commands + border bottom
+	start, end := m.visibleWindow()
+	return end - start + 2 // border top + visible commands + border bottom
 }
 
 func (m PaletteModel) View() string {
-	if len(m.filtered) == 0 {
+	if !m.canRender() {
 		return ""
 	}
 
@@ -211,16 +279,21 @@ func (m PaletteModel) View() string {
 		BorderForeground(ColorSubtle).
 		Padding(0, 1)
 
-	for idx, cmd := range m.filtered {
+	start, end := m.visibleWindow()
+	for idx := start; idx < end; idx++ {
+		cmd := m.filtered[idx]
 		cursor := "  "
 		if idx == m.cursor {
 			cursor = "> "
 		}
 		name := "/" + cmd.Name
 		desc := i18n.T(cmd.Description)
-		line := cursor + lipgloss.NewStyle().Bold(true).Foreground(ColorAccent).Render(padRight(name, 12)) + StyleSubtle.Render(desc)
+		line := cursor + lipgloss.NewStyle().Bold(true).Foreground(ColorAccent).Render(padRightCells(name, 12)) + StyleSubtle.Render(desc)
+		if m.bounded {
+			line = fitPaletteLine(line, m.width-4)
+		}
 		b.WriteString(line)
-		if idx < len(m.filtered)-1 {
+		if idx < end-1 {
 			b.WriteString("\n")
 		}
 	}
@@ -228,9 +301,21 @@ func (m PaletteModel) View() string {
 	return border.Render(b.String())
 }
 
-func padRight(s string, width int) string {
-	if len(s) >= width {
+func padRightCells(s string, width int) string {
+	stringWidth := lipgloss.Width(s)
+	if stringWidth >= width {
 		return s + " "
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", width-stringWidth)
+}
+
+func fitPaletteLine(line string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	line = ansi.Truncate(line, width, "")
+	if padding := width - lipgloss.Width(line); padding > 0 {
+		line += strings.Repeat(" ", padding)
+	}
+	return line
 }

--- a/tui/internal/tui/palette_test.go
+++ b/tui/internal/tui/palette_test.go
@@ -1,0 +1,290 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/anthropics/lingtai-tui/i18n"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestSlashPaletteFitsFrameAndScrollsSelection(t *testing.T) {
+	originalLang := i18n.Lang()
+	t.Cleanup(func() { _ = i18n.SetLang(originalLang) })
+	if err := i18n.SetLang("en"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, size := range []struct {
+		width  int
+		height int
+	}{
+		{width: 80, height: 24},
+		{width: 60, height: 20},
+	} {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			app := mailLayoutApp(t)
+			app.mail.initialLoading = false
+
+			model, _ := app.Update(tea.WindowSizeMsg{Width: size.width, Height: size.height})
+			app = model.(App)
+			model, _ = app.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+			app = model.(App)
+
+			content := app.View().Content
+			if got := lipgloss.Height(content); got > size.height {
+				t.Errorf("slash palette frame height = %d, want <= terminal height %d", got, size.height)
+			}
+			maxWidth := 0
+			for _, line := range strings.Split(content, "\n") {
+				if width := lipgloss.Width(line); width > maxWidth {
+					maxWidth = width
+				}
+			}
+			if maxWidth > size.width {
+				t.Errorf("slash palette maximum line width = %d, want <= terminal width %d", maxWidth, size.width)
+			}
+
+			for range 20 {
+				model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+				app = model.(App)
+			}
+			if marked := ansi.Strip(app.View().Content); !strings.Contains(marked, "> /export") {
+				t.Errorf("selected command is not visibly marked after scrolling:\n%s", marked)
+			}
+
+			model, cmd := app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			app = model.(App)
+			if cmd == nil {
+				t.Fatal("Enter did not emit a palette selection command")
+			}
+			selected, ok := cmd().(PaletteSelectMsg)
+			if !ok {
+				t.Fatalf("Enter emitted %T, want PaletteSelectMsg", cmd())
+			}
+			if selected.Command != "export" || selected.Args != "" {
+				t.Fatalf("Enter selected %#v, want command export with no args", selected)
+			}
+		})
+	}
+}
+
+func TestMailNoMatchPaletteDoesNotAddPhantomRow(t *testing.T) {
+	originalLang := i18n.Lang()
+	t.Cleanup(func() { _ = i18n.SetLang(originalLang) })
+	if err := i18n.SetLang("en"); err != nil {
+		t.Fatal(err)
+	}
+
+	app := mailLayoutApp(t)
+	app.mail.initialLoading = false
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	app = model.(App)
+	for _, r := range "/zz" {
+		model, _ = app.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		app = model.(App)
+	}
+
+	if !app.mail.input.IsPaletteActive() {
+		t.Fatal("slash input did not leave the palette active")
+	}
+	if got := app.mail.palette.LineCount(); got != 0 {
+		t.Fatalf("no-match palette LineCount = %d, want 0", got)
+	}
+	if got := app.mail.palette.View(); got != "" {
+		t.Fatalf("no-match palette View = %q, want empty", got)
+	}
+	if got := lipgloss.Height(app.View().Content); got > 24 {
+		t.Fatalf("no-match slash frame height = %d, want <= 24", got)
+	}
+}
+
+func TestSlashPaletteFitsLocalizedMailChildWidths(t *testing.T) {
+	originalLang := i18n.Lang()
+	t.Cleanup(func() { _ = i18n.SetLang(originalLang) })
+
+	sizes := []struct {
+		terminalWidth int
+		childWidth    int
+	}{
+		{terminalWidth: 60, childWidth: 60},
+		{terminalWidth: 80, childWidth: 80},
+		{terminalWidth: 85, childWidth: 61},
+		{terminalWidth: 100, childWidth: 76},
+	}
+	for _, lang := range []string{"en", "zh", "wen"} {
+		if err := i18n.SetLang(lang); err != nil {
+			t.Fatal(err)
+		}
+		for _, size := range sizes {
+			t.Run(fmt.Sprintf("%s/%d", lang, size.terminalWidth), func(t *testing.T) {
+				app := mailLayoutApp(t)
+				app.mail.initialLoading = false
+
+				model, _ := app.Update(tea.WindowSizeMsg{Width: size.terminalWidth, Height: 24})
+				app = model.(App)
+				model, _ = app.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+				app = model.(App)
+
+				if got := app.mail.width; got != size.childWidth {
+					t.Fatalf("Mail child width = %d, want %d", got, size.childWidth)
+				}
+				assertPaletteGeometry(t, app.mail.palette, size.childWidth)
+			})
+		}
+	}
+}
+
+func TestPaletteNavigationFilterAndExclusionKeepSelectionVisible(t *testing.T) {
+	m := NewPaletteModel()
+	m.SetSize(60, 5)
+
+	for range len(DefaultCommands()) + 5 {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	assertMarkedPaletteSelection(t, m, "quit")
+	assertPaletteSelection(t, m, "quit")
+
+	for range len(DefaultCommands()) + 5 {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	}
+	assertMarkedPaletteSelection(t, m, "btw")
+	assertPaletteSelection(t, m, "btw")
+
+	m.ExcludeCommands("btw", "quit")
+	m.SetFilter("presets")
+	assertMarkedPaletteSelection(t, m, "presets")
+	assertPaletteSelection(t, m, "presets")
+
+	m.SetFilter("")
+	assertMarkedPaletteSelection(t, m, "sleep")
+	assertPaletteSelection(t, m, "sleep")
+
+	m.SetFilter("no-command-matches-this")
+	if got := m.LineCount(); got != 0 {
+		t.Fatalf("empty filter result LineCount = %d, want 0", got)
+	}
+	if got := m.View(); got != "" {
+		t.Fatalf("empty filter result View = %q, want empty", got)
+	}
+	if _, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+		t.Fatal("empty filter result emitted a selection command")
+	}
+}
+
+func TestMailPaletteAllowanceReservesVariableRows(t *testing.T) {
+	cases := []struct {
+		name               string
+		input              string
+		topBanner          bool
+		bottomBanner       bool
+		telemetry          bool
+		wantPaletteLines   int
+		wantInputLineCount int
+	}{
+		{name: "baseline", input: "/", wantPaletteLines: 17, wantInputLineCount: 1},
+		{name: "top banner", input: "/", topBanner: true, wantPaletteLines: 16, wantInputLineCount: 1},
+		{name: "telemetry", input: "/", telemetry: true, wantPaletteLines: 16, wantInputLineCount: 1},
+		{name: "multiline composer", input: "/\nsecond\nthird", wantPaletteLines: 15, wantInputLineCount: 3},
+		{name: "all variable rows", input: "/\nsecond\nthird", topBanner: true, bottomBanner: true, telemetry: true, wantPaletteLines: 12, wantInputLineCount: 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := mailLayoutApp(t)
+			app.mail.initialLoading = false
+			model, _ := app.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+			app = model.(App)
+
+			app.mail.initialLoading = tc.topBanner
+			if tc.bottomBanner {
+				app.mail.loadedExtra = 1
+			}
+			if tc.telemetry {
+				app.mail.homeTelemetryLoaded = true
+				app.mail.homeTelemetry = homeTelemetry{contextUsage: 0.5}
+			}
+			app.mail.input.SetValue(tc.input)
+			app.mail.palette.SetFilter("")
+			app.mail.lastInputLines = -1
+			app.mail.syncViewportHeight()
+
+			if got := app.mail.input.LineCount(); got != tc.wantInputLineCount {
+				t.Fatalf("input LineCount = %d, want %d", got, tc.wantInputLineCount)
+			}
+			if got := app.mail.palette.LineCount(); got != tc.wantPaletteLines {
+				t.Fatalf("palette LineCount = %d, want %d", got, tc.wantPaletteLines)
+			}
+			if got := lipgloss.Height(app.mail.View()); got > 24 {
+				t.Fatalf("Mail frame height = %d, want <= 24", got)
+			}
+			assertPaletteGeometry(t, app.mail.palette, 80)
+		})
+	}
+}
+
+func TestSlashPaletteTinySizesDoNotPanic(t *testing.T) {
+	for _, size := range []struct {
+		width  int
+		height int
+	}{
+		{width: 0, height: 0},
+		{width: 1, height: 1},
+		{width: 3, height: 2},
+		{width: 4, height: 3},
+	} {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			app := mailLayoutApp(t)
+			app.mail.initialLoading = false
+			model, _ := app.Update(tea.WindowSizeMsg{Width: size.width, Height: size.height})
+			app = model.(App)
+			model, _ = app.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+			app = model.(App)
+			_ = app.View()
+			assertPaletteGeometry(t, app.mail.palette, size.width)
+		})
+	}
+}
+
+func assertPaletteGeometry(t *testing.T, m PaletteModel, width int) {
+	t.Helper()
+	view := m.View()
+	viewHeight := 0
+	if view != "" {
+		viewHeight = lipgloss.Height(view)
+	}
+	if got, want := viewHeight, m.LineCount(); got != want {
+		t.Fatalf("palette View height = %d, LineCount = %d", got, want)
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if got := lipgloss.Width(line); got > width {
+			t.Fatalf("palette line width = %d, want <= %d: %q", got, width, ansi.Strip(line))
+		}
+	}
+}
+
+func assertMarkedPaletteSelection(t *testing.T, m PaletteModel, command string) {
+	t.Helper()
+	marked := ansi.Strip(m.View())
+	if !strings.Contains(marked, "> /"+command) {
+		t.Fatalf("selected command /%s is not visibly marked:\n%s", command, marked)
+	}
+}
+
+func assertPaletteSelection(t *testing.T, m PaletteModel, command string) {
+	t.Helper()
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("Enter did not emit selection for /%s", command)
+	}
+	selected, ok := cmd().(PaletteSelectMsg)
+	if !ok {
+		t.Fatalf("Enter emitted %T, want PaletteSelectMsg", cmd())
+	}
+	if selected.Command != command || selected.Args != "" {
+		t.Fatalf("Enter selected %#v, want /%s with no args", selected, command)
+	}
+}


### PR DESCRIPTION
## Summary

- size the Mail slash-command palette from the actual child rectangle after root chrome/rail allocation, reserving the existing composer, footer, telemetry, and at least one transcript row
- render a cursor-following command window whose reported line count matches its visible rows, including navigation and filtered results
- fit ANSI-styled/localized command rows by terminal display cells so narrow and CJK layouts do not wrap implicitly
- omit the palette separator when an active filter has no matches, preventing a zero-row palette from adding an unbudgeted blank row

## Scope

This is the palette/layout half of the reported failure. It intentionally does not change the Mail composer's virtual/physical cursor integration; that is a separate follow-up so the two behaviors remain independently reviewable.

No command definitions or localized descriptions change.

## Validation

Authentic test-first evidence covered both defects on the real App/Mail frame:

- before implementation, an unfiltered slash palette rendered 41 rows and a 130-cell row at both 80x24 and 60x20
- before the no-match repair, real `/zz` key events produced an empty zero-line palette but a 25-row frame at 80x24

The final exact head passes:

- six focused frame, localized-width, navigation/filter, variable-row-budget, no-match, and tiny-size regressions
- all `Palette|Slash` tests
- seven existing layout/footer geometry regressions
- TUI Architecture checks
- full `internal/tui` and full module tests with only the two unchanged inherited FirstRun nil-cursor tests excluded
- `go vet ./...`, read-only gofmt, and `git diff --check`

Related: #784
