### PR TITLE
docs(readme): update Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Digital Scientist · lifelong agent · self-growing memory · durable knowledge 
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
 [![Kernel](https://img.shields.io/badge/kernel-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
 [![Site](https://img.shields.io/badge/site-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-join-%235865F2?logo=discord&logoColor=white)](https://discord.gg/8KBGVYMS)
+[![Discord](https://img.shields.io/badge/discord-join-%235865F2?logo=discord&logoColor=white)](https://discord.gg/pfc7z2TRq)
 
 </div>
 
@@ -167,7 +167,7 @@ See [`RELEASING.md`](RELEASING.md) for the release process. Areas that often nee
 
 - Website, tutorial, and release notes: <https://lingtai.ai>
 - Main repo: <https://github.com/Lingtai-AI/lingtai> · Kernel: <https://github.com/Lingtai-AI/lingtai-kernel>
-- Discord: <https://discord.gg/8KBGVYMS>
+- Discord: <https://discord.gg/pfc7z2TRq>
 - Issues: <https://github.com/Lingtai-AI/lingtai/issues> · Discussions: <https://github.com/Lingtai-AI/lingtai/discussions>
 
 For Chinese-language discussion and early testing, scan the WeChat QR below. Add the author on WeChat with the note `lingtai`; if the QR has expired, open an issue and we will refresh it.

--- a/README.wen.md
+++ b/README.wen.md
@@ -16,7 +16,7 @@
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
 [![Kernel](https://img.shields.io/badge/内核-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
 [![Site](https://img.shields.io/badge/site-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/8KBGVYMS)
+[![Discord](https://img.shields.io/badge/discord-入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/pfc7z2TRq)
 
 </div>
 
@@ -171,7 +171,7 @@ git diff --check && git status --short
 
 - 官网、教程与发布日志：<https://lingtai.ai>
 - 主仓：<https://github.com/Lingtai-AI/lingtai> · 内核：<https://github.com/Lingtai-AI/lingtai-kernel>
-- Discord：<https://discord.gg/8KBGVYMS>
+- Discord：<https://discord.gg/pfc7z2TRq>
 - Issues：<https://github.com/Lingtai-AI/lingtai/issues> · Discussions：<https://github.com/Lingtai-AI/lingtai/discussions>
 
 **微信同道群**：扫码加作者微信（备注 *lingtai*），引入测试群。此码按时更之，若已过期，请君提 issue 相告。

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,7 +11,7 @@
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
 [![Kernel](https://img.shields.io/badge/内核-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
 [![Site](https://img.shields.io/badge/site-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-加入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/8KBGVYMS)
+[![Discord](https://img.shields.io/badge/discord-加入-%235865F2?logo=discord&logoColor=white)](https://discord.gg/pfc7z2TRq)
 
 </div>
 
@@ -166,7 +166,7 @@ git diff --check && git status --short
 
 - 官网、教程与发布日志：<https://lingtai.ai>
 - 主仓库：<https://github.com/Lingtai-AI/lingtai> · 内核：<https://github.com/Lingtai-AI/lingtai-kernel>
-- Discord：<https://discord.gg/8KBGVYMS>
+- Discord：<https://discord.gg/pfc7z2TRq>
 - Issues：<https://github.com/Lingtai-AI/lingtai/issues> · Discussions：<https://github.com/Lingtai-AI/lingtai/discussions>
 
 **微信交流群**：扫码加作者微信（备注 *lingtai*），拉入测试群。二维码会定期更新，若过期请提 issue。


### PR DESCRIPTION
## Summary
- Updates the prominent Discord header badge and Community link in README.md, README.zh.md, and README.wen.md.
- All six links now use the supplied invite: https://discord.gg/pfc7z2TRq.
- Replaces the actual prior README invite (8KBGVYMS) while preserving surrounding markup and localized text.

## Validation
- git diff --check
- Exactly two target-URL occurrences in each README (six total)
- No legacy invite occurrence remains in the three changed README files
- Independent scope and localization review: ACCEPT

## Scope
This opens a reviewable documentation PR only. It does not merge or release the change.
