### PR TITLE
fix(tui): restore tool_call parameters in LTP v2 display

### DIFF
--- a/tui/internal/fs/session.go
+++ b/tui/internal/fs/session.go
@@ -1981,10 +1981,14 @@ func extractSessionEventText(entry map[string]interface{}, eventType string) str
 		if args == "" {
 			if argsMap, ok := entry["tool_args"].(map[string]interface{}); ok {
 				// LingTai tool protocol (LTP v2): args carry an explicit
-				// "action" field. Render the tool as tool.action_name instead
-				// of the full args JSON, and change nothing else about the
-				// tool_call display (timestamp, color, truncation, body layout).
+				// "action" field. Keep the readable tool.action_name prefix
+				// but DO NOT drop the parameters — the remaining args are
+				// appended so the call stays inspectable, e.g.
+				// file.read({"file_path":"/tmp/x"}) instead of file.read.
 				if action, ok := argsMap["action"].(string); ok && action != "" {
+					if params := renderLTPToolParams(argsMap); params != "" {
+						return fmt.Sprintf("%s.%s(%s)", name, action, params)
+					}
 					return fmt.Sprintf("%s.%s", name, action)
 				}
 				data, _ := json.Marshal(argsMap)
@@ -1999,6 +2003,39 @@ func extractSessionEventText(entry map[string]interface{}, eventType string) str
 		return formatToolResultEvent(entry)
 	}
 	return ""
+}
+
+// renderLTPToolParams renders the parameter portion of an LTP v2 tool_call
+// args map. It drops the "action" selector and the private "_reasoning" key,
+// unwraps the conventional "input" wrapper (which nests the real arguments),
+// and returns the remaining parameters as compact JSON. An empty result means
+// the call has no meaningful parameters beyond its action.
+func renderLTPToolParams(argsMap map[string]interface{}) string {
+	rest := make(map[string]interface{}, len(argsMap))
+	for k, v := range argsMap {
+		switch k {
+		case "action", "_reasoning":
+			continue
+		case "input":
+			if inner, ok := v.(map[string]interface{}); ok {
+				for ik, iv := range inner {
+					rest[ik] = iv
+				}
+				continue
+			}
+			rest[k] = v
+		default:
+			rest[k] = v
+		}
+	}
+	if len(rest) == 0 {
+		return ""
+	}
+	data, err := json.Marshal(rest)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 func formatToolResultEvent(entry map[string]interface{}) string {

--- a/tui/internal/fs/tool_call_render_test.go
+++ b/tui/internal/fs/tool_call_render_test.go
@@ -22,7 +22,7 @@ func TestExtractSessionEventTextToolCallLTP(t *testing.T) {
 					"input":  map[string]interface{}{"command": "ls"},
 				},
 			},
-			want: "shell.run",
+			want: `shell.run({"command":"ls"})`,
 		},
 		{
 			name: "ltp-v2-nested-args-with-action",
@@ -33,7 +33,7 @@ func TestExtractSessionEventTextToolCallLTP(t *testing.T) {
 					"input":  map[string]interface{}{"file_path": "/tmp/x"},
 				},
 			},
-			want: "file.read",
+			want: `file.read({"file_path":"/tmp/x"})`,
 		},
 		{
 			name: "non-ltp-map-args-without-action",
@@ -63,6 +63,43 @@ func TestExtractSessionEventTextToolCallLTP(t *testing.T) {
 				},
 			},
 			want: `shell({"action":"","input":{"command":"ls"}})`,
+		},
+		{
+			name: "ltp-v2-reasoning-dropped",
+			raw: map[string]interface{}{
+				"tool_name": "file",
+				"tool_args": map[string]interface{}{
+					"action":     "read",
+					"file_path":  "/tmp/x",
+					"_reasoning": "private diary text",
+				},
+			},
+			want: `file.read({"file_path":"/tmp/x"})`,
+		},
+		{
+			name: "ltp-v2-action-only-no-params",
+			raw: map[string]interface{}{
+				"tool_name": "system",
+				"tool_args": map[string]interface{}{
+					"action": "presets",
+				},
+			},
+			want: "system.presets",
+		},
+		{
+			name: "ltp-v2-multi-input-keys",
+			raw: map[string]interface{}{
+				"tool_name": "file",
+				"tool_args": map[string]interface{}{
+					"action": "edit",
+					"input": map[string]interface{}{
+						"file_path":  "/tmp/a.txt",
+						"old_string": "x",
+						"new_string": "y",
+					},
+				},
+			},
+			want: `file.edit({"file_path":"/tmp/a.txt","new_string":"y","old_string":"x"})`,
 		},
 	}
 


### PR DESCRIPTION
## What
Restore the tool-call **parameters** in the TUI session view for LingTai-protocol (LTP v2) tool calls.

## Why
PR #781 (commit 3172f394, Aug 2) changed LTP v2 tool_call rendering to show only `tool.action_name` (e.g. `file.read`), dropping the arguments entirely. For ~a dozen commits the TUI has shown bare tool names: no 150-char preview, no meaningful ctrl+o extended view, and no way to see what parameters an agent actually passed.

## Fix
Keep the readable `tool.action_name` prefix, but append the remaining parameters as compact JSON:
- `file.read({"file_path":"/tmp/x"})` instead of `file.read`
- Drops the private `_reasoning` key
- Unwraps the conventional LTP v2 `input` wrapper so `{"action":"run","input":{"command":"ls"}}` renders as `shell.run({"command":"ls"})`
- Non-LTP shapes unchanged: string args still `bash(echo hi)`, maps without action still render full JSON

## Tests
- `TestExtractSessionEventTextToolCallLTP` updated for the new expectations + 3 new cases (reasoning dropped, action-only, multi-input keys)
- Full suite green: `go build ./... && go test ./...` (14 packages ok)