### PR TITLE
docs(readme): fold installer edge cases into details, use GFM alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+<details>
+<summary><b>Development installer</b> — current <code>main</code> of both the TUI and kernel</summary>
+
+<br>
+
 For the explicit development installer (current `main` of both the TUI and kernel), use:
 
 ```bash
@@ -85,6 +90,8 @@ curl -fsSL https://lingtai.ai/install.sh | bash -s -- --latest
 ```
 
 It prints and records the exact full commit SHA for each repository. This mode is separate from the default stable installer and cannot be combined with `--version`, `--ref`, `--update`, `--source`, or `--skip-python`.
+
+</details>
 
 The installer covers macOS, Linux, and WSL. It installs `lingtai-tui` and `lingtai-portal`. From there, **the TUI manages everything else** — on first run it creates `.lingtai/`, provisions its own Python runtime, walks you through model/preset setup, and starts one resident scientist for the project. To upgrade later, re-run the installer (or `lingtai-tui self-update`) and restart the TUI.
 
@@ -96,10 +103,23 @@ irm https://lingtai.ai/install.ps1 | iex
 
 This resolves the latest tagged release, verifies the Windows binary archive and the pinned kernel release against their published checksums, and installs both `lingtai-tui`/`lingtai-portal` and the Python runtime venv. Pass `-SkipVenv` to install the TUI/portal binaries only. See [`RELEASING.md`](RELEASING.md) for the exact contract.
 
-For a native Windows current-main debugging install, use `.\install.ps1 -Latest`. It is amd64-only; on ARM64, use WSL2 with `install.sh --latest`. It checks Git, Go, Node.js/npm (Node 20.19+, 22.12+, or a newer major; Node 21 and Node 22.<12 are unsupported), and supported 64-bit CPython 3.11–3.13 in one pass, then uses `winget install --id <ID> --exact --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity --silent` for only the missing or unsupported prerequisite packages (`Git.Git`, `GoLang.Go`, `OpenJS.NodeJS.LTS`, and/or `Python.Python.3.13`). Successful prerequisite installs are external winget changes and are not rolled back if a later package or checkout fails; LingTai destination writes still wait until validation/build succeeds. The installer refreshes this process PATH and revalidates before pinning full `main` SHAs, building both binaries, and installing the checked-out kernel source as a non-editable local build into `%USERPROFILE%\.lingtai-tui\runtime\venv`. If winget or package policy/elevation blocks the repair, it fails with exact remediation commands. `-Latest -DryRun` reports the exact repair plan without invoking winget or writing destinations, PATH, or config. `-Latest` cannot be combined with `-Version`, `-ArchivePath`, or `-SkipVenv`. The separate website repository still needs a matching install-flow note.
+<details>
+<summary><b>Native Windows current-main debugging install</b> — <code>install.ps1 -Latest</code></summary>
 
+<br>
+
+For a native Windows current-main debugging install, use `.\install.ps1 -Latest`. It is amd64-only; on ARM64, use WSL2 with `install.sh --latest`.
+
+It checks Git, Go, Node.js/npm (Node 20.19+, 22.12+, or a newer major; Node 21 and Node 22.<12 are unsupported), and supported 64-bit CPython 3.11–3.13 in one pass, then uses `winget install --id <ID> --exact --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity --silent` for only the missing or unsupported prerequisite packages (`Git.Git`, `GoLang.Go`, `OpenJS.NodeJS.LTS`, and/or `Python.Python.3.13`). Successful prerequisite installs are external winget changes and are not rolled back if a later package or checkout fails; LingTai destination writes still wait until validation/build succeeds. The installer refreshes this process PATH and revalidates before pinning full `main` SHAs, building both binaries, and installing the checked-out kernel source as a non-editable local build into `%USERPROFILE%\.lingtai-tui\runtime\venv`. If winget or package policy/elevation blocks the repair, it fails with exact remediation commands.
+
+`-Latest -DryRun` reports the exact repair plan without invoking winget or writing destinations, PATH, or config. `-Latest` cannot be combined with `-Version`, `-ArchivePath`, or `-SkipVenv`. The separate website repository still needs a matching install-flow note.
+
+</details>
+
+> [!TIP]
 > **New here?** Follow the step-by-step [tutorial at lingtai.ai](https://lingtai.ai/en/tutorial/) — install, first task, channels, memory, and lifecycle, walked through end to end.
 
+> [!NOTE]
 > Homebrew (`brew install lingtai-ai/lingtai/lingtai-tui`) still works for existing users, but the one-line installer is the recommended path for new installs. The `lingtai` PyPI package is the Python runtime the TUI manages for you — reach for `pip` only when developing or diagnosing the kernel itself.
 
 For deeper TUI/portal update operations, install-method detection, Homebrew, and mainland-China build routing, see the bundled [`lingtai-update` skill](tui/internal/preset/skills/lingtai-update/SKILL.md).

--- a/README.wen.md
+++ b/README.wen.md
@@ -82,6 +82,11 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+<details>
+<summary><b>开发之安装</b>——TUI 与内核当前 <code>main</code></summary>
+
+<br>
+
 若欲明启 TUI 与内核当前 `main` 之开发安装，可行：
 
 ```bash
@@ -89,6 +94,8 @@ curl -fsSL https://lingtai.ai/install.sh | bash -s -- --latest
 ```
 
 此命令会显出并录下两仓库之完整提交 SHA。此模式别于默认稳定安装，不能与 `--version`、`--ref`、`--update`、`--source` 或 `--skip-python` 并用。
+
+</details>
 
 一令安装之脚本，通 macOS、Linux 与 WSL，装 `lingtai-tui` 与 `lingtai-portal`。此后**余事皆委于 TUI**——初启之时，作 `.lingtai/`，备其 Python 运行时，引君择模型与配方，并令一常驻格物者守此项目。后欲升级，重跑安装脚本（或 `lingtai-tui self-update`），再启 TUI 可也。
 
@@ -100,10 +107,23 @@ irm https://lingtai.ai/install.ps1 | iex
 
 此令解析最新之发布标签，校 Windows 二进制包与所锁内核发布之验证码，遂装 `lingtai-tui`、`lingtai-portal` 及 Python 运行时之虚环境。加 `-SkipVenv` 则唯装 TUI/portal 二进制。其详见 [`RELEASING.md`](RELEASING.md)。
 
-欲于原生 Windows 调试今之主线，可行 `.\install.ps1 -Latest`。此唯支 amd64；ARM64 宜用 WSL2 与 `install.sh --latest`。此会一次检查 Git、Go、Node.js/npm（Node 20.19+、22.12+，或更高主版本；Node 21 及 Node 22.<12 不支）与 64 位 CPython 3.11–3.13；凡缺失或版本/架构不合者，唯以 `winget install --id <ID> --exact --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity --silent` 装其所需（`Git.Git`、`GoLang.Go`、`OpenJS.NodeJS.LTS` 与/或 `Python.Python.3.13`）。前置条件装成者，乃 winget 对机身之外部变更；若后续包、检出或构建失败，不自动回滚，然 LingTai 目标目录之写入仍待验证/构建成功之后。安装器刷新当前进程 PATH 而后再验，再钉住两仓 `main` 之完整 SHA、构建两二进制，并以非 editable 之本地构建将确切内核检出装入 `%USERPROFILE%\.lingtai-tui\runtime\venv`。winget 或包之策略/提权阻其修复时，必以精确补救命令失败。`-Latest -DryRun` 只报精确修复计划，不召 winget，亦不写目标目录、PATH 或配置；`-Latest` 不得与 `-Version`、`-ArchivePath` 或 `-SkipVenv` 同用。网站仓库仍须另补相应安装说明。
+<details>
+<summary><b>原生 Windows 主线调试之安装</b>——<code>install.ps1 -Latest</code></summary>
 
+<br>
+
+欲于原生 Windows 调试今之主线，可行 `.\install.ps1 -Latest`。此唯支 amd64；ARM64 宜用 WSL2 与 `install.sh --latest`。
+
+此会一次检查 Git、Go、Node.js/npm（Node 20.19+、22.12+，或更高主版本；Node 21 及 Node 22.<12 不支）与 64 位 CPython 3.11–3.13；凡缺失或版本/架构不合者，唯以 `winget install --id <ID> --exact --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity --silent` 装其所需（`Git.Git`、`GoLang.Go`、`OpenJS.NodeJS.LTS` 与/或 `Python.Python.3.13`）。前置条件装成者，乃 winget 对机身之外部变更；若后续包、检出或构建失败，不自动回滚，然 LingTai 目标目录之写入仍待验证/构建成功之后。安装器刷新当前进程 PATH 而后再验，再钉住两仓 `main` 之完整 SHA、构建两二进制，并以非 editable 之本地构建将确切内核检出装入 `%USERPROFILE%\.lingtai-tui\runtime\venv`。winget 或包之策略/提权阻其修复时，必以精确补救命令失败。
+
+`-Latest -DryRun` 只报精确修复计划，不召 winget，亦不写目标目录、PATH 或配置；`-Latest` 不得与 `-Version`、`-ArchivePath` 或 `-SkipVenv` 同用。网站仓库仍须另补相应安装说明。
+
+</details>
+
+> [!TIP]
 > **初入灵台？** 循 [lingtai.ai 之教程](https://lingtai.ai/wen/tutorial/) 逐步而行——自安装、首务、外接诸渠、记忆与生死，首尾一贯。
 
+> [!NOTE]
 > Homebrew（`brew install lingtai-ai/lingtai/lingtai-tui`）于旧用者犹可用；然新装宜用一令之脚本。PyPI 之 `lingtai` 包者，乃 TUI 代管之 Python 运行时——唯开发或诊断内核时，方用 `pip`。
 
 欲知 TUI/portal 之深更新、安法辨识、Homebrew 与中原构建之路，读内置 [`lingtai-update` 技能](tui/internal/preset/skills/lingtai-update/SKILL.md)。

--- a/README.zh.md
+++ b/README.zh.md
@@ -77,6 +77,11 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+<details>
+<summary><b>开发版安装</b>——TUI 与内核当前 <code>main</code></summary>
+
+<br>
+
 如需显式安装 TUI 与内核当前 `main` 的开发版本，请运行：
 
 ```bash
@@ -84,6 +89,8 @@ curl -fsSL https://lingtai.ai/install.sh | bash -s -- --latest
 ```
 
 它会打印并记录两个仓库的完整提交 SHA。该模式独立于默认稳定版安装，不能与 `--version`、`--ref`、`--update`、`--source` 或 `--skip-python` 同时使用。
+
+</details>
 
 安装脚本支持 macOS、Linux 和 WSL，会装好 `lingtai-tui` 和 `lingtai-portal`。之后**其余的事都交给 TUI**——首次启动时它会创建 `.lingtai/`，准备自己的 Python 运行时，引导你配置模型/配方，并为这个项目启动一个常驻的科学家。之后升级，重新跑一遍安装脚本（或 `lingtai-tui self-update`）再重启 TUI 即可。
 
@@ -95,10 +102,23 @@ irm https://lingtai.ai/install.ps1 | iex
 
 它会解析最新的发布标签，校验 Windows 二进制压缩包与锁定的内核发布版本的校验和，并安装 `lingtai-tui`/`lingtai-portal` 及 Python 运行时虚拟环境。加上 `-SkipVenv` 可只安装 TUI/portal 二进制文件。详细契约见 [`RELEASING.md`](RELEASING.md)。
 
-若要在原生 Windows 上调试当前主线，请运行 `.\install.ps1 -Latest`。它仅支持 amd64；ARM64 请使用 WSL2 和 `install.sh --latest`。它会一次检查 Git、Go、Node.js/npm（Node 20.19+、22.12+ 或更高主版本；Node 21 及 Node 22.<12 不支持）和 64 位 CPython 3.11–3.13，然后只为缺失或不受支持的前置条件运行 `winget install --id <ID> --exact --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity --silent`（`Git.Git`、`GoLang.Go`、`OpenJS.NodeJS.LTS` 和/或 `Python.Python.3.13`）。成功安装的前置条件是外部 winget 变更；如果后续包、检出或构建失败，不会自动回滚，但 LingTai 目标目录写入仍会等到验证/构建成功之后。安装器会刷新当前进程 PATH 并重新验证，再固定两个仓库 `main` 的完整 SHA、构建两个二进制文件，并通过本地路径把准确的内核检出以非 editable 方式安装到 `%USERPROFILE%\.lingtai-tui\runtime\venv`。winget 或包策略/提权阻止修复时，会失败并给出精确补救命令。`-Latest -DryRun` 只报告精确修复计划，不调用 winget，也不写入目标目录、PATH 或配置；`-Latest` 不能与 `-Version`、`-ArchivePath` 或 `-SkipVenv` 合用。网站仓库仍需另行补充对应安装说明。
+<details>
+<summary><b>原生 Windows 主线调试安装</b>——<code>install.ps1 -Latest</code></summary>
 
+<br>
+
+若要在原生 Windows 上调试当前主线，请运行 `.\install.ps1 -Latest`。它仅支持 amd64；ARM64 请使用 WSL2 和 `install.sh --latest`。
+
+它会一次检查 Git、Go、Node.js/npm（Node 20.19+、22.12+ 或更高主版本；Node 21 及 Node 22.<12 不支持）和 64 位 CPython 3.11–3.13，然后只为缺失或不受支持的前置条件运行 `winget install --id <ID> --exact --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity --silent`（`Git.Git`、`GoLang.Go`、`OpenJS.NodeJS.LTS` 和/或 `Python.Python.3.13`）。成功安装的前置条件是外部 winget 变更；如果后续包、检出或构建失败，不会自动回滚，但 LingTai 目标目录写入仍会等到验证/构建成功之后。安装器会刷新当前进程 PATH 并重新验证，再固定两个仓库 `main` 的完整 SHA、构建两个二进制文件，并通过本地路径把准确的内核检出以非 editable 方式安装到 `%USERPROFILE%\.lingtai-tui\runtime\venv`。winget 或包策略/提权阻止修复时，会失败并给出精确补救命令。
+
+`-Latest -DryRun` 只报告精确修复计划，不调用 winget，也不写入目标目录、PATH 或配置；`-Latest` 不能与 `-Version`、`-ArchivePath` 或 `-SkipVenv` 合用。网站仓库仍需另行补充对应安装说明。
+
+</details>
+
+> [!TIP]
 > **第一次用？** 跟着 [lingtai.ai 上的教程](https://lingtai.ai/zh/tutorial/) 一步步来——安装、第一个任务、外接渠道、记忆与生命周期，从头到尾走一遍。
 
+> [!NOTE]
 > Homebrew（`brew install lingtai-ai/lingtai/lingtai-tui`）对老用户依然可用，但新安装推荐用一行安装脚本。PyPI 上的 `lingtai` 包是 TUI 代你管理的 Python 运行时——只有在开发或诊断内核本身时才需要动 `pip`。
 
 更深入的 TUI/portal 更新、安装方式检测、Homebrew 与中国大陆构建路由，见内置的 [`lingtai-update` 技能](tui/internal/preset/skills/lingtai-update/SKILL.md)。


### PR DESCRIPTION
## What changed

A layout-only pass on all three README locales (`README.md`, `README.zh.md`, `README.wen.md`). **No prose was added, removed, or reworded.**

`## Quick start` was 34 lines, of which ~26 were installer edge cases — including a single **1391-character paragraph** (797 zh / 775 wen) documenting the native-Windows `-Latest` debugging install. That buried the three-command start the section is named after.

1. **Fold two developer-only blocks into `<details>`, in place** — the `--latest` development installer and the native-Windows current-main debugging install. Nothing moves; both stay exactly where they were in the reading order. This is the same pattern this repo already used for install variants.
2. **Split the Windows `-Latest` paragraph into three** — usage/platform, what it does, flags and limits. Blank lines only; not one character of text changed.
3. **Promote the two stacked bare blockquotes to GitHub alerts** — `[!TIP]` for the tutorial pointer, `[!NOTE]` for the Homebrew note. Two adjacent quote blocks previously ran together visually.

The only new words in the diff are the four `<summary>` labels (two per file), each lifted from the sentence it now heads.

Net: `3 files changed, 63 insertions(+), 3 deletions(-)`.

## Why

The quick start is the highest-traffic section in the file and the one most likely to be read by someone who has not installed anything yet. Collapsing the Windows/dev-installer detail keeps every word available one click away while restoring the three-command path as the visible content.

## Validation

- **Content preservation, mechanically checked.** After stripping the added scaffolding (`<details>`, `<summary>`, `<br>`, `[!TIP]`, `[!NOTE]`) and all whitespace, each file is **character-identical** to its `origin/main` version. All three: `True`.
- **Rendered through GitHub's own GFM API** (`POST /markdown`, `mode: gfm`) — each file yields 2 collapsible sections, 1 tip alert, 1 note alert, and correctly syntax-highlighted code blocks inside `<details>`.
- `git diff --check` — clean.
- Rebased onto live `main` (`111e2da3`) after the base moved mid-work; none of the intervening commits touched these files.

## Distributed systems

**ANATOMY** and **CONTRACT** both checked — neither is affected. This is documentation layout only: no files, symbols, connections, state ownership, interfaces, or expected behavior changed.

## Not included (deliberately out of scope — would require moving or rewording content)

- The `[!TIP]` tutorial pointer currently sits *after* the installer detail; moving it directly below the three-command block would serve new readers better, but that is a reordering.
- The four blocks under `## Ways to work with it` are bold-lead paragraphs rather than `###` sub-headings (the TUI one runs 651 chars). Converting them would require rewriting sentences.
- No table of contents added — at ~180 lines and 8 H2s, GitHub's built-in outline covers it.

Happy to follow up on any of these as a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
