### PR TITLE
ci: delete merged PR head branches automatically

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,93 @@
+name: Delete merged PR branch
+
+# Merged pull-request head branches are never removed in this repository, so
+# `origin` has accumulated hundreds of dead refs (the overwhelming majority of
+# them heads of long-merged PRs). This workflow deletes a head branch at the
+# moment its PR merges, which is the only point where "merged, and nothing else
+# points at it" is knowable without guessing.
+#
+# `pull_request_target` (not `pull_request`) is deliberate: it runs the copy of
+# this file that lives on the base branch with a writable token, so a fork PR
+# can never substitute its own version of this workflow and inherit the delete
+# permission. The job never checks out the repository and never executes any
+# PR-authored code -- it only reads event metadata and calls the refs API.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: delete-merged-branch-${{ github.event.pull_request.number }}
+
+jobs:
+  delete-head-branch:
+    # Merged only: a PR closed without merging keeps its branch, so unfinished
+    # work is never destroyed. Same-repository heads only: a fork's branch
+    # belongs to its owner and is not ours to delete.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Delete the merged head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Git allows `$`, backticks and parentheses in ref names, so every
+          # attacker-influenceable value crosses into the script as an
+          # environment variable and is never interpolated into shell source.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # Refuse anything that could be read as a `gh` flag rather than a
+          # branch name. Fail closed: an undeleted branch is a nuisance, a
+          # wrongly deleted one is lost work.
+          case "$HEAD_REF" in
+            ""|-*)
+              echo "::warning::refusing to act on head ref '$HEAD_REF'"
+              exit 0
+              ;;
+          esac
+
+          # Long-lived integration branches stay even if one is ever merged
+          # through a PR.
+          case "$HEAD_REF" in
+            "$DEFAULT_BRANCH"|main|master|develop|gh-pages|release/*)
+              echo "Keeping protected branch '$HEAD_REF'."
+              exit 0
+              ;;
+          esac
+
+          # One branch can be the head of several PRs (a stacked branch also
+          # targeting a release base). Deleting it would force-close the others.
+          open_heads="$(gh pr list --repo "$REPO" --state open \
+            --head="$HEAD_REF" --json number --jq 'length')"
+          if [ "$open_heads" != "0" ]; then
+            echo "Keeping '$HEAD_REF': still the head of $open_heads open PR(s)."
+            exit 0
+          fi
+
+          # The branch may already be gone -- a human can delete it from the
+          # merge page, and the repository's own "automatically delete head
+          # branches" setting would win this race if it is ever enabled. Treat
+          # a missing ref as success; treat anything else as a real failure.
+          if gh api -X DELETE "repos/$REPO/git/refs/heads/$HEAD_REF" \
+              2>"$RUNNER_TEMP/delete-ref.err"; then
+            echo "Deleted '$HEAD_REF' (merged in PR #$PR_NUMBER)."
+          elif grep -qiE 'Reference does not exist|Not Found' \
+              "$RUNNER_TEMP/delete-ref.err"; then
+            echo "'$HEAD_REF' was already deleted; nothing to do."
+          else
+            cat "$RUNNER_TEMP/delete-ref.err" >&2
+            echo "::error::failed to delete '$HEAD_REF'"
+            exit 1
+          fi

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -14,6 +14,7 @@ related_files:
   - CLAUDE.md
   - .github/workflows/release.yml
   - .github/workflows/windows-installer-smoke.yml
+  - .github/workflows/delete-merged-branch.yml
   - install.sh
   - install.ps1
   - scripts/update.sh
@@ -158,6 +159,7 @@ The repo root holds two binary trees plus shared infrastructure. Each binary is 
 - **`RELEASING.md`** — Release process: tag, GitHub release, Windows asset/bundle publication, automated Homebrew tap update, manual tap fallback, and the PowerShell install path.
 - **`.github/workflows/release.yml`** — Tag-push workflow (`v*` push only), three jobs. `source-release` verifies the tag and creates the public GitHub Release without building or uploading binaries. `update-homebrew` fails closed unless the pushed tag is an exact `vX.Y.Z` (checked in its first step, before the `Lingtai-AI/homebrew-lingtai` checkout materializes `HOMEBREW_TAP_TOKEN` on the runner), then computes the GitHub tag source-tarball checksum, rewrites `lingtai-tui.rb`, and pushes the source-build formula update to that tap; the tag reaches every step as `env: TAG`, never as a `${{ }}` expression interpolated into a shell script. `windows-release` (`needs: source-release`) fails closed unless `kernel-release.json`'s pinned kernel release exists and publishes a verified `win_amd64` wheel, then cross-compiles `lingtai-tui.exe`/`lingtai-portal.exe` for `windows/amd64`, packages `lingtai-<tag>-windows-amd64.zip`+`.sha256`, generates `lingtai-bundle-manifest.json`, and uploads all three via `gh release upload` — the only job in this workflow that uploads assets. See `RELEASING.md`.
 - **`.github/workflows/windows-installer-smoke.yml`** — Runs `scripts/test-install-ps1.ps1` and `scripts/test-remove-ps1.ps1` under both Windows PowerShell 5.1 and PowerShell 7 on `windows-latest` (PR/push, no live-release dependency), plus a `windows-release-asset-smoke` job gated to `push: tags: v*` that polls the just-published release for its Windows asset and runs a real `-SkipVenv` install against it.
+- **`.github/workflows/delete-merged-branch.yml`** — Deletes a pull request's head branch when that PR merges, so merged refs stop accumulating on `origin`. Runs on `pull_request_target: closed` (base-branch definition, writable token, no checkout and no PR-authored code) and acts only when the PR actually merged and its head lives in this repository — fork heads and closed-without-merge branches are left alone, as are the default/`develop`/`gh-pages`/`release/*` branches and any branch that is still the head of another open PR. An already-deleted ref is a success, not a failure, so it composes with the repository's own "automatically delete head branches" setting rather than fighting it.
 - **`CLAUDE.md`** — Repo-specific Claude Code instructions (build commands, gotchas, sibling repos).
 
 ### `tui/` packages


### PR DESCRIPTION
## Why

`origin` currently carries **214 branches**:

| | count |
|---|---|
| head of an already-merged PR | 164 |
| head of an open PR | 3 |
| no PR at all (abandoned pushes, incl. a stray branch literally named `origin`) | 46 |
| `main` | 1 |

Roughly 95% of the ref list is dead weight. `git branch -r` is unreadable, every fetch drags refs nobody wants, and picking a new branch name means scrolling past a year of finished work. Nothing in this repository removes a head branch today.

## What this does

Adds `.github/workflows/delete-merged-branch.yml`, which deletes a pull request's head branch at the moment that PR merges — the only point where *"merged, and nothing else points at it"* is knowable without guessing.

## Why `pull_request_target`

`pull_request_target` runs the **base-branch** copy of the workflow with a writable token. Under `pull_request`, a fork PR ships its own copy of the workflow file, so anyone opening a PR could rewrite this job and inherit its delete permission.

The usual danger of `pull_request_target` is checking out and executing PR-authored code with that token. This job **checks out nothing and runs no PR code** — it reads event metadata and calls the refs API. Top-level `permissions: {}`; the single job takes `contents: write` + `pull-requests: read`.

Ref names may legally contain `$`, backticks and parentheses, so the head ref and default branch cross into the script as environment variables and are never interpolated into shell source.

## Guards — all fail closed

An undeleted branch is a nuisance; a wrongly deleted one is lost work. So:

| Situation | Behavior |
|---|---|
| PR closed **without** merging | branch kept — unfinished work survives |
| head branch lives in a **fork** | never touched — not ours to delete |
| head is default / `develop` / `gh-pages` / `release/*` | kept |
| branch is still the head of **another open PR** | kept — deleting it would force-close that PR |
| ref name could be read as a `gh` flag (`-…`) or is empty | skipped with a `::warning::` |
| ref is **already gone** | success, not failure |

That last row matters: it means this composes with the repository setting **Settings → General → "Automatically delete head branches"** rather than fighting it. If a maintainer enables that setting, this workflow simply reports "already deleted" and stays quiet.

**Which raises the honest question:** that native setting is one checkbox and needs no code. If an org owner can flip it, that is the better primary mechanism and this workflow becomes a redundant safety net. I do not have admin on this repository, so I could not read or change the setting. Two reasonable outcomes — maintainer's call:

1. **Enable the setting and merge this anyway** as a belt-and-braces layer that also refuses to delete a branch backing another open PR (something the native setting does not check).
2. **Enable the setting and close this PR.** Fully legitimate; no argument from me.

Please don't leave *both* off.

## Validation

`bash -n` and YAML parse are clean, and `cd tui && go test -run TestArchitecture ./...` passes (the new file is registered in root `ANATOMY.md` `related_files`, which `TestArchitectureDocumentsCoverEveryTrackedFile` enforces).

The delete step was extracted and executed against a mock `gh` across the full case matrix:

| head ref | open PRs | API result | outcome |
|---|---|---|---|
| `fix/foo` | 0 | ok | ✅ deleted |
| `main` | 0 | — | kept (protected), no API call |
| `release/1.0` | 0 | — | kept (protected), no API call |
| `gh-pages` | 0 | — | kept (protected), no API call |
| `feat/bar` | 2 | — | kept (open PRs), no delete call |
| `fix/gone` | 0 | 422 ref missing | ✅ treated as success |
| `fix/denied` | 0 | 403 | ❌ exit 1, error surfaced |
| `-rf` | 0 | — | skipped with warning |
| `$(touch PWNED)x` | 0 | ok | passed through literally; **no command executed** |

## Scope

This is only the forward-looking half. The ~209 branches already stranded need a separate, owner-gated sweep — filed separately so a bulk delete is never a side effect of merging a CI change.
