### PR TITLE
docs(security): check in the ruleset state that main is missing

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,27 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/release-tags.json
+++ b/.github/rulesets/release-tags.json
@@ -1,0 +1,17 @@
+{
+  "name": "release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "update" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -14,6 +14,8 @@ related_files:
   - CLAUDE.md
   - .github/workflows/release.yml
   - .github/workflows/windows-installer-smoke.yml
+  - .github/rulesets/main.json
+  - .github/rulesets/release-tags.json
   - install.sh
   - install.ps1
   - scripts/update.sh
@@ -157,6 +159,8 @@ The repo root holds two binary trees plus shared infrastructure. Each binary is 
 - **`README.md` / `README.zh.md` / `README.wen.md`** — Tri-lingual project README: concise orientation (what LingTai is, install/start, interfaces, architecture, contributing). Each links to its locale's website tutorial (`https://lingtai.ai/{en,zh,wen}/tutorial/`) for step-by-step beginner learning rather than duplicating it.
 - **`RELEASING.md`** — Release process: tag, GitHub release, Windows asset/bundle publication, automated Homebrew tap update, manual tap fallback, and the PowerShell install path.
 - **`.github/workflows/release.yml`** — Tag-push workflow (`v*` push only), three jobs. `source-release` verifies the tag and creates the public GitHub Release without building or uploading binaries. `update-homebrew` fails closed unless the pushed tag is an exact `vX.Y.Z` (checked in its first step, before the `Lingtai-AI/homebrew-lingtai` checkout materializes `HOMEBREW_TAP_TOKEN` on the runner), then computes the GitHub tag source-tarball checksum, rewrites `lingtai-tui.rb`, and pushes the source-build formula update to that tap; the tag reaches every step as `env: TAG`, never as a `${{ }}` expression interpolated into a shell script. `windows-release` (`needs: source-release`) fails closed unless `kernel-release.json`'s pinned kernel release exists and publishes a verified `win_amd64` wheel, then cross-compiles `lingtai-tui.exe`/`lingtai-portal.exe` for `windows/amd64`, packages `lingtai-<tag>-windows-amd64.zip`+`.sha256`, generates `lingtai-bundle-manifest.json`, and uploads all three via `gh release upload` — the only job in this workflow that uploads assets. See `RELEASING.md`.
+- **`.github/rulesets/`** — Intended GitHub branch/tag ruleset state as reviewable JSON (`main.json` targets `~DEFAULT_BRANCH`; `release-tags.json` makes `refs/tags/v*` immutable so the ref that triggers `release.yml` cannot be moved or deleted after publication). Rulesets are repository *settings*, so nothing in this tree applies them — an admin POSTs these files. `docs/repository-rulesets.md` owns the evidence for why they exist, the apply commands, and the read-back checks that prove a ruleset actually targets a ref. Not read by any binary.
+
 - **`.github/workflows/windows-installer-smoke.yml`** — Runs `scripts/test-install-ps1.ps1` and `scripts/test-remove-ps1.ps1` under both Windows PowerShell 5.1 and PowerShell 7 on `windows-latest` (PR/push, no live-release dependency), plus a `windows-release-asset-smoke` job gated to `push: tags: v*` that polls the just-published release for its Windows asset and runs a real `-SkipVenv` install against it.
 - **`CLAUDE.md`** — Repo-specific Claude Code instructions (build commands, gotchas, sibling repos).
 

--- a/docs/ANATOMY.md
+++ b/docs/ANATOMY.md
@@ -24,6 +24,8 @@ related_files:
   - docs/example-role.md
   - docs/headless-runtime-contract.md
   - docs/tui-agent-alignment.md
+  - docs/repository-rulesets.md
+
   - docs/plans/2026-04-18-lingtai-p2p-spec.md
   - docs/plans/design-postman-ipv6-mesh.md
   - docs/plans/tui-image-clipboard-paste.md
@@ -84,6 +86,7 @@ Human- and developer-facing documentation for the Go-side LingTai repo.
 | `cyclic-manifold-architecture.md`, `design-molt-and-network-intelligence.md`, `三魂七魄.md` | Conceptual/architectural essays behind the agent model. Background reading, not normative — the binaries' anatomies and `CONTRACT.md` are. |
 | `headless-runtime-contract.md` | The public controller contract for `lingtai-tui spawn` / `lingtai-tui list` (spawn readiness, output shape). The implementation map is `tui/internal/headless/ANATOMY.md`. |
 | `discussion-log.md`, `example-role.md` | The 2026-03-15 design-discussion log, and a worked example agent role prompt. |
+| `repository-rulesets.md` | Runbook for the branch/tag rulesets checked in under `.github/rulesets/` (root `ANATOMY.md`): why they exist, the `gh api` apply commands, and the read-back checks. Rulesets are repo settings, so this doc plus that JSON is the only in-repo record of the intended state. |
 | `22610.svg`, `三魂七魄-横版.jpeg` | Diagram/glyph assets referenced by the docs above. The braille renderings of the same 𢘐 glyph live in `assets/braille/` (root `ANATOMY.md`). |
 
 ## Connections

--- a/docs/repository-rulesets.md
+++ b/docs/repository-rulesets.md
@@ -1,0 +1,156 @@
+# Repository rulesets
+
+GitHub rulesets are per-repository *settings*, not repository *content* — nothing in
+this tree applies them. `.github/rulesets/*.json` therefore holds the intended state
+as reviewable, diffable JSON, and this document holds the commands an admin runs to
+put that state into effect and to prove it took.
+
+Keep the JSON and the live rulesets in sync: change the file in a PR, then re-apply.
+
+## Why these files exist
+
+`Lingtai-AI/lingtai` has two active branch rulesets. Both have an **empty**
+`conditions.ref_name.include`, which matches no ref, so neither has ever applied to
+anything:
+
+| id | name | rules | `ref_name.include` |
+|---|---|---|---|
+| 14453254 | `Zesen Huang` | `deletion`, `non_fast_forward` | `[]` |
+| 14481209 | `main rule` | `pull_request` | `[]` |
+
+`main` is consequently unprotected. Reproduce:
+
+```bash
+gh api repos/Lingtai-AI/lingtai/rules/branches/main      # -> []
+gh api repos/Lingtai-AI/lingtai/branches/main --jq .protected   # -> false
+```
+
+`/rules/branches/{branch}` is the authoritative "which rules actually apply to this
+ref" endpoint — it resolves repository-, organization-, and enterprise-level rulesets
+together. Two controls make its empty answer meaningful:
+
+```bash
+# Positive control: the same read on a repo that IS protected returns rules,
+# including an Organization-sourced one, so the endpoint is not being silenced
+# by a low-privilege token.
+gh api repos/github/docs/rules/branches/main \
+  --jq '[.[] | {type, ruleset_source_type}] | .[0:3]'
+
+# Negative control: [] is not self-validating — a nonexistent ref returns [] too,
+# so this result must always be read alongside the positive control.
+gh api repos/Lingtai-AI/lingtai/rules/branches/no-such-branch    # -> []
+
+# Organization-level parents ruled out: both entries are source_type Repository.
+gh api "repos/Lingtai-AI/lingtai/rulesets?includes_parents=true" \
+  --jq '[.[] | {name, source_type, target}]'
+```
+
+There is also **no tag ruleset at all** (`gh api
+"repos/Lingtai-AI/lingtai/rulesets?targets=tag" --jq length` returns `0`). Tag pushes
+are what trigger `.github/workflows/release.yml`, and a branch ruleset never covers
+tags — so nothing currently constrains the ref that drives the release pipeline.
+
+## Intended state
+
+### `main.json` — branch ruleset for the default branch
+
+This is the *existing* configuration with the one broken field repaired. It merges
+what the two current rulesets already declare into a single ruleset that actually
+targets a ref:
+
+- `conditions.ref_name.include: ["~DEFAULT_BRANCH"]` — the fix. `~DEFAULT_BRANCH` and
+  `~ALL` are the two special targets; `~ALL` would gate every feature branch, so it is
+  the wrong choice here.
+- `deletion` and `non_fast_forward` — carried over from `Zesen Huang`. Blocks
+  force-push and deletion of `main`.
+- `pull_request` — carried over from `main rule`, **parameters unchanged**, including
+  `required_approving_review_count: 0`.
+
+> **`required_approving_review_count: 0` means a PR is required but no approval is.**
+> The author can open and merge their own PR unreviewed. That is what is configured
+> today; this file preserves it rather than quietly changing policy. Raising it is a
+> one-line edit, but it is a team-size decision — on a repo where one person does
+> nearly all the pushing, `1` blocks all work until a second reviewer exists.
+
+Applying this ruleset is a real workflow change: `main` currently receives direct
+pushes, including from `github-actions[bot]`. Expect that to start failing.
+
+### `release-tags.json` — tag ruleset for `refs/tags/v*`
+
+New. Makes release tags immutable once pushed:
+
+- `deletion` — a published release tag cannot be deleted.
+- `update` and `non_fast_forward` — a published release tag cannot be moved to a
+  different commit.
+
+It deliberately does **not** include `creation`. `creation` restricts tag creation to
+bypass actors only, so with `bypass_actors: []` it would block every release. To
+restrict who may cut a release, add it together with an explicit bypass list:
+
+```json
+{ "type": "creation" }
+```
+```json
+"bypass_actors": [
+  { "actor_type": "OrganizationAdmin", "bypass_mode": "always" }
+]
+```
+
+Decide the bypass list deliberately — it is the only thing standing between the rule
+and a broken release pipeline.
+
+## Apply
+
+Requires admin on the repository. Create the new rulesets first, verify, then retire
+the two inert ones:
+
+```bash
+gh api -X POST repos/Lingtai-AI/lingtai/rulesets --input .github/rulesets/main.json
+gh api -X POST repos/Lingtai-AI/lingtai/rulesets --input .github/rulesets/release-tags.json
+```
+
+```bash
+gh api -X DELETE repos/Lingtai-AI/lingtai/rulesets/14453254   # "Zesen Huang"  (inert)
+gh api -X DELETE repos/Lingtai-AI/lingtai/rulesets/14481209   # "main rule"    (inert)
+```
+
+To update an already-applied ruleset instead of creating a duplicate, use its id:
+
+```bash
+gh api -X PUT repos/Lingtai-AI/lingtai/rulesets/<id> --input .github/rulesets/main.json
+```
+
+## Verify
+
+The branch ruleset has a direct check — this must go from `[]` to a non-empty array:
+
+```bash
+gh api repos/Lingtai-AI/lingtai/rules/branches/main \
+  --jq '[.[] | {type, ruleset_source_type}]'
+```
+
+There is no per-ref rules endpoint for tags, so verify the tag ruleset by reading it
+back and then by behavior:
+
+```bash
+gh api "repos/Lingtai-AI/lingtai/rulesets?targets=tag" \
+  --jq '[.[] | {name, enforcement}]'          # -> one active entry
+
+git push origin :refs/tags/<some-old-tag>     # -> must be rejected by the ruleset
+```
+
+Read back what GitHub actually stored, not what was sent — the API silently accepts
+some shapes it then normalizes:
+
+```bash
+gh api repos/Lingtai-AI/lingtai/rulesets/<id> --jq '{conditions, rules: [.rules[].type]}'
+```
+
+## Notes
+
+- `Lingtai-AI/homebrew-lingtai` — the tap that `release.yml` pushes to — has no
+  rulesets either. The same treatment applies there.
+- `bypass_actors` on the two existing rulesets is not readable without admin. Audit it
+  when applying: a bypass list survives a `conditions` repair and would quietly undo it.
+- A CODEOWNERS file is only load-bearing once `require_code_owner_review` is `true` in
+  the `pull_request` rule. Adding one before that changes nothing.


### PR DESCRIPTION
> **No injection here, so no danger marker.** This is a missing-control finding, not
> an exploited one. It is verified against the live API, but nothing has been proven
> to have been abused, and this PR changes no repository behavior on its own.

## TL;DR

`main` has no protection. Both active branch rulesets have an **empty**
`conditions.ref_name.include`, which matches no ref, so neither has ever applied to
anything. There is also no tag ruleset at all, so nothing constrains `refs/tags/v*` —
the ref that triggers `release.yml`.

## Problem

| id | name | rules | `ref_name.include` | effect |
|---|---|---|---|---|
| 14453254 | `Zesen Huang` | `deletion`, `non_fast_forward` | `[]` | none |
| 14481209 | `main rule` | `pull_request` | `[]` | none |

```bash
gh api repos/Lingtai-AI/lingtai/rules/branches/main            # -> []
gh api repos/Lingtai-AI/lingtai/branches/main --jq .protected  # -> false
gh api "repos/Lingtai-AI/lingtai/rulesets?targets=tag" --jq length   # -> 0
```

Both rulesets are `enforcement: active` and neither is disabled or in `evaluate` mode.
They read as protection in the settings UI and enforce nothing.

## Evidence, with controls

`/rules/branches/{branch}` is the authoritative "which rules actually apply to this
ref" endpoint — it resolves repository-, organization-, and enterprise-level rulesets
together. An empty answer from it needs two controls before it means anything, and
this PR's runbook carries both:

**Positive control** — the same endpoint, same pull-only token, against a protected
repo, returns rules including an `Organization`-sourced one. So the empty result is
not the token being silenced:

```
$ gh api repos/github/docs/rules/branches/main --jq '[.[] | {type, ruleset_source_type}] | .[0:3]'
[{"ruleset_source_type":"Organization","type":"copilot_code_review"},
 {"ruleset_source_type":"Repository","type":"deletion"},
 {"ruleset_source_type":"Repository","type":"non_fast_forward"}]
```

**Negative control** — `[]` is not self-validating; a nonexistent ref returns `[]` too.
Never cite the empty result without the positive control beside it:

```
$ gh api repos/Lingtai-AI/lingtai/rules/branches/no-such-branch
[]
```

**Org-level parents ruled out** — both entries are `source_type: Repository`, so there
is no hidden org ruleset supplying protection:

```
$ gh api "repos/Lingtai-AI/lingtai/rulesets?includes_parents=true" --jq '[.[] | {name, source_type, target}]'
[{"name":"Zesen Huang","source_type":"Repository","target":"branch"},
 {"name":"main rule","source_type":"Repository","target":"branch"}]
```

## Corrections to the original report

Two claims in the finding as first written do not survive checking, and the runbook
states the corrected versions:

- **"can be deleted"** — no. `main` is the default branch, and GitHub refuses to delete
  the current default branch regardless of rules. The `deletion` rule genuinely does not
  apply; the platform independently does.
- **"can force-push"** — this is inference, not observation. `non_fast_forward` provably
  does not apply, so nothing would stop a force-push, but no force-push to `main` has
  been observed. Direct-push, by contrast, is observed: there are commits on `main` with
  no associated pull request, dated after the `main rule` ruleset was created.

## Solution

Rulesets are repository *settings*; no in-repo change can apply them. So this PR ships
the intended state as reviewable, diffable JSON plus the commands to apply and verify
it. Nothing here executes.

**`.github/rulesets/main.json`** — today's configuration with the one broken field
repaired. The two existing rulesets' rules merged into one that actually targets a ref:

- `conditions.ref_name.include: ["~DEFAULT_BRANCH"]` — the fix. `~ALL` would gate every
  feature branch and is the wrong target here.
- `deletion` + `non_fast_forward` from `Zesen Huang`, `pull_request` from `main rule`.
- `pull_request` parameters are **byte-identical to the live ruleset**, verified by
  diffing against `gh api .../rulesets/14481209`. That includes
  `required_approving_review_count: 0`. This PR deliberately does not change policy —
  the only delta from what is configured today is `conditions`. Raising the approval
  count is a one-line edit and a team-size call, called out in the doc.

**`.github/rulesets/release-tags.json`** — new. `deletion` + `update` +
`non_fast_forward` on `refs/tags/v*`, so a published release tag cannot be moved or
deleted. It deliberately omits `creation`: `creation` restricts tag creation to bypass
actors, so with an empty `bypass_actors` it would block every release. The doc gives the
exact JSON for adding it together with a bypass list, and says why that list must be
chosen deliberately.

**`docs/repository-rulesets.md`** — the evidence above, the apply commands, and the
read-back checks.

## Gain

The intended protection state becomes reviewable in a PR instead of living only in a
settings page where an empty `include` looks identical to a working rule.

## Validation

- Both JSON files parse, carry only keys valid in a `POST /repos/{owner}/{repo}/rulesets`
  body, and use only rule `type` values from the documented set
- `pull_request` parameters diffed against live ruleset 14481209 — identical
- Every command in the runbook was executed read-only against the live API, including
  both controls
- `cd tui && go test -run 'TestArchitecture|TestRuntimeControlSurfaceAnatomyRoute' .` — ok
  (this repo's no-orphan test requires every new tracked file to be reachable via
  `related_files`; root `ANATOMY.md` and `docs/ANATOMY.md` updated accordingly)
- `git diff --check` — clean

**Not validated:** the JSON has not been POSTed to GitHub. That needs admin, which the
account preparing this PR does not have on `Lingtai-AI/lingtai`. Shape and rule-type
validity are checked against the live API schema and the existing rulesets, but
acceptance by the endpoint is unproven — read the ruleset back after applying rather
than trusting a `201`.

## Tradeoffs

- **Applying `main.json` is a real workflow change.** `main` currently receives direct
  pushes, including from `github-actions[bot]`. Those start failing. Socialize it or it
  gets reverted.
- **`.github/rulesets/` can drift from the live settings.** Nothing enforces the link.
  The doc states the rule: change the file in a PR, then re-apply.
- **`bypass_actors` on the two existing rulesets is not readable without admin.** Audit
  it while applying — a bypass list survives a `conditions` repair and would quietly
  undo it.
