### PR TITLE
feat(tui): propose self-healing config.json from .env in recovery mode

### DIFF
--- a/docs/tui-agent-alignment.md
+++ b/docs/tui-agent-alignment.md
@@ -1,0 +1,64 @@
+# TUI ↔ Agent Requirement Alignment
+
+Status: draft · 2026-08-08 · authored from the config.json recovery incident
+
+## Problem statement
+
+A LingTai network can be healthy (agents running, mail flowing, kernels alive)
+while the **TUI cannot start correctly**. When that happens the user is dropped
+into a recovery wizard that asks for API keys the system already has — because
+the TUI and the agents read credentials from **different stores**.
+
+Goal: **if an agent can run, the TUI should run too.** Where the two sides
+diverge, the doctor should diagnose the exact gap and propose the exact fix.
+
+## What an agent needs to run
+
+| Requirement | Source | Notes |
+|---|---|---|
+| `init.json` | `<net>/.lingtai/<agent>/init.json` | identity, manifest, addons, env_file |
+| API keys | `.env` via `init.json` `env_file` | `~/.lingtai-tui/.env` shared by all agents |
+| Kernel/runtime | installed kernel + venv | boot-time readiness check |
+| Addon secrets | `<agent>/.secrets/<addon>.json` | operator-supplied, fragile |
+| Heartbeat | writes on a schedule | proves liveness to peers/mail |
+
+## What the TUI needs to run
+
+| Requirement | Source | Notes |
+|---|---|---|
+| `config.json` | `~/.lingtai-tui/config.json` | UI prefs + `keys` map (API keys) |
+| API keys | `config.json` → `keys` | TUI does NOT read `.env` directly |
+| Kernel/runtime | same kernel + venv | `lingtai-tui doctor` checks bootstrap |
+| Addon secrets | `<net>/.lingtai/.secrets/*.json` (agent dirs) | same files agents use |
+| TUI binary | `~/.local/bin/lingtai-tui` | version must match kernel expectations |
+
+## Misalignment matrix
+
+| # | Divergence | Incident/risk | Fix direction |
+|---|---|---|---|
+| M1 | **API keys**: agents read `.env` (env_file); TUI reads `config.json` `keys` | 2026-08-08: reinstall wiped `config.json`, agents kept running with `.env` keys; TUI hard-blocked into API-key recovery wizard | Make `.env` the single source of truth; TUI derives/restores `config.json` from `.env` when missing (self-heal) |
+| M2 | **Version skew**: TUI binary version vs kernel expectations | Wrong-fork build reported `v0.4.36-20-g873af31` while release was `v0.12.0`; string-compare bugs misreported updates | Semver compare; doctor reports TUI vs kernel versions; verify build source |
+| M3 | **`.secrets/` fragility**: operator-supplied addon secrets deleted by config incidents | imap/feishu/whatsapp MCP declared but cannot boot after wipe | Doctor lists missing addon secrets explicitly; operator re-supply |
+| M4 | **Recovery UX is binary**: TUI either works or hard-blocks into wizard | User trapped re-typing keys that already exist | Degraded launch: TUI starts with a persistent warning banner, disables only key-dependent features, doctor reachable |
+| M5 | **Doctor coverage**: `lingtai-tui doctor` only checks update/bootstrap, not the config/env/secrets surface | Gaps like M1/M3 invisible to the existing doctor | Extend doctor with the TUI-can't-start diagnostic set |
+
+## Design direction
+
+1. **Single source of truth for API keys**: `.env` (already the agent boot source)
+   becomes canonical; `config.json` keys are derived/restored from it, never
+exclusively hand-entered. A missing `config.json` is a recoverable condition,
+not a setup event.
+2. **Blanket doctor** for "agents running but TUI can't": detect agents alive,
+   check `config.json`/`.env`/`.secrets`/runtime/version, and for each finding
+   propose the exact fix (self-heal where safe, operator action where not).
+3. **Degraded launch**: when a non-fatal requirement is missing, start the TUI
+   with clear signage and disable only the affected features; the doctor is one
+   keystroke away instead of a hard gate.
+
+## Follow-ups
+
+- [ ] PR #813: self-heal `config.json` from `.env` in the recovery wizard (M1 narrow fix)
+- [ ] Extend `lingtai-tui doctor` with the TUI-can't-start diagnostic set (M5, M3)
+- [ ] Degraded launch banner + feature gating (M4)
+- [ ] `.env` single-source refactor for TUI keys (M1 long-term)
+- [ ] Semver-aware version reporting in doctor (M2)

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -840,5 +840,8 @@
   "agent_selector.unread_failed": "Agent unread status could not be updated",
   "agent_selector.title": "Choose an agent",
   "agent_selector.hint": "↑↓ move · enter select · esc cancel",
-  "firstrun.cap_desc.web": "Search the web and read pages in one capability.\nSearch for current information, then browse a result to read its content."
+  "firstrun.cap_desc.web": "Search the web and read pages in one capability.\nSearch for current information, then browse a result to read its content.",
+  "firstrun.self_heal_proposal": "⚠ Detected %d API key(s) in ~/.lingtai-tui/.env (agents keep running) — press [s] to self-heal config.json from them",
+  "firstrun.self_heal_done": "Self-healed config.json from %d key(s) in .env. Continue to propagate to your agents.",
+  "firstrun.self_heal_failed": "Self-heal failed: %v"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -840,5 +840,8 @@
   "agent_selector.omitted": "已略 %d 不安靈使列",
   "agent_selector.unread_failed": "靈使未讀之狀未能更新",
   "agent_selector.title": "擇靈使",
-  "agent_selector.hint": "↑↓ 移 · enter 擇 · esc 罷"
+  "agent_selector.hint": "↑↓ 移 · enter 擇 · esc 罷",
+  "firstrun.self_heal_proposal": "⚠ 察見 ~/.lingtai-tui/.env 載有 %d 枚 API key（靈使尚在運行）— 按 [s] 自 .env 自癒 config.json",
+  "firstrun.self_heal_done": "已自 .env %d 枚鑰自癒 config.json。續行以佈達諸靈使。",
+  "firstrun.self_heal_failed": "自癒不成：%v"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -840,5 +840,8 @@
   "agent_selector.omitted": "已省略 %d 个不安全的智能体条目",
   "agent_selector.unread_failed": "无法更新智能体未读状态",
   "agent_selector.title": "选择智能体",
-  "agent_selector.hint": "↑↓ 移动 · enter 选择 · esc 取消"
+  "agent_selector.hint": "↑↓ 移动 · enter 选择 · esc 取消",
+  "firstrun.self_heal_proposal": "⚠ 检测到 ~/.lingtai-tui/.env 中有 %d 个 API key（agent 仍在运行）— 按 [s] 从这些 key 自愈 config.json",
+  "firstrun.self_heal_done": "已从 .env 的 %d 个 key 自愈 config.json。继续即可同步给 agent。",
+  "firstrun.self_heal_failed": "自愈失败：%v"
 }

--- a/tui/internal/config/global.go
+++ b/tui/internal/config/global.go
@@ -350,6 +350,38 @@ func readEnvLines(path string) ([]string, error) {
 	return strings.Split(content, "\n"), nil
 }
 
+// ReadEnvKeys parses ~/.lingtai-tui/.env for `KEY=VALUE` assignments and
+// returns them as an env-var-name → value map. A missing or empty file
+// returns an empty map; comment lines and empty values are ignored.
+//
+// The setup/recovery wizard uses this to propose self-healing config.json
+// from keys that already exist in .env — the .env is loaded by agents at
+// boot via init.json's env_file, so it commonly survives a partial wipe of
+// ~/.lingtai-tui while agents keep running.
+func ReadEnvKeys(globalDir string) map[string]string {
+	keys := map[string]string{}
+	lines, err := readEnvLines(EnvFilePath(globalDir))
+	if err != nil {
+		return keys
+	}
+	for _, line := range lines {
+		name, isAssign := parseEnvKey(line)
+		if !isAssign {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		val := strings.TrimSpace(line[eq+1:])
+		if val == "" {
+			continue
+		}
+		keys[name] = val
+	}
+	return keys
+}
+
 // writeEnvLines writes lines back to the .env file with a single
 // trailing newline and 0600 permissions. When the file already exists
 // its existing permission bits are preserved rather than reset to 0600,

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -244,6 +244,12 @@ type FirstRunModel struct {
 	// in setup mode to pre-fill runtime fields with the user's previously-saved
 	// values instead of the preset's defaults.
 	setupKeepInitJSON map[string]interface{}
+	// selfHealKeys are API keys recovered from ~/.lingtai-tui/.env that are
+	// missing from config.json. Populated in setup/recovery mode when the
+	// global config was lost but agents keep running; non-empty enables the
+	// 's' self-heal proposal on the preset-pick step (restores config.json
+	// from these keys instead of forcing the user to retype them).
+	selfHealKeys map[string]string
 	// Rehydration mode (agora cloned network): runs the normal first-run wizard
 	// but prefills the orchestrator name/dir from .agent.json, locks the dir
 	// (can't be edited), and adds stepPropagate at the end to propagate the
@@ -857,6 +863,27 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 	}
 	if state.Recipe == preset.RecipeCustom && state.CustomDir != "" {
 		m.recipeCustomInput.SetValue(state.CustomDir)
+	}
+
+	// Self-heal proposal: when config.json is missing (or lacks keys) but
+	// ~/.lingtai-tui/.env still carries API keys — the running agents read
+	// them at boot via env_file — offer to restore config.json from .env
+	// instead of forcing the user to retype every key (recovery scenario:
+	// a partial wipe of ~/.lingtai-tui while agents kept running).
+	cfg, _ := config.LoadConfig(globalDir)
+	if len(cfg.Keys) == 0 {
+		for envName, val := range config.ReadEnvKeys(globalDir) {
+			if !strings.HasSuffix(envName, "_API_KEY") {
+				continue
+			}
+			if _, already := cfg.Keys[envName]; already {
+				continue
+			}
+			if m.selfHealKeys == nil {
+				m.selfHealKeys = map[string]string{}
+			}
+			m.selfHealKeys[envName] = val
+		}
 	}
 
 	return m
@@ -1758,6 +1785,29 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 						}
 					}
 				}
+				return m, nil
+			case "s", "S":
+				// Self-heal proposal (setup/recovery mode): restore config.json
+				// from API keys already present in ~/.lingtai-tui/.env (they
+				// survived a partial wipe while agents kept running) instead of
+				// forcing the user to retype them.
+				if len(m.selfHealKeys) == 0 {
+					return m, nil
+				}
+				cfg, _ := config.LoadConfig(m.globalDir)
+				if cfg.Keys == nil {
+					cfg.Keys = map[string]string{}
+				}
+				for envName, val := range m.selfHealKeys {
+					cfg.Keys[envName] = val
+				}
+				if err := config.SaveConfig(m.globalDir, cfg); err != nil {
+					m.message = fmt.Sprintf(i18n.T("firstrun.self_heal_failed"), err)
+					return m, nil
+				}
+				m.existingKeys = cfg.Keys
+				m.message = fmt.Sprintf(i18n.T("firstrun.self_heal_done"), len(m.selfHealKeys))
+				m.selfHealKeys = nil
 				return m, nil
 			case "esc":
 				// Esc while a Codex login is mid-flight (or the method
@@ -2795,6 +2845,10 @@ func (m FirstRunModel) View() string {
 			header = i18n.T("setup.pick_default_preset")
 		}
 		b.WriteString("\n  " + StyleSubtle.Render(fmt.Sprintf("Step %d/%d: "+header, stepNum, total)) + "\n\n")
+		if len(m.selfHealKeys) > 0 {
+			proposal := fmt.Sprintf(i18n.T("firstrun.self_heal_proposal"), len(m.selfHealKeys))
+			b.WriteString("  " + lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214")).Render(proposal) + "\n\n")
+		}
 		if m.setupMode {
 			cursor := "  "
 			style := lipgloss.NewStyle()

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -1004,3 +1004,54 @@ func TestPresetEditorCommit_KeySaveErrorSurfacesAndDoesNotSavePreset(t *testing.
 		t.Fatalf("key save failure must not persist the preset; stat %q err = %v", savedPath, err)
 	}
 }
+
+func TestSetupModeSelfHealFromEnv(t *testing.T) {
+	i18n.SetLang("en")
+	baseDir := filepath.Join(t.TempDir(), ".lingtai")
+	globalDir := t.TempDir()
+
+	// .env carries an API key (it survived the partial wipe) plus an
+	// unrelated flag that must NOT be treated as a recoverable key.
+	envContent := "DEEPSEEK_API_KEY=sk-self-heal-test\nLINGTAI_SOUL_FLOW_ENABLED=1\n"
+	if err := os.WriteFile(filepath.Join(globalDir, ".env"), []byte(envContent), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	m := NewSetupModeModel(baseDir, globalDir, "", "test")
+	if len(m.selfHealKeys) != 1 {
+		t.Fatalf("selfHealKeys = %#v, want exactly the DEEPSEEK_API_KEY entry", m.selfHealKeys)
+	}
+	if got := m.selfHealKeys["DEEPSEEK_API_KEY"]; got != "sk-self-heal-test" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want sk-self-heal-test", got)
+	}
+	if _, ok := m.selfHealKeys["LINGTAI_SOUL_FLOW_ENABLED"]; ok {
+		t.Fatalf("selfHealKeys must not include non-key env vars: %#v", m.selfHealKeys)
+	}
+
+	// The proposal renders on the preset-pick view.
+	m.width = 120
+	m.height = 40
+	if view := m.View(); !strings.Contains(view, "self-heal config.json") {
+		t.Fatalf("preset-pick view should render the self-heal proposal:\n%s", view)
+	}
+
+	// Press 's' → config.json is restored from .env, .env stays intact.
+	m, _ = m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	cfg, err := config.LoadConfig(globalDir)
+	if err != nil {
+		t.Fatalf("load config after self-heal: %v", err)
+	}
+	if got := cfg.Keys["DEEPSEEK_API_KEY"]; got != "sk-self-heal-test" {
+		t.Fatalf("config.json DEEPSEEK_API_KEY = %q, want sk-self-heal-test; keys=%#v", got, cfg.Keys)
+	}
+	if len(m.selfHealKeys) != 0 {
+		t.Fatalf("selfHealKeys should clear after self-heal; got %#v", m.selfHealKeys)
+	}
+	envAfter, err := os.ReadFile(filepath.Join(globalDir, ".env"))
+	if err != nil {
+		t.Fatalf("read .env after self-heal: %v", err)
+	}
+	if !strings.Contains(string(envAfter), "LINGTAI_SOUL_FLOW_ENABLED=1") {
+		t.Fatalf(".env lost the unmanaged soul-flow flag:\n%s", envAfter)
+	}
+}


### PR DESCRIPTION
## Problem

A partial wipe of `~/.lingtai-tui` (e.g. after a reinstall that deletes `config.json` while agents keep running) drops the TUI's API-key store. The setup/recovery wizard currently forces the user to **retype every API key**, even though the keys survive in `~/.lingtai-tui/.env` — the file agents load at boot via `init.json`'s `env_file`.

## Fix

Detect recoverable `*_API_KEY` values in `.env` that are missing from `config.json` and render a one-shot proposal on the wizard's preset-pick step (recovery/setup mode only):

> ⚠ Detected N API key(s) in ~/.lingtai-tui/.env (agents keep running) — press [s] to self-heal config.json from them

Pressing `s` restores `config.json` from those keys (`SaveConfig` writes `config.json` and merge-preserves `.env`), then the normal wizard flow continues (keep-current preset → propagate to agents). The proposal only appears when keys are actually recoverable, and never includes non-key env vars like `LINGTAI_SOUL_FLOW_ENABLED`.

## Changes

- `internal/config/global.go`: new exported `ReadEnvKeys` helper parsing `.env` assignments
- `internal/tui/firstrun.go`: `selfHealKeys` state populated by `NewSetupModeModel`, `s` key handler on `stepPickPreset`, yellow proposal banner in the preset-pick view
- `i18n/{en,zh,wen}.json`: three new strings (proposal / done / failed)
- `internal/tui/firstrun_test.go`: `TestSetupModeSelfHealFromEnv` covering recovery detection, non-key filtering, config.json restoration, and `.env` preservation

## Test

`go test ./internal/tui/ ./internal/config/ ./i18n/ -count=1` passes. Two unrelated pre-existing failures (`*AdvancesWithoutLive*`) panic on `main` too (nil pointer in bubbles cursor.Blink) and are unchanged by this PR.
