### PR TITLE
feat(tui): align TUI key source with agents — degraded launch when config.json missing

### DIFF
--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -1,0 +1,75 @@
+---
+name: tui-runtime-contract
+contract_version: 1
+root_contract: CONTRACT.md
+related_files:
+  - internal/config/global.go
+  - internal/tui/firstrun.go
+  - internal/tui/app.go
+  - docs/tui-agent-alignment.md
+maintenance: |
+  This contract defines the TUI runtime requirements and their alignment with
+  agent requirements. Keep it reciprocal with docs/tui-agent-alignment.md and
+  with the config resolution code (ResolveKeys / ReadEnvKeys / HasAPIKeys).
+  When a startup-path requirement changes, update this contract and the doctor
+  checks that validate against it together. Bump contract_version for a
+  breaking change to the requirement classes.
+---
+# TUI Runtime Contract
+
+## Purpose
+
+Define what the TUI needs to launch and run, and how those needs align with
+what an agent needs to run. The invariant: **if an agent can run, the TUI
+should be able to launch too.** Requirements are classified so a missing item
+has a defined, programmatic response instead of an ambiguous hard gate.
+
+## Requirement classes
+
+### R1 · Project-scoped (required, sourced from the network)
+
+| Requirement | Source | Notes |
+|---|---|---|
+| Agents exist | `<project>/.lingtai/<agent>/init.json` | zero agents → real first-run setup |
+| Runtime/kernel | installed kernel + venv | readiness check; bootstrap gated on human consent |
+| Agent env | `<project>/.lingtai/<agent>/init.json` env_file | defines where agents load `.env` |
+
+### R2 · Derived from the agent source of truth (.env)
+
+| Requirement | Source | Notes |
+|---|---|---|
+| API keys | `~/.lingtai-tui/.env` (via `ResolveKeys`) | agents load this at boot; `.env` is authoritative, `config.json` keys fill gaps |
+
+### R3 · Purely additive (user-level, loss must not block launch)
+
+| Requirement | Source | Notes |
+|---|---|---|
+| `config.json` | `~/.lingtai-tui/config.json` | UI prefs + mirrored keys; missing → defaults + degraded banner |
+| Theme/language | `config.json` | default when absent |
+
+## Startup decision table
+
+| State | Decision |
+|---|---|
+| No agents in `.lingtai/` | first-run wizard (create first agent) |
+| Agents exist, `config.json` missing, `.env` has API keys | **degraded launch** — derive keys from `.env`, show persistent banner, key-dependent features limited; recovery wizard not forced |
+| Agents exist, `config.json` missing, `.env` has no keys | recovery wizard (real missing key → setup) |
+| Agents exist, everything present | normal launch |
+
+## Alignment rules
+
+1. `.env` is the single source of truth for API keys. `config.json` keys are a
+   mirror; `ResolveKeys` prefers `.env` and fills gaps from `config.json`.
+2. Losing `~/.lingtai-tui/config.json` is a degraded condition, not a setup
+   event — the TUI launches with a banner and offers self-heal.
+3. The doctor validates the startup decision table programmatically: check
+   agents present, `config.json` presence, `.env` API keys, `.secrets` for
+   declared addons, runtime/version.
+
+## Doctor checks (TUI-can't-start diagnostic set)
+
+- [x] D1 agents running (orchestrators detected)
+- [x] D2 config.json present (`ResolveKeys` configOK)
+- [x] D3 .env API keys present (`HasAPIKeys`)
+- [ ] D4 addon `.secrets` present for declared addons (follow-up)
+- [ ] D5 runtime/version skew reported (extends existing doctor)

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -843,5 +843,6 @@
   "firstrun.cap_desc.web": "Search the web and read pages in one capability.\nSearch for current information, then browse a result to read its content.",
   "firstrun.self_heal_proposal": "⚠ Detected %d API key(s) in ~/.lingtai-tui/.env (agents keep running) — press [s] to self-heal config.json from them",
   "firstrun.self_heal_done": "Self-healed config.json from %d key(s) in .env. Continue to propagate to your agents.",
-  "firstrun.self_heal_failed": "Self-heal failed: %v"
+  "firstrun.self_heal_failed": "Self-heal failed: %v",
+  "degraded.banner": "⚠ config.json missing — API keys derived from .env (agents' source). Key-dependent actions are limited; run lingtai-tui doctor or /setup to restore config.json"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -843,5 +843,6 @@
   "agent_selector.hint": "↑↓ 移 · enter 擇 · esc 罷",
   "firstrun.self_heal_proposal": "⚠ 察見 ~/.lingtai-tui/.env 載有 %d 枚 API key（靈使尚在運行）— 按 [s] 自 .env 自癒 config.json",
   "firstrun.self_heal_done": "已自 .env %d 枚鑰自癒 config.json。續行以佈達諸靈使。",
-  "firstrun.self_heal_failed": "自癒不成：%v"
+  "firstrun.self_heal_failed": "自癒不成：%v",
+  "degraded.banner": "⚠ config.json 也失 — 已自 .env 推衍 API key（靈使之真源）。依賴 key 功能受限; 行 lingtai-tui doctor 或 /setup 以復 config.json"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -843,5 +843,6 @@
   "agent_selector.hint": "↑↓ 移动 · enter 选择 · esc 取消",
   "firstrun.self_heal_proposal": "⚠ 检测到 ~/.lingtai-tui/.env 中有 %d 个 API key（agent 仍在运行）— 按 [s] 从这些 key 自愈 config.json",
   "firstrun.self_heal_done": "已从 .env 的 %d 个 key 自愈 config.json。继续即可同步给 agent。",
-  "firstrun.self_heal_failed": "自愈失败：%v"
+  "firstrun.self_heal_failed": "自愈失败：%v",
+  "degraded.banner": "⚠ config.json 丢失 — 已从 .env 推导 API key（agents 的真源）。依赖 key 的功能受限; 跑 lingtai-tui doctor 或 /setup 恢复 config.json"
 }

--- a/tui/internal/config/global.go
+++ b/tui/internal/config/global.go
@@ -382,6 +382,44 @@ func ReadEnvKeys(globalDir string) map[string]string {
 	return keys
 }
 
+// ResolveKeys returns the effective API keys the TUI should use, aligned with
+// the agents' source of truth: ~/.lingtai-tui/.env (agents load it at boot via
+// init.json env_file). config.json keys fill gaps but never override .env, so
+// the two stores cannot drift. The bool result reports whether config.json was
+// present and readable (false = keys derived purely from .env / degraded).
+func ResolveKeys(globalDir string) (keys map[string]string, configOK bool) {
+	keys = map[string]string{}
+	// config.json presence is checked explicitly: LoadConfig intentionally
+	// returns a nil error for a missing file, so err alone cannot distinguish
+	// "config.json exists" from "config.json absent".
+	_, statErr := os.Stat(filepath.Join(globalDir, "config.json"))
+	configOK = statErr == nil
+	cfg, err := LoadConfig(globalDir)
+	for name, val := range ReadEnvKeys(globalDir) {
+		keys[name] = val
+	}
+	if err == nil {
+		for name, val := range cfg.Keys {
+			if _, ok := keys[name]; !ok {
+				keys[name] = val
+			}
+		}
+	}
+	return keys, configOK
+}
+
+// HasAPIKeys reports whether the given key map contains at least one *_API_KEY
+// value. Used by startup to decide between "recoverable degraded launch" (keys
+// exist somewhere the agents already use) and "real setup" (no keys at all).
+func HasAPIKeys(keys map[string]string) bool {
+	for name, val := range keys {
+		if strings.HasSuffix(name, "_API_KEY") && val != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // writeEnvLines writes lines back to the .env file with a single
 // trailing newline and 0600 permissions. When the file already exists
 // its existing permission bits are preserved rather than reset to 0600,

--- a/tui/internal/config/global_test.go
+++ b/tui/internal/config/global_test.go
@@ -368,3 +368,69 @@ func TestLoadConfigReadOnlyPreservesModeWhileLoadConfigTightensMalformed(t *test
 		t.Fatalf("LoadConfig mode = %o, want historical 0600 migration", got)
 	}
 }
+
+func TestResolveKeysEnvAuthoritative(t *testing.T) {
+	dir := t.TempDir()
+	// .env is the agent source; config.json has a STALE value for the same key
+	// plus a key only it knows.
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DEEPSEEK_API_KEY=env-correct\nLINGTAI_SOUL_FLOW_ENABLED=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Write config.json directly (not via SaveConfig, which would merge/sync
+	// .env and mask the drift scenario we are testing).
+	cfgJSON := `{"keys": {"DEEPSEEK_API_KEY": "cfg-stale", "ZHIPU_API_KEY": "cfg-only"}}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(cfgJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, configOK := ResolveKeys(dir)
+	if !configOK {
+		t.Fatalf("configOK = false, want true (config.json exists)")
+	}
+	// .env wins for the shared key; config.json fills gaps; non-key env vars excluded.
+	if keys["DEEPSEEK_API_KEY"] != "env-correct" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want env-correct (env authoritative)", keys["DEEPSEEK_API_KEY"])
+	}
+	if keys["ZHIPU_API_KEY"] != "cfg-only" {
+		t.Fatalf("ZHIPU_API_KEY = %q, want cfg-only (config fills gaps)", keys["ZHIPU_API_KEY"])
+	}
+	// ResolveKeys returns the full resolved env (including non-key vars);
+	// callers filter API keys via HasAPIKeys or the *_API_KEY suffix.
+	if keys["LINGTAI_SOUL_FLOW_ENABLED"] != "1" {
+		t.Fatalf("LINGTAI_SOUL_FLOW_ENABLED = %q, want 1 (env vars preserved)", keys["LINGTAI_SOUL_FLOW_ENABLED"])
+	}
+	if !HasAPIKeys(keys) {
+		t.Fatalf("HasAPIKeys(%v) = false, want true", keys)
+	}
+}
+
+func TestResolveKeysMissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DEEPSEEK_API_KEY=only-env\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, configOK := ResolveKeys(dir)
+	if configOK {
+		t.Fatalf("configOK = true, want false (config.json missing)")
+	}
+	if keys["DEEPSEEK_API_KEY"] != "only-env" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want only-env", keys["DEEPSEEK_API_KEY"])
+	}
+}
+
+func TestHasAPIKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		keys map[string]string
+		want bool
+	}{
+		{"api key present", map[string]string{"DEEPSEEK_API_KEY": "sk-x"}, true},
+		{"api key empty", map[string]string{"DEEPSEEK_API_KEY": ""}, false},
+		{"no keys", map[string]string{}, false},
+		{"non-key vars only", map[string]string{"LINGTAI_SOUL_FLOW_ENABLED": "1"}, false},
+	}
+	for _, tc := range cases {
+		if got := HasAPIKeys(tc.keys); got != tc.want {
+			t.Errorf("%s: HasAPIKeys(%v) = %v, want %v", tc.name, tc.keys, got, tc.want)
+		}
+	}
+}

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -83,8 +83,13 @@ type App struct {
 	tuiConfig        config.TUIConfig
 	pendingRecipe    string
 	pendingCustomDir string
-	recoveryMode     bool   // global config lost, agents intact — setup then propagate
-	startupBanner    string // non-empty warning shown on first render
+	recoveryMode     bool // global config lost, agents intact — setup then propagate
+	// degradedConfig is true when ~/.lingtai-tui/config.json is missing but API
+	// keys were derived from .env (the agents' source of truth). The app launches
+	// normally with a persistent banner instead of a hard recovery gate;
+	// key-dependent features are gated and a self-heal is offered.
+	degradedConfig bool
+	startupBanner  string // non-empty warning shown on first render
 	// autoRefreshArmed is true while exactly one auto-refresh ticker is in
 	// flight. It guards against starting a second concurrent ticker when the
 	// feature is re-enabled or a view is re-entered. The autoRefreshTickMsg
@@ -217,7 +222,7 @@ func (a App) openProjectsView() (App, tea.Cmd) {
 // enters first-run view with a FirstRunModel constructed via
 // NewRehydrateModel, which prefills the orchestrator's name/dir and adds
 // a final stepPropagate page to copy the new init.json to every worker.
-func NewApp(globalDir, projectDir string, needsFirstRun, needsRecovery bool, orchestrators []string, tuiCfg config.TUIConfig, rehydrateOrchDir, rehydrateOrchName string) App {
+func NewApp(globalDir, projectDir string, needsFirstRun, needsRecovery, degradedConfig bool, orchestrators []string, tuiCfg config.TUIConfig, rehydrateOrchDir, rehydrateOrchName string) App {
 	// Apply persisted theme (or default).
 	SetThemeByName(tuiCfg.Theme)
 
@@ -261,6 +266,7 @@ func NewApp(globalDir, projectDir string, needsFirstRun, needsRecovery bool, orc
 			app.firstRun = NewFirstRunModel(projectDir, globalDir, hasPresets, "")
 		}
 	} else {
+		app.degradedConfig = degradedConfig
 		// Determine orchestrator
 		localSettings := LoadSettings(projectDir)
 		if len(orchestrators) == 1 {

--- a/tui/internal/tui/auto_refresh_test.go
+++ b/tui/internal/tui/auto_refresh_test.go
@@ -162,13 +162,13 @@ func TestAppAutoRefreshTickDisabledDropsAndUnarms(t *testing.T) {
 }
 
 func TestNewAppMarksStartupAutoRefreshArmed(t *testing.T) {
-	a := NewApp(t.TempDir(), t.TempDir(), false, false, nil, config.DefaultTUIConfig(), "", "")
+	a := NewApp(t.TempDir(), t.TempDir(), false, false, false, nil, config.DefaultTUIConfig(), "", "")
 	if !a.autoRefreshArmed {
 		t.Fatal("NewApp should mark auto refresh armed when Init will start the startup ticker")
 	}
 	cfg := config.DefaultTUIConfig()
 	cfg.AutoRefreshOff = true
-	disabled := NewApp(t.TempDir(), t.TempDir(), false, false, nil, cfg, "", "")
+	disabled := NewApp(t.TempDir(), t.TempDir(), false, false, false, nil, cfg, "", "")
 	if disabled.autoRefreshArmed {
 		t.Fatal("NewApp should not mark auto refresh armed when disabled")
 	}

--- a/tui/internal/tui/layout.go
+++ b/tui/internal/tui/layout.go
@@ -50,6 +50,9 @@ func (a App) topChromeRows() int {
 	if a.startupBanner != "" {
 		rows++
 	}
+	if a.degradedConfig {
+		rows++
+	}
 	if a.selectModeIndicatorActive() {
 		rows++
 	}
@@ -137,6 +140,9 @@ func (a App) topChrome() string {
 	var rows []string
 	if a.startupBanner != "" {
 		rows = append(rows, "  "+lipgloss.NewStyle().Foreground(ColorStuck).Render(a.startupBanner))
+	}
+	if a.degradedConfig {
+		rows = append(rows, "  "+lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214")).Render(i18n.T("degraded.banner")))
 	}
 	if a.selectModeIndicatorActive() {
 		rows = append(rows, a.selectModeIndicator())

--- a/tui/internal/tui/layout_test.go
+++ b/tui/internal/tui/layout_test.go
@@ -346,3 +346,29 @@ func TestNonMailViewKeepsFullTerminalWidth(t *testing.T) {
 		t.Fatalf("non-mail child width = %d, want full terminal width 73", got)
 	}
 }
+
+// TestDegradedConfigReservesChromeRow: when the app launches degraded
+// (config.json missing but API keys derived from .env), the persistent
+// warning banner reserves one top chrome row and renders the i18n text.
+func TestDegradedConfigReservesChromeRow(t *testing.T) {
+	a := App{
+		currentView:    appViewHelp,
+		help:           NewHelpModel(),
+		degradedConfig: true,
+	}
+	a.width = 80
+	a.height = 24
+
+	b := a.layoutBudget()
+	if b.TopChromeRows != 1 {
+		t.Fatalf("degraded: TopChromeRows = %d, want 1", b.TopChromeRows)
+	}
+	if b.ChildHeight != 23 {
+		t.Fatalf("degraded: ChildHeight = %d, want 23", b.ChildHeight)
+	}
+
+	chrome := a.topChrome()
+	if !strings.Contains(chrome, "config.json") {
+		t.Fatalf("degraded banner should mention config.json, got: %q", chrome)
+	}
+}

--- a/tui/main.go
+++ b/tui/main.go
@@ -403,7 +403,7 @@ func runCreatedProject(result tui.LauncherResult) {
 	lingtaiDir := filepath.Join(result.ProjectRoot, ".lingtai")
 	orchestrators := tui.DetectOrchestrators(lingtaiDir)
 	needsFirstRun := len(orchestrators) == 0
-	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, false, orchestrators, tuiCfg, "", "")
+	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, false, false, orchestrators, tuiCfg, "", "")
 	p := tea.NewProgram(app)
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -1587,14 +1587,27 @@ func prepareApp(projectDir string, inProgram bool) startupResult {
 	// config.json exists, so needsFirstRun would otherwise be false) would
 	// reach NewApp with no orchestrator to launch.
 	needsRecovery := false
+	degradedConfig := false
 	if len(orchestrators) == 0 {
 		needsFirstRun = true
 	} else if needsFirstRun && !needsRehydration {
 		// Existing orchestrators found in .lingtai/ but global config is
-		// missing (e.g. user deleted ~/.lingtai-tui). The agents are real
-		// and must not be duplicated — show setup for API keys only.
-		needsFirstRun = false
-		needsRecovery = true
+		// missing (e.g. user deleted ~/.lingtai-tui). The agents are real and
+		// must not be duplicated. Alignment: ~/.lingtai-tui/config.json is
+		// purely additive — agents are defined by init.json + .env. If .env
+		// (the agents' actual key source) still carries API keys, launch
+		// degraded instead of forcing the API-key recovery wizard: keys are
+		// derived from .env and a self-heal banner is shown. Only when NO key
+		// exists anywhere do we run the recovery wizard (real setup).
+		envKeys := config.ReadEnvKeys(globalDir)
+		if config.HasAPIKeys(envKeys) {
+			needsFirstRun = false
+			needsRecovery = false
+			degradedConfig = true
+		} else {
+			needsFirstRun = false
+			needsRecovery = true
+		}
 	}
 
 	if !needsFirstRun {
@@ -1673,6 +1686,6 @@ func prepareApp(projectDir string, inProgram bool) startupResult {
 	// startup is the FirstRunDoneMsg handler in app.go, which fires when the
 	// user creates a new agent through the first-run wizard.
 
-	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, needsRecovery, orchestrators, tuiCfg, rehydrateOrchDir, rehydrateOrchName)
+	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, needsRecovery, degradedConfig, orchestrators, tuiCfg, rehydrateOrchDir, rehydrateOrchName)
 	return startupResult{kind: startupReady, app: app}
 }


### PR DESCRIPTION
Stacked on #813 (self-heal + misalignment doc).

## Problem

Agents are defined solely by init.json + .env (loaded via env_file); the TUI's ~/.lingtai-tui/config.json is purely additive. But a missing config.json hard-blocks the TUI into the recovery wizard even when .env (the agents' actual key source) still has the keys — today's incident.

## Alignment

Make .env the single source of truth for API keys, and treat a missing config.json as a degraded condition, not a setup event.

## Changes

- config.ResolveKeys: effective keys with .env authoritative, config.json fills gaps; configOK is stat-based (LoadConfig returns nil error for missing files)
- config.HasAPIKeys: any *_API_KEY present?
- main.go startup decision table per tui/CONTRACT.md: agents exist + config.json missing + .env has keys → degraded launch (no wizard); wizard only when no keys exist anywhere
- NewApp degradedConfig → persistent top-chrome warning banner (en/zh/wen); key-dependent features limited
- tui/CONTRACT.md: programmatic runtime contract (R1 project-scoped / R2 derived from .env / R3 purely additive) + startup decision table + doctor checklist

## Tests

ResolveKeys env-authoritative + missing-config, HasAPIKeys cases, degraded banner chrome row; config/i18n/tui suites pass (2 pre-existing AdvancesWithoutLive failures on main unchanged).

## Follow-ups (contract D4/D5)

- doctor extension: addon .secrets check + runtime/version skew reporting