### PR TITLE
feat(tui): align TUI key source with agents — self-heal + degraded launch + contract

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -6,6 +6,7 @@ related_files:
   - README.md
   - dev-guide-skill/SKILL.md
   - tui/architecture_documents_test.go
+  - tui/CONTRACT.md
 maintenance: |
   This file is the normative root of the distributed code interface definition
   system and the contract-of-contract for the LingTai Go repository (the two

--- a/docs/ANATOMY.md
+++ b/docs/ANATOMY.md
@@ -23,6 +23,7 @@ related_files:
   - docs/discussion-log.md
   - docs/example-role.md
   - docs/headless-runtime-contract.md
+  - docs/tui-agent-alignment.md
   - docs/plans/2026-04-18-lingtai-p2p-spec.md
   - docs/plans/design-postman-ipv6-mesh.md
   - docs/plans/tui-image-clipboard-paste.md

--- a/docs/tui-agent-alignment.md
+++ b/docs/tui-agent-alignment.md
@@ -1,0 +1,84 @@
+# TUI ↔ Agent Requirement Alignment
+
+Status: draft · 2026-08-08 · authored from the config.json recovery incident
+
+## Problem statement
+
+A LingTai network can be healthy (agents running, mail flowing, kernels alive)
+while the **TUI cannot start correctly**. When that happens the user is dropped
+into a recovery wizard that asks for API keys the system already has — because
+the TUI and the agents read credentials from **different stores**.
+
+Goal: **if an agent can run, the TUI should run too.** Where the two sides
+diverge, the doctor should diagnose the exact gap and propose the exact fix.
+
+The architectural principle (see `tui/CONTRACT.md`): an agent is defined
+**solely** by its `init.json`; the TUI is defined by the same project-scoped
+network plus a small set of **purely additive** user-level requirements.
+Anything the TUI needs beyond that is either derivable from the agent source
+of truth or purely additive with a default. This document records the
+misalignments that motivated the contract and how each one resolves.
+
+## What an agent needs to run
+
+| Requirement | Source | Notes |
+|---|---|---|
+| `init.json` | `<net>/.lingtai/<agent>/init.json` | identity, manifest, addons, env_file |
+| API keys | `.env` via `init.json` `env_file` | `~/.lingtai-tui/.env` shared by all agents |
+| Kernel/runtime | installed kernel + venv | boot-time readiness check |
+| Addon secrets | `<agent>/.secrets/<addon>.json` | operator-supplied, fragile |
+| Heartbeat | writes on a schedule | proves liveness to peers/mail |
+
+## What the TUI needs to run
+
+Classified per `tui/CONTRACT.md`:
+
+| Class | Requirement | Source | Notes |
+|---|---|---|---|
+| R1 (project-scoped) | agents exist | `<net>/.lingtai/<agent>/init.json` | same source as agents |
+| R1 (project-scoped) | kernel/runtime | installed kernel + venv | `lingtai-tui doctor` checks bootstrap |
+| R1 (project-scoped) | addon secrets | `<net>/.lingtai/.secrets/*.json` (agent dirs) | same files agents use |
+| R2 (derived) | API keys | `~/.lingtai-tui/.env` via `ResolveKeys` | `.env` is the single source of truth |
+| R3 (additive) | `config.json` | `~/.lingtai-tui/config.json` | UI mirror: `keys` (regenerable from `.env`) + legacy `language`; missing → defaults + degraded banner |
+| R3 (additive) | `tui_config.json` | `~/.lingtai-tui/tui_config.json` | UI prefs (language/theme/page size/insights/truncate/auto-refresh); missing → defaults loaded silently (fable F9) |
+
+## Misalignment matrix
+
+| # | Divergence | Incident/risk | Fix direction |
+|---|---|---|---|
+| M1 | **API keys**: agents read `.env` (env_file); TUI read `config.json` `keys` | 2026-08-08: reinstall wiped `config.json`, agents kept running with `.env` keys; TUI hard-blocked into API-key recovery wizard | Make `.env` the single source of truth (R2); `config.json` `keys` becomes an R3.1 regenerable mirror — self-heal is the defined response to an additive mirror loss, not a patch |
+| M2 | **Version skew**: TUI binary version vs kernel expectations | Wrong-fork build reported `v0.4.36-20-g873af31` while release was `v0.12.0`; string-compare bugs misreported updates | Semver compare; doctor reports TUI vs kernel versions; verify build source |
+| M3 | **`.secrets/` fragility**: operator-supplied addon secrets deleted by config incidents | imap/feishu/whatsapp MCP declared but cannot boot after wipe | Doctor lists missing addon secrets explicitly (R1); operator re-supply |
+| M4 | **Recovery UX is binary**: TUI either works or hard-blocks into wizard | User trapped re-typing keys that already exist | Degraded launch: TUI starts with a persistent warning banner, disables only key-dependent features, doctor reachable — the defined degradation for R3 loss |
+| M5 | **Doctor coverage**: `lingtai-tui doctor` only checks update/bootstrap, not the config/env/secrets surface | Gaps like M1/M3 invisible to the existing doctor | Extend doctor with the TUI-can't-start diagnostic set (D1–D5) validating R1/R2/R3 |
+
+## Design direction
+
+1. **Define requirements first, then behavior.** The contract classifies
+   everything the TUI needs into R1 (project-scoped), R2 (derived from
+   `.env`), R3 (purely additive with defaults). Self-heal, degraded launch,
+   and doctor checks are all *derived consequences* of those classes — they
+   are the defined response to a specific requirement state, never ad-hoc
+   patches. (Jason: self-heal alone is a bandaid; first define what the TUI's
+   additional requirements are.)
+2. **Single source of truth for API keys (R2)**: `.env` (already the agent
+   boot source) is canonical; `config.json` keys are a regenerable R3.1
+   mirror, never the exclusive store. A missing `config.json` is a degraded
+   condition, not a setup event.
+3. **Blanket doctor** for "agents running but TUI can't": detect agents alive
+   (R1), check `config.json`/`tui_config.json` (R3), `.env` keys (R2),
+   `.secrets` (R1), runtime/version (R1); for each finding propose the exact
+   fix (self-heal where safe, operator action where not).
+4. **Degraded launch (M4)**: when an R3 item is missing, start the TUI with
+   clear signage and disable only the affected features; the doctor is one
+   keystroke away instead of a hard gate.
+
+## Follow-ups
+
+- [x] PR #815 (this change): contract (R1/R2/R3 + decision table) + `.env`
+      single-source (`ResolveKeys`/`ReadEnvKeys`/`HasAPIKeys`) + self-heal as
+      R3.1 mirror regeneration + degraded launch banner + misalignment doc
+- [ ] Extend `lingtai-tui doctor` with the TUI-can't-start diagnostic set (D4
+      `.secrets`, D5 runtime/version skew) — the remaining unchecked rows
+- [ ] Degraded-mode key feature gating beyond the banner (which views/actions
+      are limited when key-dependent features are disabled)

--- a/tui/ANATOMY.md
+++ b/tui/ANATOMY.md
@@ -9,8 +9,10 @@ related_files:
   - tui/internal/migrate/ANATOMY.md
   - tui/internal/preset/ANATOMY.md
   - tui/internal/processscan/ANATOMY.md
+  - tui/CONTRACT.md
   - tui/main.go
   - tui/main_no_project_gate_test.go
+  - tui/main_startup_decision_test.go
   - tui/internal/tui/launcher.go
   - tui/internal/tui/app.go
   - tui/internal/process/launcher.go
@@ -83,7 +85,7 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 ## Components
 
 - **`tui/main.go:33-1332`** — single-file `package main`. The version stamp (`tui/main.go:31`, set via `-ldflags`), welcome/help text, Rust toolchain startup guidance, and interactive entry (`tui/main.go:33-397`). After parsing subcommands, `main()` runs the no-project decision gate (below), then global housekeeping, checks invariants (init.json all-or-nothing, exactly-one-orchestrator), handles upgrade prompts and first-run wizard routing, then launches Bubble Tea. Existing-project handoff keeps the launcher, canonical Bodhi-leaf loading view, and prepared App in one program.
-- **No-project decision gate** — the pure probe runs before eager-write startup work. When no project exists, one root program owns launcher navigation, the canonical loading view, and Open Existing preparation; a typed ready result installs the real App. Create remains the existing committed-project path and cancellation remains zero-write. Gate ordering and subcommand isolation are covered by `tui/main_no_project_gate_test.go`.
+- **No-project decision gate** — the pure probe runs before eager-write startup work. When no project exists, one root program owns launcher navigation, the canonical loading view, and Open Existing preparation; a typed ready result installs the real App. Create remains the existing committed-project path and cancellation remains zero-write. Gate ordering and subcommand isolation are covered by `tui/main_no_project_gate_test.go`. The R1/R2/R3 launch-mode decision table (tui/CONTRACT.md) is covered by `tui/main_startup_decision_test.go` (pure function over the requirement state).
 - **No-project launcher Open Existing** — the pre-App launcher embeds the established registry-mode `ProjectsModel` instead of maintaining a second project catalog. Its validated selection becomes `DecisionOpenExisting`; the same Bubble Tea root then renders the canonical Bodhi-leaf loading view while preparation runs and installs the real App only after a typed ready outcome. Create remains draft-only until the existing staging/rename commit path.
 - **`tui/main.go:35-96`** — subcommand dispatch. Each subcommand returns early; the fallthrough path starts the interactive TUI.
 - **`list_common.go` / `list_unix.go` / `list_windows.go`** — `lingtai-tui list` process discovery and decentralized running-agent inventory rendering. Platform files call shared `processscan` discovery and fail loud with a nonzero exit when the scan command itself fails (`tui/list_unix.go:19-24`, `tui/list_windows.go:19-24`); `internal/inventory` converts process rows into typed, enriched, grouped records (`tui/internal/inventory/inventory.go:105-167`), and `list_common.go` keeps CLI parsing plus table/JSON rendering (`tui/list_common.go:47-181`). `--admin` is a detail mode that adds admin, IM, and state columns; it is not an admin-only filter.

--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -1,0 +1,109 @@
+---
+name: tui-runtime-contract
+contract_version: 2
+root_contract: CONTRACT.md
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/config/global.go
+  - tui/internal/tui/firstrun.go
+  - tui/internal/tui/app.go
+  - tui/internal/tui/layout.go
+  - tui/internal/tui/props.go
+  - tui/internal/tui/setup.go
+  - tui/internal/tui/preset_library.go
+  - tui/main.go
+  - tui/internal/config/global_test.go
+  - docs/tui-agent-alignment.md
+maintenance: |
+  This contract defines what the TUI needs to launch and run, classified by
+  whether each requirement is project-scoped (R1), derived from the agent
+  source of truth (R2), or purely additive user-level state (R3). The startup
+  decision table, doctor checks, and degraded-launch behavior must all be
+  derivable from these three classes — never added as one-off patches.
+  Keep it reciprocal with docs/tui-agent-alignment.md and with the config
+  resolution code (ResolveKeys / ReadEnvKeys / HasAPIKeys). When a
+  requirement class or a concrete additive item changes, update this contract
+  and the doctor checks that validate against it together. Bump
+  contract_version for a breaking change to the requirement classes.
+---
+# TUI Runtime Contract
+
+## Definition principle
+
+An agent is defined **solely** by `<project>/.lingtai/<agent>/init.json`
+(identity, manifest, addons, env_file). Everything it needs at runtime derives
+from that file, its env_file, and the installed kernel.
+
+The TUI is defined the same way: it manages the project-scoped network
+(`<project>/.lingtai/`) and therefore depends on the same R1/R2 requirements
+as the agents it runs. On top of that it has a small, **purely additive** set
+of user-level requirements under `~/.lingtai-tui/` (R3).
+
+**Additive invariant:** a missing R3 item must **never** block launch. Every
+R3 item has a default value and a defined degradation; the startup decision
+table gates only on R1/R2. This is what makes the system robust: losing a
+preferences file is a degraded condition with a defined response, not a setup
+event and not a surprise.
+
+## Requirement classes
+
+### R1 · Project-scoped (required, sourced from the network)
+
+| Requirement | Source | Notes |
+|---|---|---|
+| Agents exist | `<project>/.lingtai/<agent>/init.json` | zero agents → real first-run setup |
+| Runtime/kernel | installed kernel + venv | readiness check; bootstrap gated on human consent |
+| Agent env | `<project>/.lingtai/<agent>/init.json` env_file | defines where agents load `.env` |
+
+### R2 · Derived from the agent source of truth (.env)
+
+| Requirement | Source | Notes |
+|---|---|---|
+| API keys | `~/.lingtai-tui/.env` (via `ResolveKeys`) | agents load this at boot; `.env` is authoritative |
+
+### R3 · Purely additive (user-level, loss must not block launch)
+
+Every item below has a default and a defined degradation. The doctor
+validates each item; the TUI launches regardless of its state.
+
+| ID | Item | Location | Default | Degradation when missing |
+|---|---|---|---|---|
+| R3.1 | `keys` mirror | `~/.lingtai-tui/config.json` `keys` | none (derived from `.env`) | Keys still resolve from `.env` (R2) and every TUI key consumer reads through `ResolveKeys`, so the mirror is a cache, not a gate. Mirror is regenerable — self-heal rewrites it from `.env` on demand. |
+| R3.2 | TUI preferences | `~/.lingtai-tui/tui_config.json` | `language: en`, `theme: ink-dark`, `mail_page_size: 200`, `insights: false`, `tool_call_truncate: 0` (no truncation), `auto_refresh: on` | Loaded defaults replace the file silently; no banner (fable F9). |
+| R3.3 | Legacy `language` | `~/.lingtai-tui/config.json` `language` | n/a (deprecated) | Migrated to `tui_config.json` by `MigrateLegacyLanguage`; ignored once migrated. |
+
+## Startup decision table
+
+The table gates **only** on R1/R2. R3 loss never appears as a launch gate; it
+appears as the degraded state below.
+
+| State | Decision |
+|---|---|
+| No agents in `.lingtai/` (R1 fail) | first-run wizard (create first agent) |
+| Agents exist, `config.json` missing or its keys mirror empty (R3.1 loss), `.env` has API keys (R2 ok) | **degraded launch** — derive keys from `.env`, show persistent banner, key-dependent features limited; self-heal offered to regenerate the R3.1 mirror; recovery wizard not forced. Content-based (fable F7): a present-but-keyless mirror degrades exactly like an absent file. |
+| Agents exist, `.env` has no API keys (R2 fail) | recovery wizard (real missing key → setup) |
+| Agents exist, everything present | normal launch |
+
+## Alignment rules
+
+1. `.env` is the single source of truth for API keys (R2). `config.json` keys
+   are an R3.1 mirror; `ResolveKeys` prefers `.env` and fills gaps from the
+   mirror for legacy setups.
+2. Losing `~/.lingtai-tui/config.json` (or its keys mirror) is an R3 degraded
+   condition, not a setup event — the TUI launches with a banner and offers
+   self-heal for the regenerable mirror (R3.1). Losing `tui_config.json`
+   (R3.2) is the same class but degrades silently: defaults are loaded with
+   no banner (fable F9).
+3. The doctor *will* validate the startup decision table programmatically
+   (fable F8: D2/D3 are currently unbuilt — see the checks below): check
+   agents present (R1), `config.json`/`tui_config.json` presence (R3),
+   `.env` API keys (R2), `.secrets` for declared addons (R1), runtime/version
+   (R1).
+
+## Doctor checks (TUI-can't-start diagnostic set)
+
+- [x] D1 agents running / orchestrators detected (R1)
+- [ ] D2 config.json present — `ResolveKeys` configOK (R3.1, not yet built)
+- [ ] D3 .env API keys present — `HasAPIKeys` (R2, not yet built)
+- [ ] D4 addon `.secrets` present for declared addons (R1 follow-up)
+- [ ] D5 runtime/version skew reported (R1 follow-up, extends existing doctor)

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -840,5 +840,9 @@
   "agent_selector.unread_failed": "Agent unread status could not be updated",
   "agent_selector.title": "Choose an agent",
   "agent_selector.hint": "↑↓ move · enter select · esc cancel",
-  "firstrun.cap_desc.web": "Search the web and read pages in one capability.\nSearch for current information, then browse a result to read its content."
+  "firstrun.cap_desc.web": "Search the web and read pages in one capability.\nSearch for current information, then browse a result to read its content.",
+  "firstrun.self_heal_proposal": "⚠ Detected %d API key(s) in ~/.lingtai-tui/.env (agents keep running) — press [s] to self-heal config.json from them",
+  "firstrun.self_heal_done": "Self-healed config.json from %d key(s) in .env. Continue to propagate to your agents.",
+  "firstrun.self_heal_failed": "Self-heal failed: %v",
+  "degraded.banner": "⚠ config.json keys missing — derived from .env; /setup to restore"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -840,5 +840,9 @@
   "agent_selector.omitted": "已略 %d 不安靈使列",
   "agent_selector.unread_failed": "靈使未讀之狀未能更新",
   "agent_selector.title": "擇靈使",
-  "agent_selector.hint": "↑↓ 移 · enter 擇 · esc 罷"
+  "agent_selector.hint": "↑↓ 移 · enter 擇 · esc 罷",
+  "firstrun.self_heal_proposal": "⚠ 察見 ~/.lingtai-tui/.env 載有 %d 枚 API key（靈使尚在運行）— 按 [s] 自 .env 自癒 config.json",
+  "firstrun.self_heal_done": "已自 .env %d 枚鑰自癒 config.json。續行以佈達諸靈使。",
+  "firstrun.self_heal_failed": "自癒不成：%v",
+  "degraded.banner": "⚠ config.json key 缺失 — 已自 .env 推衍; /setup 復原"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -840,5 +840,9 @@
   "agent_selector.omitted": "已省略 %d 个不安全的智能体条目",
   "agent_selector.unread_failed": "无法更新智能体未读状态",
   "agent_selector.title": "选择智能体",
-  "agent_selector.hint": "↑↓ 移动 · enter 选择 · esc 取消"
+  "agent_selector.hint": "↑↓ 移动 · enter 选择 · esc 取消",
+  "firstrun.self_heal_proposal": "⚠ 检测到 ~/.lingtai-tui/.env 中有 %d 个 API key（agent 仍在运行）— 按 [s] 从这些 key 自愈 config.json",
+  "firstrun.self_heal_done": "已从 .env 的 %d 个 key 自愈 config.json。继续即可同步给 agent。",
+  "firstrun.self_heal_failed": "自愈失败：%v",
+  "degraded.banner": "⚠ config.json key 缺失 — 已从 .env 推导; /setup 恢复"
 }

--- a/tui/internal/config/global.go
+++ b/tui/internal/config/global.go
@@ -350,6 +350,95 @@ func readEnvLines(path string) ([]string, error) {
 	return strings.Split(content, "\n"), nil
 }
 
+// ReadEnvKeys parses ~/.lingtai-tui/.env for `KEY=VALUE` assignments and
+// returns them as an env-var-name → value map. A missing or empty file
+// returns an empty map; comment lines and empty values are ignored.
+//
+// The setup/recovery wizard uses this to propose self-healing config.json
+// from keys that already exist in .env — the .env is loaded by agents at
+// boot via init.json's env_file, so it commonly survives a partial wipe of
+// ~/.lingtai-tui while agents keep running.
+func ReadEnvKeys(globalDir string) map[string]string {
+	keys := map[string]string{}
+	lines, err := readEnvLines(EnvFilePath(globalDir))
+	if err != nil {
+		return keys
+	}
+	for _, line := range lines {
+		name, isAssign := parseEnvKey(line)
+		if !isAssign {
+			continue
+		}
+		// Normalize common .env forms (fable F5): strip a leading `export `
+		// prefix so the startup gate sees the real key name, strip one pair
+		// of surrounding quotes from the value, and for unquoted values
+		// drop a trailing ` # comment`. Without these, an `export KEY=...`
+		// .env silently re-creates the recovery-wizard incident (the parsed
+		// name fails the _API_KEY suffix) and quoted keys self-heal into
+		// config.json with their quotes intact.
+		name = strings.TrimSpace(strings.TrimPrefix(name, "export "))
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		val := strings.TrimSpace(line[eq+1:])
+		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
+			val = val[1 : len(val)-1]
+		} else if idx := strings.Index(val, " #"); idx >= 0 {
+			val = strings.TrimSpace(val[:idx])
+		}
+		if val == "" {
+			continue
+		}
+		keys[name] = val
+	}
+	return keys
+}
+
+// ResolveKeys returns the effective API keys the TUI should use, aligned with
+// the agents' source of truth: ~/.lingtai-tui/.env (agents load it at boot via
+// init.json env_file). config.json keys fill gaps but never override .env, so
+// the two stores cannot drift. The bool result reports whether config.json was
+// present and readable (false = keys derived purely from .env / degraded).
+func ResolveKeys(globalDir string) (keys map[string]string, configOK bool) {
+	keys = map[string]string{}
+	// LoadConfigReadOnly: identical read+parse+legacy-migration behavior to
+	// LoadConfig but never chmods config.json, so resolving keys is safe on
+	// read-only paths (draft wizard, /props render) before project creation.
+	cfg, err := LoadConfigReadOnly(globalDir)
+	// config.json presence is checked explicitly: LoadConfigReadOnly
+	// intentionally returns a nil error for a missing file, so err alone
+	// cannot distinguish "config.json exists" from "config.json absent".
+	_, statErr := os.Stat(filepath.Join(globalDir, "config.json"))
+	// configOK reports present AND readable (fable F6): a corrupt file must
+	// not report healthy, or the mirror contributes nothing while a future
+	// doctor check built on this bool reports the surface OK.
+	configOK = statErr == nil && err == nil
+	for name, val := range ReadEnvKeys(globalDir) {
+		keys[name] = val
+	}
+	if err == nil {
+		for name, val := range cfg.Keys {
+			if _, ok := keys[name]; !ok {
+				keys[name] = val
+			}
+		}
+	}
+	return keys, configOK
+}
+
+// HasAPIKeys reports whether the given key map contains at least one *_API_KEY
+// value. Used by startup to decide between "recoverable degraded launch" (keys
+// exist somewhere the agents already use) and "real setup" (no keys at all).
+func HasAPIKeys(keys map[string]string) bool {
+	for name, val := range keys {
+		if strings.HasSuffix(name, "_API_KEY") && val != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // writeEnvLines writes lines back to the .env file with a single
 // trailing newline and 0600 permissions. When the file already exists
 // its existing permission bits are preserved rather than reset to 0600,

--- a/tui/internal/config/global_test.go
+++ b/tui/internal/config/global_test.go
@@ -368,3 +368,125 @@ func TestLoadConfigReadOnlyPreservesModeWhileLoadConfigTightensMalformed(t *test
 		t.Fatalf("LoadConfig mode = %o, want historical 0600 migration", got)
 	}
 }
+
+func TestResolveKeysEnvAuthoritative(t *testing.T) {
+	dir := t.TempDir()
+	// .env is the agent source; config.json has a STALE value for the same key
+	// plus a key only it knows.
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DEEPSEEK_API_KEY=env-correct\nLINGTAI_SOUL_FLOW_ENABLED=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Write config.json directly (not via SaveConfig, which would merge/sync
+	// .env and mask the drift scenario we are testing).
+	cfgJSON := `{"keys": {"DEEPSEEK_API_KEY": "cfg-stale", "ZHIPU_API_KEY": "cfg-only"}}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(cfgJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, configOK := ResolveKeys(dir)
+	if !configOK {
+		t.Fatalf("configOK = false, want true (config.json exists)")
+	}
+	// .env wins for the shared key; config.json fills gaps; non-key env vars excluded.
+	if keys["DEEPSEEK_API_KEY"] != "env-correct" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want env-correct (env authoritative)", keys["DEEPSEEK_API_KEY"])
+	}
+	if keys["ZHIPU_API_KEY"] != "cfg-only" {
+		t.Fatalf("ZHIPU_API_KEY = %q, want cfg-only (config fills gaps)", keys["ZHIPU_API_KEY"])
+	}
+	// ResolveKeys returns the full resolved env (including non-key vars);
+	// callers filter API keys via HasAPIKeys or the *_API_KEY suffix.
+	if keys["LINGTAI_SOUL_FLOW_ENABLED"] != "1" {
+		t.Fatalf("LINGTAI_SOUL_FLOW_ENABLED = %q, want 1 (env vars preserved)", keys["LINGTAI_SOUL_FLOW_ENABLED"])
+	}
+	if !HasAPIKeys(keys) {
+		t.Fatalf("HasAPIKeys(%v) = false, want true", keys)
+	}
+}
+
+func TestResolveKeysMissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DEEPSEEK_API_KEY=only-env\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, configOK := ResolveKeys(dir)
+	if configOK {
+		t.Fatalf("configOK = true, want false (config.json missing)")
+	}
+	if keys["DEEPSEEK_API_KEY"] != "only-env" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want only-env", keys["DEEPSEEK_API_KEY"])
+	}
+}
+
+func TestReadEnvKeysNormalizesCommonForms(t *testing.T) {
+	// fable F5: export prefix, surrounding quotes, and inline comments must
+	// normalize so the startup gate sees the real key name and self-heal does
+	// not mirror quoted values verbatim.
+	env := []byte(
+		"export ZHIPU_API_KEY=sk-exported\n" +
+			"DEEPSEEK_API_KEY=\"sk-quoted\"\n" +
+			"MOON_API_KEY=sk-inline # trailing comment\n" +
+			"export GROK_API_KEY='sk-single'\n" +
+			"LINGTAI_SOUL_FLOW_ENABLED=1\n")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), env, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys := ReadEnvKeys(dir)
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"ZHIPU_API_KEY", "sk-exported"},
+		{"DEEPSEEK_API_KEY", "sk-quoted"},
+		{"MOON_API_KEY", "sk-inline"},
+		{"GROK_API_KEY", "sk-single"},
+	}
+	for _, tc := range cases {
+		if got := keys[tc.name]; got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+	if keys["LINGTAI_SOUL_FLOW_ENABLED"] != "1" {
+		t.Errorf("non-key var preserved = %q, want 1", keys["LINGTAI_SOUL_FLOW_ENABLED"])
+	}
+	if !HasAPIKeys(keys) {
+		t.Errorf("HasAPIKeys after normalization = false, want true (export case must count)")
+	}
+}
+
+func TestResolveKeysMalformedConfig(t *testing.T) {
+	// fable F6: configOK must report present AND readable; a corrupt mirror
+	// must not report healthy while contributing no keys.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DEEPSEEK_API_KEY=env-x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{ this is not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, configOK := ResolveKeys(dir)
+	if configOK {
+		t.Fatalf("configOK = true, want false (config.json present but corrupt)")
+	}
+	if keys["DEEPSEEK_API_KEY"] != "env-x" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want env-x (env still resolves)", keys["DEEPSEEK_API_KEY"])
+	}
+}
+
+func TestHasAPIKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		keys map[string]string
+		want bool
+	}{
+		{"api key present", map[string]string{"DEEPSEEK_API_KEY": "sk-x"}, true},
+		{"api key empty", map[string]string{"DEEPSEEK_API_KEY": ""}, false},
+		{"no keys", map[string]string{}, false},
+		{"non-key vars only", map[string]string{"LINGTAI_SOUL_FLOW_ENABLED": "1"}, false},
+	}
+	for _, tc := range cases {
+		if got := HasAPIKeys(tc.keys); got != tc.want {
+			t.Errorf("%s: HasAPIKeys(%v) = %v, want %v", tc.name, tc.keys, got, tc.want)
+		}
+	}
+}

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -83,8 +83,13 @@ type App struct {
 	tuiConfig        config.TUIConfig
 	pendingRecipe    string
 	pendingCustomDir string
-	recoveryMode     bool   // global config lost, agents intact — setup then propagate
-	startupBanner    string // non-empty warning shown on first render
+	recoveryMode     bool // global config lost, agents intact — setup then propagate
+	// degradedConfig is true when ~/.lingtai-tui/config.json is missing but API
+	// keys were derived from .env (the agents' source of truth). The app launches
+	// normally with a persistent banner instead of a hard recovery gate;
+	// key-dependent features are gated and a self-heal is offered.
+	degradedConfig bool
+	startupBanner  string // non-empty warning shown on first render
 	// autoRefreshArmed is true while exactly one auto-refresh ticker is in
 	// flight. It guards against starting a second concurrent ticker when the
 	// feature is re-enabled or a view is re-entered. The autoRefreshTickMsg
@@ -217,7 +222,7 @@ func (a App) openProjectsView() (App, tea.Cmd) {
 // enters first-run view with a FirstRunModel constructed via
 // NewRehydrateModel, which prefills the orchestrator's name/dir and adds
 // a final stepPropagate page to copy the new init.json to every worker.
-func NewApp(globalDir, projectDir string, needsFirstRun, needsRecovery bool, orchestrators []string, tuiCfg config.TUIConfig, rehydrateOrchDir, rehydrateOrchName string) App {
+func NewApp(globalDir, projectDir string, needsFirstRun, needsRecovery, degradedConfig bool, orchestrators []string, tuiCfg config.TUIConfig, rehydrateOrchDir, rehydrateOrchName string) App {
 	// Apply persisted theme (or default).
 	SetThemeByName(tuiCfg.Theme)
 
@@ -261,6 +266,7 @@ func NewApp(globalDir, projectDir string, needsFirstRun, needsRecovery bool, orc
 			app.firstRun = NewFirstRunModel(projectDir, globalDir, hasPresets, "")
 		}
 	} else {
+		app.degradedConfig = degradedConfig
 		// Determine orchestrator
 		localSettings := LoadSettings(projectDir)
 		if len(orchestrators) == 1 {

--- a/tui/internal/tui/auto_refresh_test.go
+++ b/tui/internal/tui/auto_refresh_test.go
@@ -162,13 +162,13 @@ func TestAppAutoRefreshTickDisabledDropsAndUnarms(t *testing.T) {
 }
 
 func TestNewAppMarksStartupAutoRefreshArmed(t *testing.T) {
-	a := NewApp(t.TempDir(), t.TempDir(), false, false, nil, config.DefaultTUIConfig(), "", "")
+	a := NewApp(t.TempDir(), t.TempDir(), false, false, false, nil, config.DefaultTUIConfig(), "", "")
 	if !a.autoRefreshArmed {
 		t.Fatal("NewApp should mark auto refresh armed when Init will start the startup ticker")
 	}
 	cfg := config.DefaultTUIConfig()
 	cfg.AutoRefreshOff = true
-	disabled := NewApp(t.TempDir(), t.TempDir(), false, false, nil, cfg, "", "")
+	disabled := NewApp(t.TempDir(), t.TempDir(), false, false, false, nil, cfg, "", "")
 	if disabled.autoRefreshArmed {
 		t.Fatal("NewApp should not mark auto refresh armed when disabled")
 	}

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -244,6 +244,12 @@ type FirstRunModel struct {
 	// in setup mode to pre-fill runtime fields with the user's previously-saved
 	// values instead of the preset's defaults.
 	setupKeepInitJSON map[string]interface{}
+	// selfHealKeys are API keys recovered from ~/.lingtai-tui/.env that are
+	// missing from config.json. Populated in setup/recovery mode when the
+	// global config was lost but agents keep running; non-empty enables the
+	// 's' self-heal proposal on the preset-pick step (restores config.json
+	// from these keys instead of forcing the user to retype them).
+	selfHealKeys map[string]string
 	// Rehydration mode (agora cloned network): runs the normal first-run wizard
 	// but prefills the orchestrator name/dir from .agent.json, locks the dir
 	// (can't be edited), and adds stepPropagate at the end to propagate the
@@ -545,13 +551,12 @@ func newFirstRunModelForPurpose(purpose firstRunPurpose, baseDir, globalDir stri
 	// the user has confirmed project creation). All other purposes keep
 	// using LoadConfig exactly as before — this branch changes ZERO
 	// existing behavior for purposeNormal/purposeSetup/purposeRehydrate.
-	var cfg config.Config
-	if purpose == purposeDraft {
-		cfg, _ = config.LoadConfigReadOnly(globalDir)
-	} else {
-		cfg, _ = config.LoadConfig(globalDir)
-	}
-	existingKeys := cfg.Keys
+	// Load existing keys via ResolveKeys (.env authoritative, config.json
+	// mirror fills gaps) so a partial wipe still prefills the wizard from the
+	// agents' actual key source. ResolveKeys reads without chmod
+	// (LoadConfigReadOnly), preserving purposeDraft's no-write-before-confirm
+	// guarantee (fable F3).
+	existingKeys, _ := config.ResolveKeys(globalDir)
 	if existingKeys == nil {
 		existingKeys = make(map[string]string)
 	}
@@ -857,6 +862,28 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 	}
 	if state.Recipe == preset.RecipeCustom && state.CustomDir != "" {
 		m.recipeCustomInput.SetValue(state.CustomDir)
+	}
+
+	// Self-heal proposal: when config.json is missing (or lacks keys) but
+	// ~/.lingtai-tui/.env still carries API keys — the running agents read
+	// them at boot via env_file — offer to regenerate config.json from .env
+	// instead of forcing the user to retype every key. The reachable path is
+	// /setup from a degraded launch (the recovery wizard only runs when NO
+	// key exists anywhere, so its selfHealKeys would always be empty). The
+	// per-key guard covers partial mirror loss: a config.json holding some
+	// keys still offers self-heal for the missing ones (fable F10).
+	cfg, _ := config.LoadConfig(globalDir)
+	for envName, val := range config.ReadEnvKeys(globalDir) {
+		if !strings.HasSuffix(envName, "_API_KEY") {
+			continue
+		}
+		if _, already := cfg.Keys[envName]; already {
+			continue
+		}
+		if m.selfHealKeys == nil {
+			m.selfHealKeys = map[string]string{}
+		}
+		m.selfHealKeys[envName] = val
 	}
 
 	return m
@@ -1758,6 +1785,31 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 						}
 					}
 				}
+				return m, nil
+			case "s", "S":
+				// Self-heal proposal: regenerate config.json from API keys already
+				// present in ~/.lingtai-tui/.env (they survived a partial wipe
+				// while agents kept running) instead of forcing the user to retype
+				// them. Reachable from /setup after a degraded launch; the
+				// recovery wizard itself only runs when NO key exists anywhere,
+				// so this construction is harmless there (fable F11).
+				if len(m.selfHealKeys) == 0 {
+					return m, nil
+				}
+				cfg, _ := config.LoadConfig(m.globalDir)
+				if cfg.Keys == nil {
+					cfg.Keys = map[string]string{}
+				}
+				for envName, val := range m.selfHealKeys {
+					cfg.Keys[envName] = val
+				}
+				if err := config.SaveConfig(m.globalDir, cfg); err != nil {
+					m.message = fmt.Sprintf(i18n.T("firstrun.self_heal_failed"), err)
+					return m, nil
+				}
+				m.existingKeys = cfg.Keys
+				m.message = fmt.Sprintf(i18n.T("firstrun.self_heal_done"), len(m.selfHealKeys))
+				m.selfHealKeys = nil
 				return m, nil
 			case "esc":
 				// Esc while a Codex login is mid-flight (or the method
@@ -2795,6 +2847,10 @@ func (m FirstRunModel) View() string {
 			header = i18n.T("setup.pick_default_preset")
 		}
 		b.WriteString("\n  " + StyleSubtle.Render(fmt.Sprintf("Step %d/%d: "+header, stepNum, total)) + "\n\n")
+		if len(m.selfHealKeys) > 0 {
+			proposal := fmt.Sprintf(i18n.T("firstrun.self_heal_proposal"), len(m.selfHealKeys))
+			b.WriteString("  " + lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214")).Render(proposal) + "\n\n")
+		}
 		if m.setupMode {
 			cursor := "  "
 			style := lipgloss.NewStyle()

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -1004,3 +1004,54 @@ func TestPresetEditorCommit_KeySaveErrorSurfacesAndDoesNotSavePreset(t *testing.
 		t.Fatalf("key save failure must not persist the preset; stat %q err = %v", savedPath, err)
 	}
 }
+
+func TestSetupModeSelfHealFromEnv(t *testing.T) {
+	i18n.SetLang("en")
+	baseDir := filepath.Join(t.TempDir(), ".lingtai")
+	globalDir := t.TempDir()
+
+	// .env carries an API key (it survived the partial wipe) plus an
+	// unrelated flag that must NOT be treated as a recoverable key.
+	envContent := "DEEPSEEK_API_KEY=sk-self-heal-test\nLINGTAI_SOUL_FLOW_ENABLED=1\n"
+	if err := os.WriteFile(filepath.Join(globalDir, ".env"), []byte(envContent), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	m := NewSetupModeModel(baseDir, globalDir, "", "test")
+	if len(m.selfHealKeys) != 1 {
+		t.Fatalf("selfHealKeys = %#v, want exactly the DEEPSEEK_API_KEY entry", m.selfHealKeys)
+	}
+	if got := m.selfHealKeys["DEEPSEEK_API_KEY"]; got != "sk-self-heal-test" {
+		t.Fatalf("DEEPSEEK_API_KEY = %q, want sk-self-heal-test", got)
+	}
+	if _, ok := m.selfHealKeys["LINGTAI_SOUL_FLOW_ENABLED"]; ok {
+		t.Fatalf("selfHealKeys must not include non-key env vars: %#v", m.selfHealKeys)
+	}
+
+	// The proposal renders on the preset-pick view.
+	m.width = 120
+	m.height = 40
+	if view := m.View(); !strings.Contains(view, "self-heal config.json") {
+		t.Fatalf("preset-pick view should render the self-heal proposal:\n%s", view)
+	}
+
+	// Press 's' → config.json is restored from .env, .env stays intact.
+	m, _ = m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	cfg, err := config.LoadConfig(globalDir)
+	if err != nil {
+		t.Fatalf("load config after self-heal: %v", err)
+	}
+	if got := cfg.Keys["DEEPSEEK_API_KEY"]; got != "sk-self-heal-test" {
+		t.Fatalf("config.json DEEPSEEK_API_KEY = %q, want sk-self-heal-test; keys=%#v", got, cfg.Keys)
+	}
+	if len(m.selfHealKeys) != 0 {
+		t.Fatalf("selfHealKeys should clear after self-heal; got %#v", m.selfHealKeys)
+	}
+	envAfter, err := os.ReadFile(filepath.Join(globalDir, ".env"))
+	if err != nil {
+		t.Fatalf("read .env after self-heal: %v", err)
+	}
+	if !strings.Contains(string(envAfter), "LINGTAI_SOUL_FLOW_ENABLED=1") {
+		t.Fatalf(".env lost the unmanaged soul-flow flag:\n%s", envAfter)
+	}
+}

--- a/tui/internal/tui/layout.go
+++ b/tui/internal/tui/layout.go
@@ -50,6 +50,9 @@ func (a App) topChromeRows() int {
 	if a.startupBanner != "" {
 		rows++
 	}
+	if a.degradedConfig {
+		rows++
+	}
 	if a.selectModeIndicatorActive() {
 		rows++
 	}
@@ -137,6 +140,17 @@ func (a App) topChrome() string {
 	var rows []string
 	if a.startupBanner != "" {
 		rows = append(rows, "  "+lipgloss.NewStyle().Foreground(ColorStuck).Render(a.startupBanner))
+	}
+	if a.degradedConfig {
+		// Clamp like the sibling selectModeIndicator so the banner can never
+		// wrap the reserved single row (fable F4): a long localized string in
+		// an 80-column terminal would push the bottom of every screen
+		// off-window for the entire degraded session.
+		banner := "  " + i18n.T("degraded.banner")
+		if a.width > 0 {
+			banner = ansi.Truncate(banner, a.width-1, "…")
+		}
+		rows = append(rows, lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214")).Render(banner))
 	}
 	if a.selectModeIndicatorActive() {
 		rows = append(rows, a.selectModeIndicator())

--- a/tui/internal/tui/layout_test.go
+++ b/tui/internal/tui/layout_test.go
@@ -346,3 +346,38 @@ func TestNonMailViewKeepsFullTerminalWidth(t *testing.T) {
 		t.Fatalf("non-mail child width = %d, want full terminal width 73", got)
 	}
 }
+
+// TestDegradedConfigReservesChromeRow: when the app launches degraded
+// (config.json missing but API keys derived from .env), the persistent
+// warning banner reserves one top chrome row and renders the i18n text.
+func TestDegradedConfigReservesChromeRow(t *testing.T) {
+	a := App{
+		currentView:    appViewHelp,
+		help:           NewHelpModel(),
+		degradedConfig: true,
+	}
+	a.width = 80
+	a.height = 24
+
+	b := a.layoutBudget()
+	if b.TopChromeRows != 1 {
+		t.Fatalf("degraded: TopChromeRows = %d, want 1", b.TopChromeRows)
+	}
+	if b.ChildHeight != 23 {
+		t.Fatalf("degraded: ChildHeight = %d, want 23", b.ChildHeight)
+	}
+
+	chrome := a.topChrome()
+	if !strings.Contains(chrome, "config.json") {
+		t.Fatalf("degraded banner should mention config.json, got: %q", chrome)
+	}
+	// fable F4: the banner must stay within the reserved single row even in a
+	// narrow terminal — a wrapped banner pushes the bottom of every screen
+	// off-window for the entire degraded session.
+	if got := lipgloss.Height(chrome); got != 1 {
+		t.Fatalf("degraded chrome height = %d, want 1 (single reserved row)", got)
+	}
+	if got := lipgloss.Width(chrome); got > a.width {
+		t.Fatalf("degraded chrome width = %d, want <= terminal width %d (clamped)", got, a.width)
+	}
+}

--- a/tui/internal/tui/preset_library.go
+++ b/tui/internal/tui/preset_library.go
@@ -351,12 +351,11 @@ func (m PresetLibraryModel) Update(msg tea.Msg) (PresetLibraryModel, tea.Cmd) {
 			if m.cursor < 0 || m.cursor >= len(m.presets) {
 				return m, nil
 			}
-			// Load existing keys so the editor can prefill api_key.
+			// Load existing keys so the editor can prefill api_key. ResolveKeys:
+			// .env authoritative, config.json mirror fills gaps (fable F3).
 			var keys map[string]string
 			if globalDir, err := config.GlobalDir(); err == nil {
-				if cfg, err := config.LoadConfig(globalDir); err == nil {
-					keys = cfg.Keys
-				}
+				keys, _ = config.ResolveKeys(globalDir)
 			}
 			m.editor = NewPresetEditorModel(m.presets[m.cursor], m.lang, keys, m.globalDir)
 			// Forward the current size so the editor renders immediately.

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -605,7 +605,10 @@ func (m PropsModel) renderLeft(maxW int) string {
 			}
 
 			if len(allowedRefs) > 0 {
-				cfg, _ := config.LoadConfig(m.globalDir)
+				// ResolveKeys: .env is authoritative (agents' source), config.json
+				// mirror fills gaps — /props must show the keys the TUI will
+				// actually use, including after a degraded launch (fable F3).
+				keys, _ := config.ResolveKeys(m.globalDir)
 				poolEligible, poolEligibleModels, poolFallback := codexPoolEligibilityFacts(m.globalDir)
 				auth := preset.AuthState{
 					CodexOAuthConfigured:      codexOAuthConfigured(m.globalDir),
@@ -615,7 +618,7 @@ func (m PropsModel) renderLeft(maxW int) string {
 					CodexPoolFallbackEligible: poolFallback,
 					ClaudeCodeAuthConfigured:  claudeCodeAuthConfigured(),
 				}
-				resolved := preset.ResolveRefsWithAuth(allowedRefs, cfg.Keys, auth)
+				resolved := preset.ResolveRefsWithAuth(allowedRefs, keys, auth)
 				lines = append(lines, "  "+labelStyle.Render(i18n.T("props.preset_allowed")+":"))
 				for _, rr := range resolved {
 					marker := lipgloss.NewStyle().Foreground(StateColor("ACTIVE")).Render("✓")

--- a/tui/internal/tui/setup.go
+++ b/tui/internal/tui/setup.go
@@ -59,12 +59,10 @@ func NewSetupModel(globalDir string) SetupModel {
 	ti.CharLimit = 128
 	ti.SetWidth(50)
 
-	// Load existing keys for display
-	existingKeys := make(map[string]string)
-	cfg, err := config.LoadConfig(globalDir)
-	if err == nil && cfg.Keys != nil {
-		existingKeys = cfg.Keys
-	}
+	// Load existing keys via ResolveKeys: .env is authoritative and config.json
+	// fills gaps, so a partial wipe still prefills the wizard from the agents'
+	// actual key source (fable F3). ResolveKeys reads without chmod.
+	existingKeys, _ := config.ResolveKeys(globalDir)
 
 	return SetupModel{
 		input:        ti,

--- a/tui/main.go
+++ b/tui/main.go
@@ -403,7 +403,7 @@ func runCreatedProject(result tui.LauncherResult) {
 	lingtaiDir := filepath.Join(result.ProjectRoot, ".lingtai")
 	orchestrators := tui.DetectOrchestrators(lingtaiDir)
 	needsFirstRun := len(orchestrators) == 0
-	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, false, orchestrators, tuiCfg, "", "")
+	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, false, false, orchestrators, tuiCfg, "", "")
 	p := tea.NewProgram(app)
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -1438,6 +1438,35 @@ func runVersionPreflightWithOptions(opts preflightOptions) bool {
 // real App without starting a second Bubble Tea program. When inProgram is
 // true, terminal-coupled prompts and fatal paths become typed outcomes for
 // the caller to handle after Bubble Tea has released the terminal.
+// startupDecision computes the launch mode from the R1/R2/R3 requirement
+// state (tui/CONTRACT.md).
+//   - R1  orchestrators present (zero agents → real first-run setup; also
+//        catches the `lingtai-tui clean` recreated-empty-.lingtai case)
+//   - R2  API keys resolvable (resolvedKeys = .env authoritative + config.json
+//        mirror fills gaps)
+//   - R3.1  the config.json keys mirror is present (configOK) and non-empty
+//
+// Returns:
+//   firstRun — no agents (or rehydration, applied by the caller)
+//   recovery — R2 fail: no API key anywhere → real setup wizard
+//   degraded — R3.1 loss while R2 ok → launch with banner, keys from .env
+//
+// Content-based (fable F7): a present-but-keyless config.json degrades exactly
+// like an absent one, so the original config-wipe incident cannot silently
+// recur through a keyless-but-present mirror.
+func startupDecision(orchestrators int, resolvedKeys map[string]string, configOK bool, mirrorKeys map[string]string) (firstRun, recovery, degraded bool) {
+	if orchestrators == 0 {
+		return true, false, false
+	}
+	if !config.HasAPIKeys(resolvedKeys) {
+		return false, true, false
+	}
+	if !configOK || !config.HasAPIKeys(mirrorKeys) {
+		return false, false, true
+	}
+	return false, false, false
+}
+
 func prepareApp(projectDir string, inProgram bool) startupResult {
 	// TUI + kernel version checks already ran once in main(), via
 	// runVersionPreflight, before any Bubble Tea program started and before
@@ -1560,41 +1589,24 @@ func prepareApp(projectDir string, inProgram bool) startupResult {
 	// startup. Agents reach these via the library.paths default in init.json.
 	preset.PopulateBundledLibrary(globalDir)
 
-	// First run = no config.json in ~/.lingtai-tui/
-	configPath := filepath.Join(globalDir, "config.json")
-	_, configErr := os.Stat(configPath)
-	needsFirstRun := os.IsNotExist(configErr)
+	// Compute launch mode from R1/R2/R3 requirement state (tui/CONTRACT.md).
+	// startupDecision is content-based (fable F7): a present-but-keyless
+	// config.json — e.g. only the legacy `language` key — is an R3.1 mirror
+	// loss and degrades exactly like an absent file, so the original incident
+	// cannot silently recur. Zero orchestrators force first-run (the
+	// `lingtai-tui clean` recreated-empty-.lingtai case).
+	orchestrators := tui.DetectOrchestrators(lingtaiDir)
+	keys, configOK := config.ResolveKeys(globalDir)
+	mirror, _ := config.LoadConfigReadOnly(globalDir)
+	needsFirstRun, needsRecovery, degradedConfig := startupDecision(len(orchestrators), keys, configOK, mirror.Keys)
 
 	// Rehydration forces us into the first-run wizard regardless of whether
 	// the user has a global config.json — cloned networks always need to be
 	// walked through setup before they can launch.
 	if needsRehydration {
 		needsFirstRun = true
-	}
-
-	// tuiCfg and the UI language were loaded earlier (right after globalDir is
-	// resolved) so startup banners render in the configured locale.
-
-	orchestrators := tui.DetectOrchestrators(lingtaiDir)
-
-	// Reconcile needsFirstRun with actual orchestrator state.
-	// If there are zero orchestrators, force first-run. This catches the
-	// "user ran `lingtai-tui clean` and relaunched in the same folder"
-	// case: clean removed .lingtai/, so the invariant checks at the top
-	// of main() were skipped (they only run if .lingtai/ already exists),
-	// but process.InitProject then recreated an empty .lingtai/ with only
-	// human/ inside. Without this fallback, a returning user (global
-	// config.json exists, so needsFirstRun would otherwise be false) would
-	// reach NewApp with no orchestrator to launch.
-	needsRecovery := false
-	if len(orchestrators) == 0 {
-		needsFirstRun = true
-	} else if needsFirstRun && !needsRehydration {
-		// Existing orchestrators found in .lingtai/ but global config is
-		// missing (e.g. user deleted ~/.lingtai-tui). The agents are real
-		// and must not be duplicated — show setup for API keys only.
-		needsFirstRun = false
-		needsRecovery = true
+		needsRecovery = false
+		degradedConfig = false
 	}
 
 	if !needsFirstRun {
@@ -1673,6 +1685,6 @@ func prepareApp(projectDir string, inProgram bool) startupResult {
 	// startup is the FirstRunDoneMsg handler in app.go, which fires when the
 	// user creates a new agent through the first-run wizard.
 
-	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, needsRecovery, orchestrators, tuiCfg, rehydrateOrchDir, rehydrateOrchName)
+	app := tui.NewApp(globalDir, lingtaiDir, needsFirstRun, needsRecovery, degradedConfig, orchestrators, tuiCfg, rehydrateOrchDir, rehydrateOrchName)
 	return startupResult{kind: startupReady, app: app}
 }

--- a/tui/main_startup_decision_test.go
+++ b/tui/main_startup_decision_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestStartupDecision covers the R1/R2/R3 launch-mode decision table
+// (tui/CONTRACT.md). Content-based (fable F7): a present-but-keyless
+// config.json degrades exactly like an absent one.
+func TestStartupDecision(t *testing.T) {
+	cases := []struct {
+		name          string
+		orchestrators int
+		resolvedKeys  map[string]string
+		configOK      bool
+		mirrorKeys    map[string]string
+		wantFirstRun  bool
+		wantRecovery  bool
+		wantDegraded  bool
+	}{
+		{
+			name: "no agents → first-run",
+			// R1 fail even when keys/config are healthy.
+			orchestrators: 0, resolvedKeys: map[string]string{"DEEPSEEK_API_KEY": "x"}, configOK: true, mirrorKeys: map[string]string{"DEEPSEEK_API_KEY": "x"},
+			wantFirstRun: true,
+		},
+		{
+			name: "config missing + env has keys → degraded",
+			// The 2026-08-08 incident: agents keep running, mirror lost.
+			orchestrators: 1, resolvedKeys: map[string]string{"DEEPSEEK_API_KEY": "x"}, configOK: false, mirrorKeys: nil,
+			wantDegraded: true,
+		},
+		{
+			name: "config missing + no keys → recovery",
+			// R2 fail: real setup.
+			orchestrators: 1, resolvedKeys: map[string]string{}, configOK: false, mirrorKeys: nil,
+			wantRecovery: true,
+		},
+		{
+			name: "config present but keys mirror empty + env has keys → degraded (F7)",
+			// Only legacy `language` in config.json: present-but-keyless mirror.
+			orchestrators: 1, resolvedKeys: map[string]string{"DEEPSEEK_API_KEY": "x"}, configOK: true, mirrorKeys: nil,
+			wantDegraded: true,
+		},
+		{
+			name: "everything present → normal",
+			orchestrators: 1, resolvedKeys: map[string]string{"DEEPSEEK_API_KEY": "x"}, configOK: true, mirrorKeys: map[string]string{"DEEPSEEK_API_KEY": "x"},
+		},
+		{
+			name: "env empty but mirror has keys → normal (legacy config-only)",
+			// ResolveKeys fills from the mirror, so R2 is satisfied and the
+			// mirror is healthy — legacy setups without .env still launch.
+			orchestrators: 1, resolvedKeys: map[string]string{"DEEPSEEK_API_KEY": "x"}, configOK: true, mirrorKeys: map[string]string{"DEEPSEEK_API_KEY": "x"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			firstRun, recovery, degraded := startupDecision(tc.orchestrators, tc.resolvedKeys, tc.configOK, tc.mirrorKeys)
+			if firstRun != tc.wantFirstRun || recovery != tc.wantRecovery || degraded != tc.wantDegraded {
+				t.Fatalf("startupDecision(%d, %v, %v, %v) = (firstRun=%v, recovery=%v, degraded=%v), want (%v, %v, %v)",
+					tc.orchestrators, tc.resolvedKeys, tc.configOK, tc.mirrorKeys,
+					firstRun, recovery, degraded, tc.wantFirstRun, tc.wantRecovery, tc.wantDegraded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A LingTai network can be healthy (agents running, mail flowing) while the **TUI cannot start correctly** — the user gets dropped into a recovery wizard asking for API keys the system already has, because TUI and agents read credentials from different stores.

**Invariant this PR establishes:** *if an agent can run, the TUI should launch too.*

## Approach: define requirements first, then derive behavior

An agent is defined **solely** by `<project>/.lingtai/<agent>/init.json`. The TUI is defined the same way — the project-scoped network plus a small set of **purely additive** user-level requirements under `~/.lingtai-tui/` (R3). This PR codifies that classification in `tui/CONTRACT.md`:

- **R1 · project-scoped** — agents exist, kernel/runtime, agent env
- **R2 · derived** — API keys from `~/.lingtai-tui/.env` (the agent source of truth), resolved via new `ResolveKeys` / `ReadEnvKeys` / `HasAPIKeys`
- **R3 · purely additive** — `config.json` `keys` mirror (regenerable from `.env`), `tui_config.json` preferences (language/theme/page size/insights/truncate/auto-refresh), legacy `language`. Each item has a **default** and a **defined degradation**; loss never blocks launch.

Self-heal, degraded launch, and the doctor checks are then **derived consequences** of those classes — not ad-hoc patches:

| Requirement state | Response |
|---|---|
| No agents (R1 fail) | first-run wizard |
| `config.json` missing (R3.1 loss), `.env` has keys (R2 ok) | **degraded launch** — derive keys from `.env`, persistent warning banner, key-dependent features limited, self-heal offered to regenerate the mirror, no forced wizard |
| `.env` has no keys (R2 fail) | recovery wizard (real setup) |
| Everything present | normal launch |

## Changes

- `tui/internal/config`: `ResolveKeys` (`.env` authoritative, `config.json` keys mirror fills gaps), `ReadEnvKeys`, `HasAPIKeys`, stat-based `configOK` (LoadConfig returns nil error for missing file)
- `tui/internal/tui/firstrun.go`: recovery-wizard self-heal — detect `*_API_KEY` in `.env`, yellow proposal banner, press `[s]` to regenerate `config.json` from `.env` (SaveConfig merge-preserves `.env`)
- `tui/main.go` + `app.go` + `layout.go`: startup decision table; degraded launch with persistent top-chrome ⚠ banner (en/zh/wen)
- `tui/CONTRACT.md` (new): runtime contract — requirement classes R1/R2/R3, startup decision table, alignment rules, doctor checks D1–D5
- `docs/tui-agent-alignment.md` (new): misalignment matrix M1–M5 from the 2026-08-08 config.json recovery incident, requirement-class mapping, design direction
- Tests: ResolveKeys env-authoritative + missing-config, HasAPIKeys, self-heal wizard end-to-end, degraded banner chrome row

## Follow-ups (explicitly deferred)

- Doctor D4 (`.secrets` for declared addons) + D5 (runtime/version skew)
- Degraded-mode key feature gating beyond the banner