### PR TITLE
feat(tui): mail footer active N sec uses last_progress_at semantics

### DIFF
--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -212,6 +212,19 @@ func readNetworkStatusSnapshot(agentDir string) (networkStatusSnapshot, time.Tim
 	return status, info.ModTime(), true
 }
 
+// LastProgressAt returns the agent's clamped runtime.last_progress_at from its
+// .status.json, or zero + false when the file is missing, the field is absent/
+// invalid, or the timestamp is beyond the future grace window. This mirrors the
+// kernel taskcard footer semantics: while state==active, the elapsed display is
+// seconds since this timestamp (age of the last progress).
+func LastProgressAt(agentDir string, now time.Time) (time.Time, bool) {
+	status, _, ok := readNetworkStatusSnapshot(agentDir)
+	if !ok || !status.Runtime.LastProgressAt.OK {
+		return time.Time{}, false
+	}
+	return statusFreshnessTime(now, unixSeconds(status.Runtime.LastProgressAt.Value))
+}
+
 func latestStatusFreshnessTime(now time.Time, candidates ...time.Time) time.Time {
 	var latest time.Time
 	for _, candidate := range candidates {

--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -214,12 +214,16 @@ func readNetworkStatusSnapshot(agentDir string) (networkStatusSnapshot, time.Tim
 
 // LastProgressAt returns the agent's clamped runtime.last_progress_at from its
 // .status.json, or zero + false when the file is missing, the field is absent/
-// invalid, or the timestamp is beyond the future grace window. This mirrors the
-// kernel taskcard footer semantics: while state==active, the elapsed display is
-// seconds since this timestamp (age of the last progress).
+// invalid, the runtime state is not active, or the timestamp is beyond the
+// future grace window. Requiring state==active on the SAME snapshot mirrors the
+// kernel taskcard footer semantics and avoids seeding the elapsed badge from a
+// stale timestamp after a restart (Jason 2026-08-08, fable review).
 func LastProgressAt(agentDir string, now time.Time) (time.Time, bool) {
 	status, _, ok := readNetworkStatusSnapshot(agentDir)
 	if !ok || !status.Runtime.LastProgressAt.OK {
+		return time.Time{}, false
+	}
+	if !strings.EqualFold(status.Runtime.State, NetworkStatusActive) {
 		return time.Time{}, false
 	}
 	return statusFreshnessTime(now, unixSeconds(status.Runtime.LastProgressAt.Value))

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -80,6 +80,8 @@ type mailRefreshMsg struct {
 	selectorRows         []agentSelectorRow
 	directPublication    *fs.DirectMailPublication
 	directStates         map[string]string // stable direct-thread key -> target lifecycle state
+	lastProgressAt       time.Time            // orchestrator .status.json runtime.last_progress_at (zero when absent)
+	directLastProgress   map[string]time.Time // stable direct-thread key -> target last_progress_at
 	alive                bool
 	state                string // active, idle, stuck, asleep, suspended, or ""
 	activity             fs.NetworkActivity
@@ -698,6 +700,20 @@ func (m MailModel) refreshMail() tea.Msg {
 
 	alive, state, orchestrator := resolveAgentLifecycle(m.orchestrator)
 	directStates := resolveDirectLifecycleStates(selectorRows)
+	lastProgressAt, _ := fs.LastProgressAt(m.orchestrator, time.Now())
+	directLastProgress := make(map[string]time.Time, len(directStates))
+	for _, row := range selectorRows {
+		if row.Main {
+			continue
+		}
+		key := fs.DirectThreadKey(row.Target)
+		if key == "" {
+			continue
+		}
+		if lp, ok := fs.LastProgressAt(row.Target.Directory, time.Now()); ok {
+			directLastProgress[key] = lp
+		}
+	}
 	var activity fs.NetworkActivity
 	if m.baseDir != "" {
 		if a, err := fs.ComputeNetworkActivity(m.baseDir); err == nil {
@@ -719,6 +735,8 @@ func (m MailModel) refreshMail() tea.Msg {
 		selectorRows:         selectorRows,
 		directPublication:    directPublication,
 		directStates:         directStates,
+		lastProgressAt:       lastProgressAt,
+		directLastProgress:   directLastProgress,
 		alive:                alive,
 		state:                state,
 		activity:             activity,
@@ -1140,7 +1158,7 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				m.cache = msg.cache
 				m.acceptedSnapshot = msg.acceptedSnapshot
 				m = m.installSelectorRows(msg.selectorRows)
-				m = m.installDirectLifecycleStates(msg.directStates)
+				m = m.installDirectLifecycleStates(msg.directStates, msg.directLastProgress)
 				m.directPublication = msg.directPublication
 				m = m.clampAgentRail()
 				m, directVisibilityCmd = m.publishAcceptedDirectSnapshot()
@@ -1162,7 +1180,15 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				m.quoteIdx++
 				m.pulseTick = 0
 				m.insightPending = false
-				m.activeSince = time.Now()
+				m.activeSince = msg.lastProgressAt
+				if m.activeSince.IsZero() {
+					m.activeSince = time.Now()
+				}
+			} else if isActive && !msg.lastProgressAt.IsZero() && !msg.lastProgressAt.Equal(m.activeSince) {
+				// Still active but the kernel reports a different last progress —
+				// adopt it so "active N sec" measures seconds since the last tool
+				// call (matches the kernel taskcard footer semantics).
+				m.activeSince = msg.lastProgressAt
 			} else if !isActive {
 				// Not active — stop the elapsed timer so the badge drops it
 				m.activeSince = time.Time{}
@@ -2153,14 +2179,21 @@ func (m MailModel) humanName() string {
 	return i18n.T("mail.you")
 }
 
-func (m MailModel) installDirectLifecycleStates(states map[string]string) MailModel {
+func (m MailModel) installDirectLifecycleStates(states map[string]string, lastProgress map[string]time.Time) MailModel {
 	now := time.Now()
 	next := make(map[string]directAgentLifecycle, len(states))
 	for key, state := range states {
 		status := m.directLifecycles[key]
 		if strings.EqualFold(state, "ACTIVE") {
 			if !strings.EqualFold(status.state, "ACTIVE") || status.activeSince.IsZero() {
-				status.activeSince = now
+				status.activeSince = lastProgress[key]
+				if status.activeSince.IsZero() {
+					status.activeSince = now
+				}
+			} else if lp, ok := lastProgress[key]; ok && !lp.IsZero() && !lp.Equal(status.activeSince) {
+				// Still active but the target reports a different last progress —
+				// adopt it (matches kernel taskcard footer semantics).
+				status.activeSince = lp
 			}
 		} else {
 			status.activeSince = time.Time{}

--- a/tui/internal/tui/mail_activity_indicator_test.go
+++ b/tui/internal/tui/mail_activity_indicator_test.go
@@ -72,13 +72,15 @@ func TestActiveElapsed(t *testing.T) {
 // TestActiveSinceLifecycle verifies the activeSince timestamp is set on entry to
 // ACTIVE, preserved while staying ACTIVE, and cleared on any non-ACTIVE refresh
 // (including the synthesized suspended/refreshing states, which arrive as
-// non-ACTIVE through the same mailRefreshMsg path).
+// non-ACTIVE through the same mailRefreshMsg path). When the refresh carries a
+// kernel last_progress_at it is used as the baseline (so "active N sec" measures
+// seconds since the last tool call), falling back to wall-clock when absent.
 func TestActiveSinceLifecycle(t *testing.T) {
 	dir := t.TempDir()
 	m := NewMailModel(dir, "human", dir, dir, "orch", 20, dir, "en", false, 0)
 	m = sizeMail(t, m)
 
-	// Enter ACTIVE → timer starts.
+	// Enter ACTIVE → timer starts (wall-clock fallback when no progress field).
 	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true})
 	if m.activeSince.IsZero() {
 		t.Fatal("activeSince should be set on entering ACTIVE")
@@ -89,6 +91,13 @@ func TestActiveSinceLifecycle(t *testing.T) {
 	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true})
 	if !m.activeSince.Equal(first) {
 		t.Errorf("activeSince should be preserved while staying ACTIVE; was %v, now %v", first, m.activeSince)
+	}
+
+	// Stay ACTIVE with fresh kernel progress → baseline advances to it.
+	progress := time.Now().Add(-4 * time.Second)
+	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true, lastProgressAt: progress})
+	if !m.activeSince.Equal(progress) {
+		t.Errorf("activeSince should advance to last_progress_at; was %v, now %v", first, m.activeSince)
 	}
 
 	// Leave ACTIVE → timer cleared so the badge drops the elapsed suffix.


### PR DESCRIPTION
## What

The mail view footer activity indicator ("Email To: Agent  ◎ active 12s") previously measured seconds since the TUI first observed the ACTIVE transition (wall-clock). This drifts from the kernel taskcard footer when an agent stays active for a long time without a TUI refresh. Now the TUI reads each target's `.status.json` `runtime.last_progress_at` and uses it as the elapsed baseline while ACTIVE, so "active N sec" shows seconds since the last tool call — the same semantics as the kernel taskcard footer (Lingtai-AI/lingtai-kernel#1239).

## Details

- **internal/fs/activity.go**: export `fs.LastProgressAt(agentDir, now)` reusing the existing status-snapshot reader and future-clamp logic.
- **internal/tui/mail.go**: carry `lastProgressAt` / `directLastProgress` on mailRefreshMsg; on entering ACTIVE (and on later refresh when the kernel reports a different last_progress_at) set activeSince from it; fall back to wall-clock when the field is absent so older kernels still show some elapsed.
- Render helper (activeElapsedFor) untouched.

## Tests

- TestActiveSinceLifecycle extended: entering ACTIVE with a last_progress_at baseline adopts it; staying ACTIVE with fresh progress advances the baseline.
- Existing TestActiveElapsed and fs last_progress parsing tests still pass.

Note: TestResolveAddress / TestSessionAtomicReplacement (fs) and two skill-folder tests (tui) fail on this Windows host pre-existing (path separators / file locks), unrelated to this change.
