### PR TITLE
docs(dev-guide): add PYTHONPATH launch-session hygiene rules

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -7,8 +7,8 @@ description: >
   running network, audit security, run a runtime self-check, get a PR
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
-version: 2.7.0
-last_changed_at: "2026-07-18T00:00:00Z"
+version: 2.8.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
@@ -54,6 +54,15 @@ generic procedures here for local guidance, or restate local rules from memory.
   not as a reason to paste large content into `SKILL.md`. Put dense material in
   related/nested reference files and link to `skills-manual` for current
   authoring mechanics and limit-aware structure.
+- **Launch-session / PYTHONPATH hygiene rule:** never launch the TUI or an agent
+  from a shell session that exports `PYTHONPATH`. A leftover `PYTHONPATH` pointing
+  at another project's scratch/worktree/temp repo `src` shadows the venv's own
+  `lingtai` import, and because the refresh watcher copies `os.environ` verbatim,
+  the pollution survives refresh — a plain `refresh` re-inherits it. Debug
+  sessions that `export PYTHONPATH=...` for one experiment silently infect every
+  agent they launch. See `reference/gotchas/SKILL.md` ("PYTHONPATH pollution")
+  and `reference/runtime-self-check/SKILL.md` §1 for the probe and clean-relaunch
+  recipe.
 
 ## ANATOMY frontmatter contract
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
@@ -2,8 +2,8 @@
 name: dev-guide-gotchas
 description: >
   Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, dev-mode rebuilds, editable installs, migrations, localization, authorization gates, config conventions, and rebuild-gate test false-passes.
-version: 1.1.0
-last_changed_at: "2026-07-18T00:00:00Z"
+version: 1.2.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
@@ -110,6 +110,53 @@ A successful PR merge does not prove running agents execute the merged code. The
 **Symptom:** a feature present on GitHub is missing at runtime; imports such as `lingtai.mcp_servers` fail; an MCP/addon path still points at an old standalone repo or a detached worktree.
 
 **Fix:** probe the exact Python interpreter the agent uses and print `module.__file__` for `lingtai`, `lingtai.kernel`, and the relevant MCP/addon modules; inspect the git root/HEAD behind those paths; fast-forward or editable-reinstall the intended source; then call `system(action="refresh")` and rerun the probe. Command recipe: `reference/setup/SKILL.md` → "Verify the runtime checkout a running agent actually uses". Discipline: `reference/runtime-self-check/SKILL.md`.
+
+## PYTHONPATH pollution shadows the runtime import
+
+A leftover `PYTHONPATH` in the launch environment can silently replace the
+runtime venv's `lingtai` with another project's source. This is a real incident:
+2026-08-09, a dev agent refreshed onto a fresh frozen main, then post-refresh
+probing showed `import lingtai` resolving to a *different* project's scratch
+checkout (`exact-8c44d232/src`) because the live parent process carried
+`PYTHONPATH=/Users/.../dev-2/.../scratch/.../src` from the session that launched
+it. The intended venv was untouched — the import path just pointed elsewhere.
+
+**Root cause:** debug sessions commonly `export PYTHONPATH=...` to test one
+scratch/worktree/temp repo. LingTai's refresh watcher copies the parent
+environment verbatim (`os.environ`), so pollution survives refresh — a plain
+`system(action="refresh")` re-inherits it. The wrong import can persist across
+refreshes until the *process* is relaunched from a clean environment.
+
+**Symptoms:** post-refresh probes disagree with the configured venv
+(`lingtai.__file__` points at another project's `src/`), `direct_url`/git HEAD
+resolve to the wrong checkout, or behavior matches old code that is no longer in
+`init.json`/the venv.
+
+**Prevention (launch-session discipline):** never launch the TUI or an agent
+from a shell session that exports `PYTHONPATH`. If you must test scratch source,
+use `env -u PYTHONPATH` or an isolated venv/preset rather than exporting it into
+the shared launch session.
+
+**Detection:** inspect the live process environment, not just config:
+
+```bash
+PID=<agent-parent-pid>
+ps eww -p "$PID" | tr ' ' '\n' | grep '^PYTHONPATH=' || echo 'PYTHONPATH absent'
+```
+
+Then confirm the import resolves from the intended venv with the same probe
+under a clean environment:
+
+```bash
+VENV_PY=<configured-venv>/bin/python
+env -u PYTHONPATH "$VENV_PY" -c 'import lingtai; print(lingtai.__file__)'
+```
+
+**Recovery when pollution is already live:** a plain refresh re-inherits the
+pollution, so use an identity-verified clean relaunch of the agent process (with
+`PYTHONPATH` unset in the new parent and children) instead of relying on
+refresh. See `reference/runtime-self-check/SKILL.md` §1 for the full probe and
+relaunch recipe.
 
 ## Migration cross-package contract
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -9,8 +9,8 @@ description: >
   evidence safely with secrets redacted. Includes verifying that long-lived
   runtime objects (services/adapters/caches) were actually rebuilt after a
   refresh, not just that new source is imported.
-version: 1.2.0
-last_changed_at: "2026-07-18T00:00:00Z"
+version: 1.3.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
@@ -113,6 +113,38 @@ auto-upgraded by the TUI (`tui/internal/config/venv.go:isEditableLingtaiInstall`
 so once dev mode is established it stays. An unexpected `site-packages` path means
 the auto-upgrader or a `brew reinstall` clobbered it — re-establish dev mode per
 the setup/gotchas references.
+
+### PYTHONPATH shadowing check
+
+Before trusting an import probe, confirm the live agent process is not carrying a
+stale `PYTHONPATH` that overrides the venv. Debug sessions often `export
+PYTHONPATH=...` to test a scratch/worktree/temp repo, and because LingTai's
+refresh watcher copies the parent environment verbatim, that pollution survives
+refresh — a plain refresh re-inherits it and the wrong import can persist until
+the process is relaunched from a clean environment. See `reference/gotchas/SKILL.md`
+("PYTHONPATH pollution") for the full incident and rules.
+
+```bash
+PID=<agent-parent-pid>
+ps eww -p "$PID" | tr ' ' '\n' | grep '^PYTHONPATH=' && echo 'POLLUTED' || echo 'clean'
+```
+
+Then confirm the import resolves from the intended venv under a clean
+environment (this is the source of truth, not whatever `python` resolves on
+PATH):
+
+```bash
+VENV_PY=<configured-venv>/bin/python   # e.g. ~/.lingtai-tui/runtime/venv/bin/python
+env -u PYTHONPATH "$VENV_PY" - <<'PY'
+import importlib.util, json
+spec = importlib.util.find_spec("lingtai")
+print(json.dumps({"lingtai_file": spec.origin if spec else None}))
+PY
+```
+
+If `ps eww` shows a `PYTHONPATH` and the venv probe differs, a normal
+`system(action="refresh")` will **not** fix it (the watcher re-inherits the
+pollution); use the clean-relaunch recipe in §8 instead.
 
 ## 2. Active binary and dev-mode symlink check
 
@@ -283,6 +315,42 @@ never print env *values*; generalize private absolute paths to
 `<your-lingtai-checkout>` / `~/.lingtai-tui/...`; omit or redact Telegram chat
 IDs, emails, and recipient lists; report "match found" / "uses env reference",
 not the matched secret.
+
+## 8. Clean relaunch of a polluted agent process
+
+When a live agent carries a `PYTHONPATH` that points at another project's source
+and a plain refresh re-inherits it, the only correct recovery is an
+identity-verified clean relaunch of the process with `PYTHONPATH` unset in the
+new parent and children. This is an **authorized owner/operator action** — get
+explicit permission for the exact PID/root before doing it.
+
+1. **Identity-verify the old parent.** Confirm the PID, full command, parent
+   lineage, working directory, and start identity match the agent root you think
+   you are restarting. Never kill on a `ps | grep | xargs kill` hunch.
+2. **SIGTERM the old parent gracefully** and confirm its children exit.
+3. **Launch the new parent from a clean environment**, explicitly unsetting the
+   pollution the session would otherwise inherit:
+
+   ```bash
+   ROOT=<agent-root-dir>                 # e.g. .../.lingtai/<agent>
+   VENV_PY=<configured-venv>/bin/python  # exact venv from init.json
+   env -u PYTHONPATH \
+       -u LINGTAI_RUNTIME_PYTHON \
+       -u LINGTAI_RUNTIME_VENV \
+       -u LINGTAI_REFRESH_ENV_OVERWRITE \
+       "$VENV_PY" -m lingtai run "$ROOT"
+   ```
+4. **Verify the relaunch, not just that a process exists:** new parent/children
+   PIDs and PPID 1; `ps eww` shows `PYTHONPATH` absent; `sys.executable`,
+   `lingtai.__file__`, `kernel.find_spec`, and `direct_url` all resolve from the
+   intended venv/source; heartbeat fresh; a producer-channel read (e.g. Telegram)
+   and a self-email canary both PASS; the old PID is absent. Preserve any old
+   rollback/evidence and do not do a second refresh.
+
+This recipe was proven on 2026-08-09 when a dev agent's live parent inherited
+`PYTHONPATH` from its launch session (pointing at another project's scratch
+`src`), survived the first refresh, and required exactly this clean relaunch
+before `import lingtai` resolved from the intended frozen source.
 
 ## Related references
 


### PR DESCRIPTION
## Summary
Adds the launch-session / PYTHONPATH hygiene rules from the 2026-08-09 machine-wide PYTHONPATH 乱象 investigation to the bundled `lingtai-dev-guide` skill.

## What changed
1. **Router** (`tui/internal/preset/skills/lingtai-dev-guide/SKILL.md`): new non-negotiable rule — never launch TUI/agents from a session that exports `PYTHONPATH`; the refresh watcher copies `os.environ` verbatim so pollution survives refresh.
2. **Gotchas** (`reference/gotchas/SKILL.md`): new `PYTHONPATH pollution shadows the runtime import` entry documenting the real 2026-08-09 incident, root cause, symptoms, prevention, detection (ps eww + env -u probe), and recovery (clean relaunch).
3. **Runtime self-check** (`reference/runtime-self-check/SKILL.md`): PYTHONPATH shadowing check in §1, and new §8 identity-verified clean-relaunch recipe for already-polluted agent processes.

## Validation
- `git diff --check` PASS
- YAML frontmatter parse PASS for all three skill files
- Versions bumped: router 2.7.0→2.8.0, gotchas 1.1.0→1.2.0, runtime-self-check 1.2.0→1.3.0
- Canonical author/committer: `Huang Zesen <hzsbazinga@outlook.com>`

## Scope
Docs-only change to the bundled dev-guide skill. No runtime/kernel code, no tests, no release. No secrets or private paths included (incident reference uses generalized `exact-8c44d232/src` and `.../dev-2/...` forms).