### PR TITLE
fix: close parent-side agent.log fd after agent launch

### DIFF
--- a/tui/internal/process/launcher.go
+++ b/tui/internal/process/launcher.go
@@ -122,7 +122,9 @@ func launchAgentUnsafe(lingtaiCmd, agentDir string) (*exec.Cmd, error) {
 	cmd := exec.Command(python, "-m", "lingtai", "run", agentDir)
 	// Redirect agent output to a log file instead of the TUI terminal
 	logPath := filepath.Join(agentDir, "logs")
-	os.MkdirAll(logPath, 0o755)
+	if err := os.MkdirAll(logPath, 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
 	logFile, err := os.OpenFile(filepath.Join(logPath, "agent.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err == nil {
 		cmd.Stdout = logFile
@@ -130,7 +132,16 @@ func launchAgentUnsafe(lingtaiCmd, agentDir string) (*exec.Cmd, error) {
 	}
 
 	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
 		return nil, fmt.Errorf("launch agent: %w", err)
+	}
+	// The child inherited its own copy of the descriptor for stdout/stderr;
+	// close the parent's copy so repeated launches and /refresh cycles do
+	// not accumulate open handles to agent.log.
+	if logFile != nil {
+		_ = logFile.Close()
 	}
 	return cmd, nil
 }


### PR DESCRIPTION
Fixes #487.

## Problem

`launchAgentUnsafe()` in `tui/internal/process/launcher.go` opens `<agent>/logs/agent.log`, assigns it to the child stdout/stderr, and starts the child without ever closing the parent-side copy of the file handle. Every launch (incl. repeated `/refresh`, preset switches, spawning agents) leaks one fd in the long-lived TUI process; `os.MkdirAll` errors were also silently ignored.

## Change

- Handle the `os.MkdirAll(logPath, 0o755)` error explicitly and surface it (`create log dir: %w`).
- Close the parent copy of `logFile` after a successful `cmd.Start()` (the child inherited its own descriptor; the parent no longer needs its copy).
- Close `logFile` when `cmd.Start()` fails, before returning the wrapped error.

Single-file, behavior-preserving fix; the `if err == nil` fallback that lets the child inherit the TUI terminal when the log cannot be opened is unchanged.

## Verification

- `go test ./... -count=1` in `tui/`: all packages pass (14/14 ok, incl. `internal/process`).
- `go vet ./internal/process/...`: ok. `gofmt -l`: clean. `go build ./...`: ok.
- Ad-hoc fd-leak check against the real `launchAgentUnsafe` (lsof on the test process):
  - **Unpatched main**: parent held **1 open fd** to `agent.log` after start (test failed as designed).
  - **Patched**: parent holds **0 fds** to `agent.log`, and the child still writes stdout/stderr markers into `agent.log` through its inherited descriptor.