### PR TITLE
fix(tui): atomic writes for init.json/.agent.json/settings.json

### DIFF
--- a/tui/internal/fs/atomic_write.go
+++ b/tui/internal/fs/atomic_write.go
@@ -96,6 +96,15 @@ func writeAtomicBytes(path string, data []byte, mode os.FileMode) error {
 	})
 }
 
+// WriteFileAtomic atomically replaces path with data by writing to a unique
+// sibling temporary file in the same directory, syncing it, and renaming it
+// over the destination. A crash or power loss mid-write leaves the previous
+// content intact instead of a truncated or empty file. Existing files keep
+// their permission bits; new files use mode subject to the process umask.
+func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
+	return writeAtomicBytes(path, data, mode)
+}
+
 func bestEffortSyncDirectory(path string) {
 	directory, err := os.Open(path)
 	if err != nil {

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/anthropics/lingtai-tui/internal/config"
+	lingfs "github.com/anthropics/lingtai-tui/internal/fs"
 )
 
 //go:embed all:covenant
@@ -2224,7 +2225,7 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	}
 
 	initPath := filepath.Join(agentDir, "init.json")
-	if err := os.WriteFile(initPath, data, 0o644); err != nil {
+	if err := lingfs.WriteFileAtomic(initPath, data, 0o644); err != nil {
 		return fmt.Errorf("write init.json: %w", err)
 	}
 
@@ -2288,8 +2289,13 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 		merged["state"] = ""
 	}
 
-	mdata, _ := json.MarshalIndent(merged, "", "  ")
-	os.WriteFile(agentJSONPath, mdata, 0o644)
+	mdata, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal .agent.json: %w", err)
+	}
+	if err := lingfs.WriteFileAtomic(agentJSONPath, mdata, 0o644); err != nil {
+		return fmt.Errorf("write .agent.json: %w", err)
+	}
 
 	return nil
 }
@@ -2391,7 +2397,7 @@ func rewritePresetBlock(initPath, defaultRef string, allowed []string, allowedSe
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
-	if err := os.WriteFile(initPath, out, 0o644); err != nil {
+	if err := lingfs.WriteFileAtomic(initPath, out, 0o644); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	return nil

--- a/tui/internal/preset/rehydrate.go
+++ b/tui/internal/preset/rehydrate.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	lingfs "github.com/anthropics/lingtai-tui/internal/fs"
 )
 
 // RehydrateNetwork propagates the orchestrator's init.json to every other
@@ -114,7 +116,7 @@ func RehydrateNetwork(lingtaiDir, orchDirName string) (workersRehydrated int, er
 		if err != nil {
 			return workersRehydrated, fmt.Errorf("marshal %s/init.json: %w", entry.Name(), err)
 		}
-		if err := os.WriteFile(initPath, out, 0o644); err != nil {
+		if err := lingfs.WriteFileAtomic(initPath, out, 0o644); err != nil {
 			return workersRehydrated, fmt.Errorf("write %s/init.json: %w", entry.Name(), err)
 		}
 		workersRehydrated++

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1335,7 +1335,7 @@ func resetActivePresetToDefault(dir string) {
 	if err != nil {
 		return
 	}
-	os.WriteFile(initPath, out, 0o644)
+	fs.WriteFileAtomic(initPath, out, 0o644)
 }
 
 // readAllowedPresets returns the contents of manifest.preset.allowed from
@@ -1484,7 +1484,7 @@ func setActivePreset(dir, presetPath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(initPath, out, 0o644)
+	return fs.WriteFileAtomic(initPath, out, 0o644)
 }
 
 type childWindowSizeMsg struct {

--- a/tui/internal/tui/detect.go
+++ b/tui/internal/tui/detect.go
@@ -140,7 +140,7 @@ func PropagateOrchestratorConfig(baseDir, orchDir string) error {
 		if err != nil {
 			continue
 		}
-		os.WriteFile(initPath, out, 0o644)
+		fs.WriteFileAtomic(initPath, out, 0o644)
 	}
 	return nil
 }

--- a/tui/internal/tui/settings.go
+++ b/tui/internal/tui/settings.go
@@ -42,7 +42,7 @@ func SaveSettings(baseDir string, s Settings) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, "settings.json"), data, 0o644)
+	return fs.WriteFileAtomic(filepath.Join(dir, "settings.json"), data, 0o644)
 }
 
 // SettingField represents a single configurable setting.
@@ -370,7 +370,7 @@ func (m *SettingsModel) saveNickname() {
 		manifest["nickname"] = m.nickname
 	}
 	if out, err := json.MarshalIndent(manifest, "", "  "); err == nil {
-		os.WriteFile(humanPath, out, 0o644)
+		fs.WriteFileAtomic(humanPath, out, 0o644)
 	}
 }
 
@@ -389,7 +389,7 @@ func (m *SettingsModel) saveAgentName() {
 				manifest["agent_name"] = m.agentName
 			}
 			if out, err := json.MarshalIndent(init, "", "  "); err == nil {
-				os.WriteFile(initPath, out, 0o644)
+				fs.WriteFileAtomic(initPath, out, 0o644)
 			}
 		}
 	}
@@ -417,7 +417,7 @@ func (m *SettingsModel) saveAgentLang(lang string) {
 	delete(initData, "covenant")
 	delete(initData, "principle")
 	if out, err := json.MarshalIndent(initData, "", "  "); err == nil {
-		os.WriteFile(initPath, out, 0o644)
+		fs.WriteFileAtomic(initPath, out, 0o644)
 	}
 }
 


### PR DESCRIPTION
Fixes #482.

## Problem

Runtime writes to `init.json`, `.agent.json` and `settings.json` used bare `os.WriteFile`, so a crash or power loss mid-write could leave the file truncated or empty, making the agent unlaunchable on next boot. The setup wizard also swallowed the `.agent.json` marshal/write errors entirely (issues additional finding).

## Change

- Export `fs.WriteFileAtomic` (unique sibling temp file, fsync, rename, existing-mode preservation) from `tui/internal/fs` — the same primitive already used for mail/session/location durability.
- Convert every runtime (non-migration) write to `init.json` / `.agent.json` / `settings.json` to the shared helper:
  - `tui/internal/preset/preset.go`: `GenerateInitJSONWithOpts` (init.json + .agent.json), `rewritePresetBlock`
  - `tui/internal/preset/rehydrate.go`: `RehydrateNetwork`
  - `tui/internal/tui/app.go`: `resetActivePresetToDefault`, `setActivePreset`
  - `tui/internal/tui/detect.go`: `PropagateOrchestratorConfig`
  - `tui/internal/tui/settings.go`: `SaveSettings`, `saveNickname`, `saveAgentName`, `saveAgentLang`
- `GenerateInitJSONWithOpts` now returns the `.agent.json` marshal/write errors instead of silently ignoring them.

Intentionally left out of scope (same boundary as the closed #581): one-shot migrations (`internal/migrate`), non-config state files (`.sleep`/`.suspend`/`.clear`), auth/temp files, and embedded-asset bootstrap writes.

## Validation

- `go build ./...` → ok
- `go vet ./internal/fs/ ./internal/preset/ ./internal/tui/` → ok
- `go test ./internal/fs/... ./internal/preset/... -count=1` → ok (5.1s / 4.9s)
- `go test ./internal/tui/ -count=1` → ok (33s)

No merge/close is performed by this PR.