### PR TITLE
fix(tui): keep waiting for launch heartbeat while agent process is alive

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1749,18 +1749,39 @@ func reviveDir(lingtaiCmd, dir string) error {
 	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
+// Launch heartbeat watchdog tuning. Overridable in tests to keep the poll fast.
+var (
+	launchHeartbeatPoll      = 200 * time.Millisecond
+	launchHeartbeatCap       = 60 * time.Second
+	launchHeartbeatIsAlive   = fs.IsAlive
+	launchHeartbeatIsRunning = process.IsAgentRunning
+)
+
+// waitForLaunchHeartbeat polls for a fresh heartbeat from a freshly launched
+// agent. If the launched process exits before the first heartbeat, that is a
+// hard failure. Slow startup (e.g. several stdio MCP addons initialized
+// serially) can legitimately exceed timeout before the first heartbeat: as
+// long as a process is still alive in the agent dir we keep waiting past the
+// initial deadline, up to launchHeartbeatCap, so a recovering launch is not
+// misreported as failed and the user is not pushed into a duplicate relaunch
+// (see #671).
 func waitForLaunchHeartbeat(cmd *exec.Cmd, dir string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if fs.IsAlive(dir, 3.0) {
+	started := time.Now()
+	deadline := started.Add(timeout)
+	for {
+		if launchHeartbeatIsAlive(dir, 3.0) {
 			return nil
 		}
-		if cmd != nil && !process.IsAgentRunning(dir) {
+		if cmd != nil && !launchHeartbeatIsRunning(dir) {
 			return fmt.Errorf("agent launch exited before writing a fresh heartbeat; see %s", filepath.Join(dir, "logs", "agent.log"))
 		}
-		time.Sleep(200 * time.Millisecond)
+		if now := time.Now(); now.After(deadline) && now.Sub(started) >= launchHeartbeatCap {
+			// The heartbeat was re-checked at the top of this iteration, so
+			// this is a true absence-of-heartbeat verdict after the cap.
+			return fmt.Errorf("agent launch did not write a fresh heartbeat within %s; see %s", launchHeartbeatCap, filepath.Join(dir, "logs", "agent.log"))
+		}
+		time.Sleep(launchHeartbeatPoll)
 	}
-	return fmt.Errorf("agent launch did not write a fresh heartbeat within %s; see %s", timeout, filepath.Join(dir, "logs", "agent.log"))
 }
 
 // firstLine returns the first line of err.Error(), trimmed of trailing

--- a/tui/internal/tui/launch_heartbeat_test.go
+++ b/tui/internal/tui/launch_heartbeat_test.go
@@ -1,0 +1,97 @@
+package tui
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubLaunchHeartbeat overrides the waitForLaunchHeartbeat dependencies so
+// tests can simulate heartbeat freshness and process liveness without
+// launching a real agent. The cap is shrunk so the alive-grace path is
+// exercised in milliseconds.
+func stubLaunchHeartbeat(t *testing.T, alive func(string, float64) bool, running func(string) bool) {
+	t.Helper()
+	origAlive := launchHeartbeatIsAlive
+	origRunning := launchHeartbeatIsRunning
+	origPoll := launchHeartbeatPoll
+	origCap := launchHeartbeatCap
+	launchHeartbeatIsAlive = alive
+	launchHeartbeatIsRunning = running
+	launchHeartbeatPoll = time.Millisecond
+	launchHeartbeatCap = 60 * time.Millisecond
+	t.Cleanup(func() {
+		launchHeartbeatIsAlive = origAlive
+		launchHeartbeatIsRunning = origRunning
+		launchHeartbeatPoll = origPoll
+		launchHeartbeatCap = origCap
+	})
+}
+
+func TestWaitForLaunchHeartbeatFresh(t *testing.T) {
+	stubLaunchHeartbeat(t,
+		func(string, float64) bool { return true },
+		func(string) bool { return true },
+	)
+	if err := waitForLaunchHeartbeat(&exec.Cmd{}, t.TempDir(), 10*time.Second); err != nil {
+		t.Fatalf("fresh heartbeat should succeed immediately, got: %v", err)
+	}
+}
+
+func TestWaitForLaunchHeartbeatExitedFailsFast(t *testing.T) {
+	stubLaunchHeartbeat(t,
+		func(string, float64) bool { return false },
+		func(string) bool { return false },
+	)
+	start := time.Now()
+	err := waitForLaunchHeartbeat(&exec.Cmd{}, t.TempDir(), 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error when the launched process exits before a heartbeat")
+	}
+	if !strings.Contains(err.Error(), "exited before writing a fresh heartbeat") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("process-exit failure should be fast, took %v", elapsed)
+	}
+}
+
+func TestWaitForLaunchHeartbeatSlowStartSucceeds(t *testing.T) {
+	// Simulates an agent whose first heartbeat appears only after the initial
+	// timeout (e.g. serial stdio MCP addon initialization): the process stays
+	// alive and eventually heartbeats, so the launch must not be reported as
+	// failed at the initial deadline.
+	var calls int
+	stubLaunchHeartbeat(t,
+		func(string, float64) bool { calls++; return calls >= 5 },
+		func(string) bool { return true },
+	)
+	start := time.Now()
+	if err := waitForLaunchHeartbeat(&exec.Cmd{}, t.TempDir(), 2*time.Millisecond); err != nil {
+		t.Fatalf("slow start should succeed once the heartbeat appears, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Millisecond {
+		t.Fatalf("success should happen after the initial deadline, took %v", elapsed)
+	}
+}
+
+func TestWaitForLaunchHeartbeatAliveNoHeartbeatTimesOutAtCap(t *testing.T) {
+	// The process stays alive but never writes a heartbeat: the verdict must
+	// wait until launchHeartbeatCap (not the initial deadline) before failing.
+	stubLaunchHeartbeat(t,
+		func(string, float64) bool { return false },
+		func(string) bool { return true },
+	)
+	start := time.Now()
+	err := waitForLaunchHeartbeat(&exec.Cmd{}, t.TempDir(), 5*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected a timeout error when no heartbeat ever appears")
+	}
+	if !strings.Contains(err.Error(), "did not write a fresh heartbeat within") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
+		t.Fatalf("should keep waiting while the process is alive up to the cap, returned after %v", elapsed)
+	}
+}


### PR DESCRIPTION
Fixes #671 (TUI half: the refresh/relaunch watchdog misreporting slow startup).

## Problem

The TUI launch watchdog (`waitForLaunchHeartbeat`, used by `/refresh`, `/refresh <preset>`, and `/cpr`) declared failure at a fixed 10-second deadline even when the freshly launched agent process was still alive and merely slow to write its first heartbeat (e.g. several stdio MCP addons initialized serially at startup, which can take ~20s). The result was a misleading `agent launch did not write a fresh heartbeat within 10s` error, followed by duplicate relaunches that raced the now-healthy process (`another lingtai agent is already running`).

## Change

`waitForLaunchHeartbeat` now:
- succeeds as soon as a fresh heartbeat appears (unchanged fast path);
- fails fast only when the launched process exits before the first heartbeat (unchanged fast-fail path);
- otherwise keeps polling past the initial 10s deadline while a process stays alive in the agent dir, up to a 60s cap (`launchHeartbeatCap`), re-checking heartbeat freshness every iteration so the final verdict is never stale.

The watchdog timers/deps are exposed as package vars so the alive-grace behavior is unit-testable without launching a real agent.

The headless `spawn --ready-timeout` path is intentionally untouched (its timeout is already caller-configurable); the kernel-side halves of #671 (proxy env inheritance in `lingtai/services/mcp.py`, CPR launch watchdog in `lingtai/agent.py`) belong to `Lingtai-AI/lingtai-kernel` and should be tracked there.

## Tests

- `go build ./...` (module `github.com/anthropics/lingtai-tui`) — OK
- `go test ./internal/tui/ -run TestWaitForLaunchHeartbeat -count=1 -v` — 4/4 PASS:
  - `TestWaitForLaunchHeartbeatFresh` — immediate success on fresh heartbeat
  - `TestWaitForLaunchHeartbeatExitedFailsFast` — fast failure when the process exits
  - `TestWaitForLaunchHeartbeatSlowStartSucceeds` — late heartbeat after the initial deadline still succeeds
  - `TestWaitForLaunchHeartbeatAliveNoHeartbeatTimesOutAtCap` — verdict waits until the cap, not the initial deadline
- `go test ./internal/tui/ ./internal/headless/ ./internal/fs/ ./internal/process/...` — all ok (tui 24.3s, headless 2.5s, fs 5.8s, process 1.2s)
- `gofmt -l` clean; `go vet ./internal/tui/` clean
