### PR TITLE
ci: delete merged PR head branches automatically (fable fixes)

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,93 @@
+name: Delete merged PR branch
+
+# Merged pull-request head branches are never removed in this repository, so
+# `origin` has accumulated hundreds of dead refs (the overwhelming majority of
+# them heads of long-merged PRs). This workflow deletes a head branch at the
+# moment its PR merges, which is the only point where "merged, and nothing else
+# points at it" is knowable without guessing.
+#
+# `pull_request_target` (not `pull_request`) is deliberate: it runs the copy of
+# this file that lives on the base branch with a writable token, so a fork PR
+# can never substitute its own version of this workflow and inherit the delete
+# permission. The job never checks out the repository and never executes any
+# PR-authored code -- it only reads event metadata and calls the refs API.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: delete-merged-branch-${{ github.event.pull_request.number }}
+
+jobs:
+  delete-head-branch:
+    # Merged only: a PR closed without merging keeps its branch, so unfinished
+    # work is never destroyed. Same-repository heads only: a fork's branch
+    # belongs to its owner and is not ours to delete.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Delete the merged head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Git allows `$`, backticks and parentheses in ref names, so every
+          # attacker-influenceable value crosses into the script as an
+          # environment variable and is never interpolated into shell source.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # Refuse anything that could be read as a `gh` flag rather than a
+          # branch name. Fail closed: an undeleted branch is a nuisance, a
+          # wrongly deleted one is lost work.
+          case "$HEAD_REF" in
+            ""|-*)
+              echo "::warning::refusing to act on head ref '$HEAD_REF'"
+              exit 0
+              ;;
+          esac
+
+          # Long-lived integration branches stay even if one is ever merged
+          # through a PR.
+          case "$HEAD_REF" in
+            "$DEFAULT_BRANCH"|main|master|develop|gh-pages|release/*)
+              echo "Keeping protected branch '$HEAD_REF'."
+              exit 0
+              ;;
+          esac
+
+          # One branch can be the head of several PRs (a stacked branch also
+          # targeting a release base). Deleting it would force-close the others.
+          open_heads="$(gh pr list --repo "$REPO" --state open \
+            --head="$HEAD_REF" --json number --jq 'length')"
+          if [ "$open_heads" != "0" ]; then
+            echo "Keeping '$HEAD_REF': still the head of $open_heads open PR(s)."
+            exit 0
+          fi
+
+          # The branch may already be gone -- a human can delete it from the
+          # merge page, and the repository's own "automatically delete head
+          # branches" setting would win this race if it is ever enabled. Treat
+          # a missing ref as success; treat anything else as a real failure.
+          if gh api -X DELETE "repos/$REPO/git/refs/heads/$HEAD_REF" \
+              2>"$RUNNER_TEMP/delete-ref.err"; then
+            echo "Deleted '$HEAD_REF' (merged in PR #$PR_NUMBER)."
+          elif grep -qiE 'Reference does not exist|Not Found' \
+              "$RUNNER_TEMP/delete-ref.err"; then
+            echo "'$HEAD_REF' was already deleted; nothing to do."
+          else
+            cat "$RUNNER_TEMP/delete-ref.err" >&2
+            echo "::error::failed to delete '$HEAD_REF'"
+            exit 1
+          fi

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -49,10 +49,17 @@ jobs:
           set -euo pipefail
 
           # Refuse anything that could be read as a `gh` flag rather than a
-          # branch name. Fail closed: an undeleted branch is a nuisance, a
-          # wrongly deleted one is lost work.
+          # branch name, and anything the URL layer would reinterpret. Git
+          # permits `#` and `%` in ref names, and `gh api` hands the path to
+          # Go's URL parser, which drops everything after a `#` and decodes
+          # `%XX`: a legal head ref `fix/issue#123` would send the DELETE at
+          # `refs/heads/fix/issue`, a different and unmerged branch, past every
+          # guard below. An allowlist rather than a blocklist, so a character
+          # nobody thought about is refused rather than passed through. Fail
+          # closed: an undeleted branch is a nuisance, a wrongly deleted one is
+          # lost work.
           case "$HEAD_REF" in
-            ""|-*)
+            ""|-*|*[!A-Za-z0-9._/-]*)
               echo "::warning::refusing to act on head ref '$HEAD_REF'"
               exit 0
               ;;
@@ -69,8 +76,16 @@ jobs:
 
           # One branch can be the head of several PRs (a stacked branch also
           # targeting a release base). Deleting it would force-close the others.
-          open_heads="$(gh pr list --repo "$REPO" --state open \
-            --head="$HEAD_REF" --json number --jq 'length')"
+          # `gh pr list --head` matches on ref *name* alone, across fork PRs
+          # too, so an unrelated fork branch of the same name would block a
+          # deletion that is ours to make. The REST `head` filter takes an
+          # `owner:ref` pair instead, which is owner-qualified natively (and
+          # passes the ref as a query parameter rather than in the URL path).
+          # The base side -- a PR still open *against* this branch -- is
+          # delegated to GitHub, which retargets dependent PRs onto the merged
+          # PR's base when the base PR merges.
+          open_heads="$(gh api -X GET "repos/$REPO/pulls" \
+            -f state=open -f head="${REPO%%/*}:$HEAD_REF" --jq 'length')"
           if [ "$open_heads" != "0" ]; then
             echo "Keeping '$HEAD_REF': still the head of $open_heads open PR(s)."
             exit 0
@@ -78,12 +93,32 @@ jobs:
 
           # The branch may already be gone -- a human can delete it from the
           # merge page, and the repository's own "automatically delete head
-          # branches" setting would win this race if it is ever enabled. Treat
-          # a missing ref as success; treat anything else as a real failure.
+          # branches" setting would win this race if it is ever enabled. Treat a
+          # missing ref as success; treat anything else as a real failure.
+          #
+          # Only a genuine missing ref qualifies. GitHub answers a DELETE on a
+          # ref that is not there with `422 Reference does not exist`, whereas a
+          # bare `404 Not Found` is also what it returns for an authorization
+          # failure on a resource the token cannot see -- matching `Not Found`
+          # would report a token-scope regression, a repository rename or a
+          # malformed path as "nothing to do" and branches would quietly stop
+          # being cleaned with nothing in the Actions log to say so.
+          #
+          # Encoding constraint: `$HEAD_REF` goes into a URL *path* below with
+          # no encoding, which is only safe because the allowlist guard above
+          # has already rejected every character the URL layer reinterprets
+          # (`#`, `%`, anything outside [A-Za-z0-9._/-]). Do not relax that
+          # guard, and do not reach for `@uri` instead: it escapes `/` too and
+          # would break every nested branch name in the repository. Cases to
+          # re-check by hand after editing this step -- there is no shell test
+          # harness in this repository to hold the PR's mock-`gh` matrix, so
+          # this list is the durable artifact: protected ref, 422 missing ref,
+          # 403, `-rf`, `$(touch PWNED)x`, `main#123`, `fix/issue#123`, `ma%69n`
+          # (the last three must be refused by the guard, never requested).
           if gh api -X DELETE "repos/$REPO/git/refs/heads/$HEAD_REF" \
               2>"$RUNNER_TEMP/delete-ref.err"; then
             echo "Deleted '$HEAD_REF' (merged in PR #$PR_NUMBER)."
-          elif grep -qiE 'Reference does not exist|Not Found' \
+          elif grep -qF 'Reference does not exist' \
               "$RUNNER_TEMP/delete-ref.err"; then
             echo "'$HEAD_REF' was already deleted; nothing to do."
           else

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -14,6 +14,7 @@ related_files:
   - CLAUDE.md
   - .github/workflows/release.yml
   - .github/workflows/windows-installer-smoke.yml
+  - .github/workflows/delete-merged-branch.yml
   - install.sh
   - install.ps1
   - scripts/update.sh
@@ -158,6 +159,7 @@ The repo root holds two binary trees plus shared infrastructure. Each binary is 
 - **`RELEASING.md`** — Release process: tag, GitHub release, Windows asset/bundle publication, automated Homebrew tap update, manual tap fallback, and the PowerShell install path.
 - **`.github/workflows/release.yml`** — Tag-push workflow (`v*` push only), three jobs. `source-release` verifies the tag and creates the public GitHub Release without building or uploading binaries. `update-homebrew` fails closed unless the pushed tag is an exact `vX.Y.Z` (checked in its first step, before the `Lingtai-AI/homebrew-lingtai` checkout materializes `HOMEBREW_TAP_TOKEN` on the runner), then computes the GitHub tag source-tarball checksum, rewrites `lingtai-tui.rb`, and pushes the source-build formula update to that tap; the tag reaches every step as `env: TAG`, never as a `${{ }}` expression interpolated into a shell script. `windows-release` (`needs: source-release`) fails closed unless `kernel-release.json`'s pinned kernel release exists and publishes a verified `win_amd64` wheel, then cross-compiles `lingtai-tui.exe`/`lingtai-portal.exe` for `windows/amd64`, packages `lingtai-<tag>-windows-amd64.zip`+`.sha256`, generates `lingtai-bundle-manifest.json`, and uploads all three via `gh release upload` — the only job in this workflow that uploads assets. See `RELEASING.md`.
 - **`.github/workflows/windows-installer-smoke.yml`** — Runs `scripts/test-install-ps1.ps1` and `scripts/test-remove-ps1.ps1` under both Windows PowerShell 5.1 and PowerShell 7 on `windows-latest` (PR/push, no live-release dependency), plus a `windows-release-asset-smoke` job gated to `push: tags: v*` that polls the just-published release for its Windows asset and runs a real `-SkipVenv` install against it.
+- **`.github/workflows/delete-merged-branch.yml`** — Deletes a pull request's head branch when that PR merges, so merged refs stop accumulating on `origin`. Runs on `pull_request_target: closed` (base-branch definition, writable token, no checkout and no PR-authored code) and acts only when the PR actually merged and its head lives in this repository — fork heads and closed-without-merge branches are left alone, as are the default/`develop`/`gh-pages`/`release/*` branches and any branch that is still the head of another open PR. An already-deleted ref is a success, not a failure, so it composes with the repository's own "automatically delete head branches" setting rather than fighting it.
 - **`CLAUDE.md`** — Repo-specific Claude Code instructions (build commands, gotchas, sibling repos).
 
 ### `tui/` packages


### PR DESCRIPTION
Same-repo replacement for #801 (wchwawa fork head). Includes original content d1eaccd5 + fable r2 fixes cbd2febb:

- F1 (BLOCKING): HEAD_REF allowlist guard rejects #/% before API call; zero gh calls on 8 refused mock cases
- F2: 404 vs auth distinguished (grep only matches exact 404 text); fails safe/loud
- F3: owner-qualified open-PR guard verified live (7 open PRs, control row)
- F4/F5: comments

fable r2 VERDICT: APPROVE (tmp/fable-pr-reviews/pr-801-r2.md). 17-case mock matrix, yaml.safe_load, bash -n all pass.

@homewinlingtaibot / 深一