### PR TITLE
feat(preset): OpenCode Go preset expansion — kimi/mimo Go rows, grok-4.5, model curation

### DIFF
--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -121,10 +121,25 @@ only ever grows rots into one.
 - `providerModels` (`tui/internal/tui/preset_editor.go`) — the ←/→ picker
   on the editor's model row;
 - the default `model` of every built-in preset constructor
-  (`tui/internal/preset/preset.go`), which must itself be one of the shipped
-  ids;
+  (`tui/internal/preset/preset.go`), which for a picker-bearing provider must
+  itself be one of that provider's shipped ids;
 - `modelHasVision` (`tui/internal/tui/preset_editor.go`), which carries one
-  entry per shipped id and no entry for a retired one.
+  entry per id in `providerModels` and no entry for a retired one. The
+  bijection is what `TestModelHasVisionDeclaresEveryShippedModel` enforces,
+  minus two deliberate exemptions it names: `nvidia` (a gateway catalog whose
+  per-vendor vision facts we do not verify) and the `claude*` CLI-alias
+  spellings. Adding an exemption is a change to that test, not a silent
+  omission;
+- **not** the providers whose model row is free text. `kimi`, `gemini`,
+  `openrouter`, and `custom` have no `providerModels` entry, so they have no
+  `modelHasVision` entries either and the bijection test never sees them.
+  Their default model is still expected to be a current generation
+  (`kimi-for-coding`, `gemini-3-flash-preview`, `z-ai/glm-5.1`, and `custom`'s
+  empty model), but the maps carry nothing for them and must not be given
+  entries to "complete" the table — for `kimi` in particular, adding a
+  `providerModels` entry flips its row from free text to picker-only and one
+  `→` silently overwrites a typed Moonshot id. That deletion is deliberate and
+  pinned by a negative assertion in `preset_editor_test.go`.
 
 Reading of the rule:
 
@@ -133,7 +148,7 @@ Reading of the rule:
 | family | one vendor's model line — `MiniMax-M*`, `GLM-*`, `mimo-v*`, `deepseek-v*`, `gpt-5.*`, `kimi-k*` |
 | generation | the version step within the family — `M3` vs `M2.7`; `GLM-5.2` vs `GLM-5.1`; `gpt-5.6` vs `gpt-5.5` |
 | **not** a generation | a variant inside one generation — `-highspeed`, `-pro`, `-flash`, `-mini`, `-Air`, the `gpt-5.6-sol/-terra/-luna` routes, or the same generation respelled for another endpoint (`GLM-5.2` / `glm-5.2`). All variants of a kept generation stay. |
-| exempt | catalogs with no generation ladder: CLI aliases naming concurrent tiers (`opus`/`fable`/`sonnet`/`haiku`), and gateway catalogs that list one current id per vendor (`nvidia`). The rule still applies per family inside such a list. |
+| exempt | catalogs with no generation ladder: CLI aliases naming concurrent tiers (`opus`/`fable`/`sonnet`/`haiku`), and gateway catalogs that list one current id per vendor (`nvidia`). The rule still applies per family inside such a list. Free-text model rows (`kimi`, `gemini`, `openrouter`, `custom`) are outside the `providerModels`/`modelHasVision` bindings entirely — see the fourth clause above. |
 
 **Standing obligation.** Adding a new generation is the same change that
 removes the third-newest one — from `providerModels`, from `modelHasVision`,

--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -128,8 +128,10 @@ only ever grows rots into one.
   bijection is what `TestModelHasVisionDeclaresEveryShippedModel` enforces,
   minus two deliberate exemptions it names: `nvidia` (a gateway catalog whose
   per-vendor vision facts we do not verify) and the `claude*` CLI-alias
-  spellings. Adding an exemption is a change to that test, not a silent
-  omission;
+  spellings. The exemptions apply only to the *requirement* to carry an
+  entry — the reverse direction is not exempt: a `modelHasVision` entry for
+  an id no picker ships still fails the test. Adding an exemption is a change
+  to that test, not a silent omission;
 - **not** the providers whose model row is free text. `kimi`, `gemini`,
   `openrouter`, and `custom` have no `providerModels` entry, so they have no
   `modelHasVision` entries either and the bijection test never sees them.

--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -11,6 +11,9 @@ related_files:
   - tui/internal/tui/props.go
   - tui/internal/tui/setup.go
   - tui/internal/tui/preset_library.go
+  - tui/internal/tui/preset_editor.go
+  - tui/internal/tui/SKILL.md
+  - tui/internal/preset/preset.go
   - tui/main.go
   - tui/internal/config/global_test.go
   - docs/tui-agent-alignment.md
@@ -104,6 +107,44 @@ appears as the degraded state below.
    (fable F8, D1-D5 below): check agents present (R1), `config.json`
    presence (R3.1), `.env` API keys (R2), `.secrets` for declared addons
    (R1), runtime/version (R1).
+
+## Model list curation
+
+The model ids the TUI offers are a contract with the user: everything the
+picker shows must be something the chosen endpoint actually serves today. A
+retired id in the list is a 4xx the user did not ask for, and a list that
+only ever grows rots into one.
+
+**Two-generation rule.** For every model family, the TUI ships only the
+**latest two generations**. This binds:
+
+- `providerModels` (`tui/internal/tui/preset_editor.go`) — the ←/→ picker
+  on the editor's model row;
+- the default `model` of every built-in preset constructor
+  (`tui/internal/preset/preset.go`), which must itself be one of the shipped
+  ids;
+- `modelHasVision` (`tui/internal/tui/preset_editor.go`), which carries one
+  entry per shipped id and no entry for a retired one.
+
+Reading of the rule:
+
+| Term | Meaning |
+|---|---|
+| family | one vendor's model line — `MiniMax-M*`, `GLM-*`, `mimo-v*`, `deepseek-v*`, `gpt-5.*`, `kimi-k*` |
+| generation | the version step within the family — `M3` vs `M2.7`; `GLM-5.2` vs `GLM-5.1`; `gpt-5.6` vs `gpt-5.5` |
+| **not** a generation | a variant inside one generation — `-highspeed`, `-pro`, `-flash`, `-mini`, `-Air`, the `gpt-5.6-sol/-terra/-luna` routes, or the same generation respelled for another endpoint (`GLM-5.2` / `glm-5.2`). All variants of a kept generation stay. |
+| exempt | catalogs with no generation ladder: CLI aliases naming concurrent tiers (`opus`/`fable`/`sonnet`/`haiku`), and gateway catalogs that list one current id per vendor (`nvidia`). The rule still applies per family inside such a list. |
+
+**Standing obligation.** Adding a new generation is the same change that
+removes the third-newest one — from `providerModels`, from `modelHasVision`,
+and from any provider manual under
+`tui/internal/preset/skills/lingtai-preset-skill/reference/` that enumerates
+the lineup. Never rewrite `presets/saved/`: a user pinned to a retired id
+keeps working, the picker just stops offering it.
+
+Per-provider source lists, the rest of the inclusion checklist (served on our
+endpoint, GA not preview, documented vision, subscription gates), and the
+removal procedure live in `tui/internal/tui/SKILL.md`.
 
 ## Doctor checks (TUI-can't-start diagnostic set)
 

--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -230,7 +230,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 | `Save(p)` | `tui/internal/preset/preset.go:373` | ALWAYS to `saved/`; never templates |
 | `RefreshTemplates()` | `tui/internal/preset/preset.go:437` | rewrites `templates/` from `BuiltinPresets()`, prunes retired |
 | `PopulateBundledLibrary(globalDir)` | `tui/internal/preset/preset.go:1288` | rewrites `~/.lingtai-tui/utilities/` from embedded `skills/` |
-| `BuiltinPresets()` | `tui/internal/preset/preset.go:489` | minimax, zhipu, mimo, deepseek, gemini, kimi, nvidia, openrouter, codex, codex-pool, claude, custom |
+| `BuiltinPresets()` | `tui/internal/preset/preset.go:489` | minimax, zhipu, mimo, deepseek, gemini, kimi, grok, nvidia, openrouter, codex, codex-pool, claude, custom |
 | `skills/lingtai-preset-skill/` | `tui/internal/preset/skills/lingtai-preset-skill/SKILL.md:1` | thin dual-axis router: 13 direct provider children (one per `BuiltinPresets()` name, `reference/<preset>/SKILL.md`) plus 5 nested operation children for cross-cutting lifecycle mechanics (`reference/operations/<op>/SKILL.md`: `saved-presets`, `endpoint-capabilities`, `availability-save-gate`, `activation-session-refresh`, `troubleshooting-migration`). |
 | `IsTemplate(p)` | `tui/internal/preset/preset.go:540` | canonical "is this read-only?" — prefer over `IsBuiltin(p.Name)` |
 | `RefFor(p)` | `tui/internal/preset/preset.go:549` | `~/.lingtai-tui/presets/{templates\|saved}/<name>.json` |
@@ -257,7 +257,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 ## Composition
 
 - **Parent:** `tui/internal/` (no own anatomy)
-- **Subfolders:** `covenant/`, `principle/`, `procedures/`, `templates/`, `soul/`, `recipe_assets/`, `skills/` — all `//go:embed` targets. `skills/swiss-knife/` is a top-level router whose nested utility references live under `skills/swiss-knife/reference/*/SKILL.md`. `skills/lingtai-preset-skill/` is another top-level router with a dual-axis nested shape: 12 direct provider children mirroring `BuiltinPresets()` under `skills/lingtai-preset-skill/reference/*/SKILL.md`, plus 5 operation children under `skills/lingtai-preset-skill/reference/operations/*/SKILL.md` for cross-cutting lifecycle mechanics that apply across providers.
+- **Subfolders:** `covenant/`, `principle/`, `procedures/`, `templates/`, `soul/`, `recipe_assets/`, `skills/` — all `//go:embed` targets. `skills/swiss-knife/` is a top-level router whose nested utility references live under `skills/swiss-knife/reference/*/SKILL.md`. `skills/lingtai-preset-skill/` is another top-level router with a dual-axis nested shape: 13 direct provider children mirroring `BuiltinPresets()` under `skills/lingtai-preset-skill/reference/*/SKILL.md`, plus 5 operation children under `skills/lingtai-preset-skill/reference/operations/*/SKILL.md` for cross-cutting lifecycle mechanics that apply across providers.
 - **Siblings:** `tui/internal/migrate/ANATOMY.md` — migrations m029 (preset allowed list), m030 (preset dir split) live there
 
 ## State

--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -32,6 +32,7 @@ related_files:
   - tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -230,7 +231,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 | `RefreshTemplates()` | `tui/internal/preset/preset.go:437` | rewrites `templates/` from `BuiltinPresets()`, prunes retired |
 | `PopulateBundledLibrary(globalDir)` | `tui/internal/preset/preset.go:1288` | rewrites `~/.lingtai-tui/utilities/` from embedded `skills/` |
 | `BuiltinPresets()` | `tui/internal/preset/preset.go:489` | minimax, zhipu, mimo, deepseek, gemini, kimi, nvidia, openrouter, codex, codex-pool, claude, custom |
-| `skills/lingtai-preset-skill/` | `tui/internal/preset/skills/lingtai-preset-skill/SKILL.md:1` | thin dual-axis router: 12 direct provider children (one per `BuiltinPresets()` name, `reference/<preset>/SKILL.md`) plus 5 nested operation children for cross-cutting lifecycle mechanics (`reference/operations/<op>/SKILL.md`: `saved-presets`, `endpoint-capabilities`, `availability-save-gate`, `activation-session-refresh`, `troubleshooting-migration`). |
+| `skills/lingtai-preset-skill/` | `tui/internal/preset/skills/lingtai-preset-skill/SKILL.md:1` | thin dual-axis router: 13 direct provider children (one per `BuiltinPresets()` name, `reference/<preset>/SKILL.md`) plus 5 nested operation children for cross-cutting lifecycle mechanics (`reference/operations/<op>/SKILL.md`: `saved-presets`, `endpoint-capabilities`, `availability-save-gate`, `activation-session-refresh`, `troubleshooting-migration`). |
 | `IsTemplate(p)` | `tui/internal/preset/preset.go:540` | canonical "is this read-only?" — prefer over `IsBuiltin(p.Name)` |
 | `RefFor(p)` | `tui/internal/preset/preset.go:549` | `~/.lingtai-tui/presets/{templates\|saved}/<name>.json` |
 | `ResolveRefsWithAuth(refs, keys, auth)` / `ResolveRefs(refs, keys)` | `tui/internal/preset/preset.go` | health-check: Source, Exists, HasKey (+ `CodexAuthRef`) for each preset path; credential validity requires configured `api_key_env`, Codex OAuth, or Claude Code CLI auth for canonical provider `claude-code`. For codex, when `AuthState.CodexAuthDir` is set, validity is judged per-preset against the preset's own `manifest.llm.codex_auth_path` token file (empty → legacy `codex-auth.json` fallback) so multiple Codex accounts are independent; without the dir it falls back to the global `CodexOAuthConfigured` bool |

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -229,8 +229,8 @@ func List() ([]Preset, error) {
 	})
 	templateOrder := map[string]int{
 		"minimax": 0, "zhipu": 1, "mimo": 2, "deepseek": 3,
-		"kimi": 4, "nvidia": 5, "openrouter": 6, "codex": 7,
-		"codex-pool": 8, "claude": 9, "custom": 10,
+		"kimi": 4, "grok": 5, "nvidia": 6, "openrouter": 7,
+		"codex": 8, "codex-pool": 9, "claude": 10, "custom": 11,
 	}
 	sort.Slice(templates, func(i, j int) bool {
 		return templateOrder[templates[i].Name] < templateOrder[templates[j].Name]
@@ -389,8 +389,11 @@ func (p Preset) Validate() []error {
 		// pre-region-table wizard shape) is tolerated when regionSuffix can
 		// assign a default region (zhipu → CN, minimax → INTL): AutoEnvVarName
 		// stamps a slot for it, so such a preset remains well-defined. A
-		// region-table provider without a region fallback (deepseek) still
-		// needs an explicit endpoint, so an absent key stays a violation there.
+		// region-table provider without a region fallback (deepseek, kimi,
+		// mimo, grok) still needs an explicit endpoint, so an absent key stays
+		// a violation there. kimi and mimo joined that set when they gained a
+		// region table — a base_url-less kimi/mimo preset that validated on an
+		// older TUI must gain an explicit endpoint to save again.
 		// The editor's Custom sentinel is the only path that writes an
 		// explicit "", and that is always rejected.
 		if provider, _ := llm["provider"].(string); provider != "" {
@@ -546,13 +549,19 @@ func RefreshTemplates() error {
 //
 // Env is deliberately present ONLY where a region genuinely implies a
 // distinct credential (DeepSeek API vs OpenCode Go on deepseek, and the
-// OpenCode Go row on zhipu/minimax/kimi/mimo, are separate accounts). The
-// plain native rows (zhipu/minimax CN and INTL, Kimi Code, MiMo) declare
+// OpenCode Go row on zhipu/minimax/kimi/mimo/grok, are separate accounts).
+// The plain native rows (zhipu/minimax CN and INTL, Kimi Code, MiMo) declare
 // none: their slots are region-suffixed and host-stamped
 // (ZHIPU_INTL_1_API_KEY, MINIMAX_CN_1_API_KEY, KIMI_1_API_KEY via
 // AutoEnvVarName), and a flat Env on those rows would overwrite that slot
 // on every base_url cycle. Their provider default lives in
 // ProviderDefaultEnv instead.
+//
+// The Custom sentinel (empty URL) declares no Env either, and the editor
+// additionally leaves api_key_env untouched when landing on it: the user is
+// about to type their own endpoint and keeps whatever slot that endpoint
+// actually uses. Note the consequence for a preset arriving from an Env row —
+// the shared OpenCode Go slot carries over until the user changes it.
 type RegionURL struct {
 	Label string // user-facing option name, e.g. "CN", "INTL", "DeepSeek API", "Custom"
 	URL   string
@@ -585,18 +594,33 @@ var ProviderRegionURLs = map[string][]RegionURL{
 		{Label: "INTL", URL: "https://api.minimax.io/anthropic"},
 		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
 	},
-	// OpenCode Go serves the Kimi K-series (kimi-k3, kimi-k2.7-code,
-	// kimi-k2.6, kimi-k2.5) under lowercase model ids; the native Kimi Code
-	// endpoint serves the subscription model `kimi-for-coding`.
+	// OpenCode Go serves the Kimi K-series (kimi-k3, kimi-k2.7-code, ...)
+	// under lowercase model ids; the native Kimi Code endpoint serves the
+	// subscription model `kimi-for-coding`. Kimi had free-text base_url
+	// before it gained this table, so it carries the Custom sentinel too —
+	// a region table without one removes the only in-editor path to a
+	// corporate proxy or relay.
 	"kimi": {
 		{Label: "Kimi Code", URL: "https://api.kimi.com/coding/v1"},
 		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
+		{Label: "Custom", URL: ""}, // empty URL = free text sentinel
 	},
-	// OpenCode Go serves the MiMo V2 family (mimo-v2-pro, mimo-v2-omni,
-	// mimo-v2.5-pro, mimo-v2.5) alongside Xiaomi's own endpoint.
+	// OpenCode Go serves the MiMo V2 family alongside Xiaomi's own endpoint.
+	// Custom sentinel for the same reason as kimi above.
 	"mimo": {
 		{Label: "MiMo", URL: "https://api.xiaomimimo.com/v1"},
 		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
+		{Label: "Custom", URL: ""}, // empty URL = free text sentinel
+	},
+	// grok is the one provider whose DEFAULT row is OpenCode Go: the TUI has
+	// no native xAI route (no verified api.x.ai endpoint/model pairing), so
+	// `grok-4.5` is reached only through the Go subscription. Entry [0]
+	// therefore declares OPENCODE_GO_API_KEY and grokPreset() ships that same
+	// slot; ProviderDefaultEnv["grok"] holds the provider-generic slot used on
+	// a switch TO grok (see ProviderDefaultEnv below).
+	"grok": {
+		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
+		{Label: "Custom", URL: ""}, // empty URL = free text sentinel
 	},
 }
 
@@ -608,6 +632,14 @@ var ProviderRegionURLs = map[string][]RegionURL{
 //
 // Values match each builtin preset's declared api_key_env ("" = OAuth/CLI
 // providers with no key slot, or a generic placeholder the user replaces).
+//
+// grok is the single deliberate exception: grokPreset() declares
+// OPENCODE_GO_API_KEY because its default (and only non-Custom) endpoint IS
+// OpenCode Go, so an existing Go user needs no second copy of the key. The
+// entry below is the provider-GENERIC slot adopted on a switch TO grok from
+// another provider. Keeping the two different is what makes
+// usesRegionDeclaredEnv treat the Go slot as a cross-provider account worth
+// preserving across a save, instead of as this template's own shared slot.
 var ProviderDefaultEnv = map[string]string{
 	"minimax":    "MINIMAX_API_KEY",
 	"zhipu":      "ZHIPU_API_KEY",
@@ -615,6 +647,7 @@ var ProviderDefaultEnv = map[string]string{
 	"deepseek":   "DEEPSEEK_API_KEY",
 	"gemini":     "GEMINI_API_KEY",
 	"kimi":       "KIMI_CODE_API_KEY",
+	"grok":       "GROK_API_KEY",
 	"nvidia":     "NVIDIA_API_KEY",
 	"openrouter": "OPENROUTER_API_KEY",
 	"claude":     "",            // OAuth / CLI login
@@ -632,6 +665,7 @@ func BuiltinPresets() []Preset {
 		deepseekPreset(),
 		geminiPreset(),
 		kimiPreset(),
+		grokPreset(),
 		nvidiaPreset(),
 		openrouterPreset(),
 		codexPreset(),
@@ -653,6 +687,7 @@ var builtinNames = map[string]bool{
 	"deepseek":         true,
 	"gemini":           true,
 	"kimi":             true,
+	"grok":             true,
 	"nvidia":           true,
 	"openrouter":       true,
 	"codex":            true,
@@ -1254,6 +1289,28 @@ func kimiPreset() Preset {
 		"kimi",
 		"Kimi Code (Moonshot) — OpenAI-compatible, subscription-based, tool calling",
 		"kimi-for-coding", "KIMI_CODE_API_KEY", ProviderRegionURLs["kimi"][0].URL, "3")
+}
+
+func grokPreset() Preset {
+	// Grok (xAI) reached through the OpenCode Go subscription — the only
+	// route this TUI has verified for it. `grok-4.5` is the id the Go
+	// endpoint's model list serves; no native api.x.ai endpoint/model pairing
+	// has been checked, so none is shipped (a user with an xAI key selects
+	// the Custom base_url row, or clones the `custom` template).
+	//
+	// api_key_env is OPENCODE_GO_API_KEY rather than a grok-specific slot
+	// because the shipped endpoint IS OpenCode Go: someone who already
+	// configured that shared account for deepseek/zhipu/minimax/kimi/mimo
+	// gets a working grok preset without pasting the key a second time. The
+	// provider-generic GROK_API_KEY lives in ProviderDefaultEnv and is what a
+	// switch TO grok from another provider adopts.
+	//
+	// Text-only: the Go endpoint's image-input mapping for grok-4.5 is not
+	// pinned, so no vision capability is wired.
+	return openAICompatNoVisionPreset(
+		"grok",
+		"Grok (xAI) — OpenAI-compatible via OpenCode Go",
+		"grok-4.5", ProviderRegionURLs["grok"][0].Env, ProviderRegionURLs["grok"][0].URL, "3")
 }
 
 func nvidiaPreset() Preset {

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -546,11 +546,13 @@ func RefreshTemplates() error {
 //
 // Env is deliberately present ONLY where a region genuinely implies a
 // distinct credential (DeepSeek API vs OpenCode Go on deepseek, and the
-// OpenCode Go row on zhipu/minimax, are separate accounts). The plain
-// region rows (zhipu/minimax CN and INTL) declare none: their slots are
-// region-suffixed and host-stamped (ZHIPU_INTL_1_API_KEY,
-// MINIMAX_CN_1_API_KEY via AutoEnvVarName), and a flat Env on those rows
-// would overwrite that slot on every CN<->INTL base_url cycle.
+// OpenCode Go row on zhipu/minimax/kimi/mimo, are separate accounts). The
+// plain native rows (zhipu/minimax CN and INTL, Kimi Code, MiMo) declare
+// none: their slots are region-suffixed and host-stamped
+// (ZHIPU_INTL_1_API_KEY, MINIMAX_CN_1_API_KEY, KIMI_1_API_KEY via
+// AutoEnvVarName), and a flat Env on those rows would overwrite that slot
+// on every base_url cycle. Their provider default lives in
+// ProviderDefaultEnv instead.
 type RegionURL struct {
 	Label string // user-facing option name, e.g. "CN", "INTL", "DeepSeek API", "Custom"
 	URL   string
@@ -581,6 +583,19 @@ var ProviderRegionURLs = map[string][]RegionURL{
 	"minimax": {
 		{Label: "CN", URL: "https://api.minimaxi.com/anthropic"},
 		{Label: "INTL", URL: "https://api.minimax.io/anthropic"},
+		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
+	},
+	// OpenCode Go serves the Kimi K-series (kimi-k3, kimi-k2.7-code,
+	// kimi-k2.6, kimi-k2.5) under lowercase model ids; the native Kimi Code
+	// endpoint serves the subscription model `kimi-for-coding`.
+	"kimi": {
+		{Label: "Kimi Code", URL: "https://api.kimi.com/coding/v1"},
+		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
+	},
+	// OpenCode Go serves the MiMo V2 family (mimo-v2-pro, mimo-v2-omni,
+	// mimo-v2.5-pro, mimo-v2.5) alongside Xiaomi's own endpoint.
+	"mimo": {
+		{Label: "MiMo", URL: "https://api.xiaomimimo.com/v1"},
 		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
 	},
 }
@@ -1176,7 +1191,7 @@ func mimoPreset() Preset {
 			"llm": map[string]interface{}{
 				"provider": "mimo", "model": "mimo-v2.5",
 				"api_key": nil, "api_key_env": "XIAOMI_API_KEY",
-				"base_url": "https://api.xiaomimimo.com/v1", "api_compat": "openai",
+				"base_url": ProviderRegionURLs["mimo"][0].URL, "api_compat": "openai",
 			},
 			"capabilities": map[string]interface{}{
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
@@ -1238,7 +1253,7 @@ func kimiPreset() Preset {
 	return openAICompatNoVisionPreset(
 		"kimi",
 		"Kimi Code (Moonshot) — OpenAI-compatible, subscription-based, tool calling",
-		"kimi-for-coding", "KIMI_CODE_API_KEY", "https://api.kimi.com/coding/v1", "3")
+		"kimi-for-coding", "KIMI_CODE_API_KEY", ProviderRegionURLs["kimi"][0].URL, "3")
 }
 
 func nvidiaPreset() Preset {

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -616,16 +616,16 @@ var ProviderRegionURLs = map[string][]RegionURL{
 	// no native xAI route (no verified api.x.ai endpoint/model pairing), so
 	// `grok-4.5` is reached only through the Go subscription. Entry [0]
 	// therefore declares OPENCODE_GO_API_KEY and grokPreset() ships that same
-	// slot; ProviderDefaultEnv["grok"] holds the provider-generic slot used on
-	// a switch TO grok (see ProviderDefaultEnv below).
+	// slot; ProviderDefaultEnv["grok"] holds the provider-generic fallback
+	// name (see ProviderDefaultEnv below).
 	"grok": {
 		{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"},
 		{Label: "Custom", URL: ""}, // empty URL = free text sentinel
 	},
 }
 
-// ProviderDefaultEnv maps each provider to the api_key_env slot a freshly
-// switched-to provider should adopt. Consulted on provider switch only; it
+// ProviderDefaultEnv maps each provider to its provider-generic api_key_env
+// fallback slot. Consulted on provider switch only; it
 // must not be read from a region cycle, so zhipu/minimax region rows declare
 // no Env (see RegionURL) and their CN<->INTL cycling preserves whatever
 // region-suffixed slot the host stamped (ZHIPU_INTL_1_API_KEY etc.).
@@ -636,8 +636,8 @@ var ProviderRegionURLs = map[string][]RegionURL{
 // grok is the single deliberate exception: grokPreset() declares
 // OPENCODE_GO_API_KEY because its default (and only non-Custom) endpoint IS
 // OpenCode Go, so an existing Go user needs no second copy of the key. The
-// entry below is the provider-GENERIC slot adopted on a switch TO grok from
-// another provider. Keeping the two different is what makes
+// entry below is the provider-generic fallback name; the editor adopts the
+// landing row's slot on a switch. Keeping the two different is what makes
 // usesRegionDeclaredEnv treat the Go slot as a cross-provider account worth
 // preserving across a save, instead of as this template's own shared slot.
 var ProviderDefaultEnv = map[string]string{
@@ -1302,8 +1302,8 @@ func grokPreset() Preset {
 	// because the shipped endpoint IS OpenCode Go: someone who already
 	// configured that shared account for deepseek/zhipu/minimax/kimi/mimo
 	// gets a working grok preset without pasting the key a second time. The
-	// provider-generic GROK_API_KEY lives in ProviderDefaultEnv and is what a
-	// switch TO grok from another provider adopts.
+	// provider-generic GROK_API_KEY stays in ProviderDefaultEnv as the
+	// fallback name, separate from the slot a switch adopts.
 	//
 	// Text-only: the Go endpoint's image-input mapping for grok-4.5 is not
 	// pinned, so no vision capability is wired.

--- a/tui/internal/preset/preset_skill_router_test.go
+++ b/tui/internal/preset/preset_skill_router_test.go
@@ -60,7 +60,7 @@ var wantOperations = map[string]bool{
 
 // TestPresetSkillRouter_BuiltinBijection keeps the source preset list, the
 // embedded direct-provider manuals, the parent router, and extracted utility
-// tree aligned. Direct providers are exactly the 12 BuiltinPresets() names —
+// tree aligned. Direct providers are exactly the 13 BuiltinPresets() names —
 // nested operation children live under reference/operations/ and are
 // validated separately by TestPresetSkillRouter_OperationBijection so a
 // provider directory can never silently absorb an operation, or vice versa.
@@ -321,18 +321,19 @@ func TestPresetSkillRouter_OperationBijection(t *testing.T) {
 // operation prose into the provider page itself.
 func TestPresetSkillRouter_ProviderChildContracts(t *testing.T) {
 	wantAnchor := map[string]string{
-		"minimax":    "tui/internal/preset/preset.go:1132-1157",
-		"zhipu":      "tui/internal/preset/preset.go:1159-1176",
-		"mimo":       "tui/internal/preset/preset.go:1178-1203",
-		"deepseek":   "tui/internal/preset/preset.go:1205-1214",
-		"gemini":     "tui/internal/preset/preset.go:1216-1243",
-		"kimi":       "tui/internal/preset/preset.go:1245-1257",
-		"nvidia":     "tui/internal/preset/preset.go:1259-1278",
-		"openrouter": "tui/internal/preset/preset.go:1280-1299",
-		"codex":      "tui/internal/preset/preset.go:1301-1329",
-		"codex-pool": "tui/internal/preset/preset.go:1338-1361",
-		"claude":     "tui/internal/preset/preset.go:1363-1392",
-		"custom":     "tui/internal/preset/preset.go:1394-1416",
+		"minimax":    "tui/internal/preset/preset.go:1167-1192",
+		"zhipu":      "tui/internal/preset/preset.go:1194-1211",
+		"mimo":       "tui/internal/preset/preset.go:1213-1238",
+		"deepseek":   "tui/internal/preset/preset.go:1240-1249",
+		"gemini":     "tui/internal/preset/preset.go:1251-1278",
+		"kimi":       "tui/internal/preset/preset.go:1280-1292",
+		"grok":       "tui/internal/preset/preset.go:1294-1314",
+		"nvidia":     "tui/internal/preset/preset.go:1316-1335",
+		"openrouter": "tui/internal/preset/preset.go:1337-1356",
+		"codex":      "tui/internal/preset/preset.go:1358-1386",
+		"codex-pool": "tui/internal/preset/preset.go:1395-1418",
+		"claude":     "tui/internal/preset/preset.go:1420-1449",
+		"custom":     "tui/internal/preset/preset.go:1451-1473",
 	}
 	want := map[string]bool{}
 	for _, p := range BuiltinPresets() {

--- a/tui/internal/preset/preset_skill_router_test.go
+++ b/tui/internal/preset/preset_skill_router_test.go
@@ -321,18 +321,18 @@ func TestPresetSkillRouter_OperationBijection(t *testing.T) {
 // operation prose into the provider page itself.
 func TestPresetSkillRouter_ProviderChildContracts(t *testing.T) {
 	wantAnchor := map[string]string{
-		"minimax":    "tui/internal/preset/preset.go:1117-1142",
-		"zhipu":      "tui/internal/preset/preset.go:1144-1161",
-		"mimo":       "tui/internal/preset/preset.go:1163-1188",
-		"deepseek":   "tui/internal/preset/preset.go:1190-1199",
-		"gemini":     "tui/internal/preset/preset.go:1201-1228",
-		"kimi":       "tui/internal/preset/preset.go:1230-1242",
-		"nvidia":     "tui/internal/preset/preset.go:1244-1263",
-		"openrouter": "tui/internal/preset/preset.go:1265-1284",
-		"codex":      "tui/internal/preset/preset.go:1286-1314",
-		"codex-pool": "tui/internal/preset/preset.go:1323-1346",
-		"claude":     "tui/internal/preset/preset.go:1348-1377",
-		"custom":     "tui/internal/preset/preset.go:1379-1401",
+		"minimax":    "tui/internal/preset/preset.go:1132-1157",
+		"zhipu":      "tui/internal/preset/preset.go:1159-1176",
+		"mimo":       "tui/internal/preset/preset.go:1178-1203",
+		"deepseek":   "tui/internal/preset/preset.go:1205-1214",
+		"gemini":     "tui/internal/preset/preset.go:1216-1243",
+		"kimi":       "tui/internal/preset/preset.go:1245-1257",
+		"nvidia":     "tui/internal/preset/preset.go:1259-1278",
+		"openrouter": "tui/internal/preset/preset.go:1280-1299",
+		"codex":      "tui/internal/preset/preset.go:1301-1329",
+		"codex-pool": "tui/internal/preset/preset.go:1338-1361",
+		"claude":     "tui/internal/preset/preset.go:1363-1392",
+		"custom":     "tui/internal/preset/preset.go:1394-1416",
 	}
 	want := map[string]bool{}
 	for _, p := range BuiltinPresets() {

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -843,7 +843,7 @@ func TestCustomPresetDeclaresOpenAICompatForWireSelector(t *testing.T) {
 // beyond cosmetics: entry [0] is the template default (preset.go's
 // ProviderRegionURLs[...][0].URL), so a reorder silently repoints new presets
 // at a different region. The OpenCode Go row must stay byte-identical across
-// all three providers so one OPENCODE_GO_API_KEY serves all of them.
+// every provider that offers it so one OPENCODE_GO_API_KEY serves all of them.
 func TestProviderRegionURLTablesAreExact(t *testing.T) {
 	openCodeGo := RegionURL{Label: "OpenCode Go", URL: "https://opencode.ai/zen/go/v1", Env: "OPENCODE_GO_API_KEY"}
 
@@ -864,6 +864,14 @@ func TestProviderRegionURLTablesAreExact(t *testing.T) {
 		{"minimax", []RegionURL{
 			{Label: "CN", URL: "https://api.minimaxi.com/anthropic"},
 			{Label: "INTL", URL: "https://api.minimax.io/anthropic"},
+			openCodeGo,
+		}},
+		{"kimi", []RegionURL{
+			{Label: "Kimi Code", URL: "https://api.kimi.com/coding/v1"},
+			openCodeGo,
+		}},
+		{"mimo", []RegionURL{
+			{Label: "MiMo", URL: "https://api.xiaomimimo.com/v1"},
 			openCodeGo,
 		}},
 	}

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -232,8 +232,8 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 			t.Fatalf("RefreshTemplates() error: %v", err)
 		}
 		presets, _ := List()
-		if len(presets) != 12 {
-			t.Fatalf("expected 12 presets, got %d", len(presets))
+		if len(presets) != 13 {
+			t.Fatalf("expected 13 presets, got %d", len(presets))
 		}
 		names := map[string]bool{}
 		for _, p := range presets {
@@ -242,7 +242,7 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 				t.Errorf("preset %q: Source = %v, want SourceTemplate", p.Name, p.Source)
 			}
 		}
-		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "nvidia", "openrouter", "codex", "codex-pool", "claude", "custom"} {
+		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "grok", "nvidia", "openrouter", "codex", "codex-pool", "claude", "custom"} {
 			if !names[want] {
 				t.Errorf("missing preset %q", want)
 			}
@@ -786,6 +786,36 @@ func TestAutoEnvVarName(t *testing.T) {
 			preset: pp("zhipu", "https://api.z.ai/api/coding/paas/v4"),
 			want:   "ZHIPU_INTL_1_API_KEY",
 		},
+		// The prefix comes from the PROVIDER name, never from
+		// ProviderDefaultEnv. mimo is the case that makes the difference
+		// visible and the case a manual got wrong: ProviderDefaultEnv["mimo"]
+		// is XIAOMI_API_KEY, but the stamped slot is MIMO_1_API_KEY. kimi is
+		// the same shape (KIMI_CODE_API_KEY -> KIMI_1_API_KEY).
+		{
+			name:   "kimi native row → provider-derived prefix",
+			preset: pp("kimi", "https://api.kimi.com/coding/v1"),
+			want:   "KIMI_1_API_KEY",
+		},
+		{
+			name:   "mimo native row → MIMO_, not XIAOMI_",
+			preset: pp("mimo", "https://api.xiaomimimo.com/v1"),
+			want:   "MIMO_1_API_KEY",
+		},
+		{
+			name:   "kimi OpenCode Go gets no region suffix",
+			preset: pp("kimi", "https://opencode.ai/zen/go/v1"),
+			want:   "KIMI_1_API_KEY",
+		},
+		{
+			name:   "mimo OpenCode Go gets no region suffix",
+			preset: pp("mimo", "https://opencode.ai/zen/go/v1"),
+			want:   "MIMO_1_API_KEY",
+		},
+		{
+			name:   "grok Custom row → GROK_, not the OpenCode slot",
+			preset: pp("grok", "https://proxy.internal.example/v1"),
+			want:   "GROK_1_API_KEY",
+		},
 		{
 			name:   "no provider → empty",
 			preset: Preset{Manifest: map[string]interface{}{"llm": map[string]interface{}{}}},
@@ -866,13 +896,26 @@ func TestProviderRegionURLTablesAreExact(t *testing.T) {
 			{Label: "INTL", URL: "https://api.minimax.io/anthropic"},
 			openCodeGo,
 		}},
+		// kimi and mimo had free-text base_url before they gained a region
+		// table, so both carry the Custom sentinel: a two-row table with no
+		// Custom row makes Enter on the base_url row a no-op and removes the
+		// only in-editor path to a proxy/relay endpoint.
 		{"kimi", []RegionURL{
 			{Label: "Kimi Code", URL: "https://api.kimi.com/coding/v1"},
 			openCodeGo,
+			{Label: "Custom", URL: ""},
 		}},
 		{"mimo", []RegionURL{
 			{Label: "MiMo", URL: "https://api.xiaomimimo.com/v1"},
 			openCodeGo,
+			{Label: "Custom", URL: ""},
+		}},
+		// grok is the only provider whose entry [0] — the template default —
+		// is the OpenCode Go row: there is no verified native xAI route, so
+		// the Go subscription is the whole product.
+		{"grok", []RegionURL{
+			openCodeGo,
+			{Label: "Custom", URL: ""},
 		}},
 	}
 
@@ -1006,8 +1049,11 @@ func TestValidateRequiresBaseURLForRegionProviders(t *testing.T) {
 			t.Errorf("%s with explicitly empty base_url validated clean, want a base_url violation", provider)
 		}
 		// Absent base_url is tolerated only where regionSuffix assigns a
-		// default region (zhipu → CN, minimax → INTL); deepseek has no region
-		// fallback, so an absent endpoint is still a violation there.
+		// default region (zhipu → CN, minimax → INTL); deepseek, kimi, mimo
+		// and grok have no region fallback, so an absent endpoint is still a
+		// violation there. kimi and mimo joined that set when they gained a
+		// region table — a base_url-less kimi/mimo preset that validated on
+		// an older TUI must gain an explicit endpoint to save again.
 		wantAbsentViolation := regionSuffix(provider, "") == ""
 		if errs := presetWith(provider, "").Validate(); (len(errs) == 0) == wantAbsentViolation {
 			t.Errorf("%s with absent base_url errs=%v, wantAbsentViolation=%v", provider, errs, wantAbsentViolation)

--- a/tui/internal/preset/skill_metadata_test.go
+++ b/tui/internal/preset/skill_metadata_test.go
@@ -49,7 +49,7 @@ func TestBundledSkillsHaveLastChangedAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 71 {
-		t.Fatalf("checked %d bundled skill SKILL.md files, want 71", count)
+	if count != 72 {
+		t.Fatalf("checked %d bundled skill SKILL.md files, want 72", count)
 	}
 }

--- a/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: lingtai-preset-skill
 description: >
-  Thin dual-axis router for preset questions: which of the 12 TUI-shipped
+  Thin dual-axis router for preset questions: which of the 13 TUI-shipped
   built-in preset templates (provider axis), and which cross-cutting preset
   lifecycle mechanic (operation axis) — saving, checking availability,
   activating/refreshing, endpoint/capability facts, or troubleshooting. Read
   a child only when it is relevant; this does not describe arbitrary saved
   presets.
-version: 2.0.0
-last_changed_at: "2026-07-19T00:00:00Z"
+version: 2.1.0
+last_changed_at: "2026-08-09T00:00:00Z"
 related_files:
   - tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
   - tui/internal/preset/preset.go
@@ -21,6 +21,7 @@ related_files:
   - tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+  - tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
   - tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -57,7 +58,7 @@ endpoint, protocol, and plan facts and route to the relevant operation
 child instead of restating shared mechanics; operation pages own the shared
 lifecycle mechanics and never encode provider-specific facts.
 
-## Provider catalog (12 direct children)
+## Provider catalog (13 direct children)
 
 ```yaml
 - name: preset-skill-minimax
@@ -72,6 +73,8 @@ lifecycle mechanics and never encode provider-specific facts.
   location: reference/gemini/SKILL.md
 - name: preset-skill-kimi
   location: reference/kimi/SKILL.md
+- name: preset-skill-grok
+  location: reference/grok/SKILL.md
 - name: preset-skill-nvidia
   location: reference/nvidia/SKILL.md
 - name: preset-skill-openrouter
@@ -94,6 +97,7 @@ lifecycle mechanics and never encode provider-specific facts.
 | `deepseek` | `reference/deepseek/SKILL.md` | DeepSeek, OpenAI-compatible text route |
 | `gemini` | `reference/gemini/SKILL.md` | Google Gemini native multimodal route |
 | `kimi` | `reference/kimi/SKILL.md` | Kimi Code, OpenAI-compatible |
+| `grok` | `reference/grok/SKILL.md` | Grok (xAI) via OpenCode Go, OpenAI-compatible |
 | `nvidia` | `reference/nvidia/SKILL.md` | NVIDIA NIM/API Catalog gateway |
 | `openrouter` | `reference/openrouter/SKILL.md` | OpenRouter gateway |
 | `codex` | `reference/codex/SKILL.md` | ChatGPT OAuth Codex route |

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/claude/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/claude/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `claude`
 
-`claudePreset()` (`tui/internal/preset/preset.go:1348-1377`) uses canonical
+`claudePreset()` (`tui/internal/preset/preset.go:1363-1392`) uses canonical
 provider `claude-code`, displayed in the TUI as print-mode backend `claude-p`.
 It reuses the current Claude Code OAuth login and shows the account email
 reported by `claude auth status --json`; the TUI never reads or stores Claude

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/claude/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/claude/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `claude`
 
-`claudePreset()` (`tui/internal/preset/preset.go:1363-1392`) uses canonical
+`claudePreset()` (`tui/internal/preset/preset.go:1420-1449`) uses canonical
 provider `claude-code`, displayed in the TUI as print-mode backend `claude-p`.
 It reuses the current Claude Code OAuth login and shows the account email
 reported by `claude auth status --json`; the TUI never reads or stores Claude

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `codex-pool`
 
-`codexPoolPreset()` (`tui/internal/preset/preset.go:1323-1346`) ships
+`codexPoolPreset()` (`tui/internal/preset/preset.go:1338-1361`) ships
 provider `codex-pool`, exact model `gpt-5.6-sol`,
 `https://chatgpt.com/backend-api/codex`, `thinking: xhigh`, and an empty
 `api_key_env` because it selects from local ChatGPT OAuth token files. The

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: preset-skill-codex-pool
 description: Official-source-led manual for the TUI `codex-pool` template, including the codex-auth-pool.json format and manual-edit protocol.
-version: 2.1.0
-last_changed_at: "2026-07-19T12:00:00Z"
+version: 2.2.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `codex-pool`
 
-`codexPoolPreset()` (`tui/internal/preset/preset.go:1338-1361`) ships
+`codexPoolPreset()` (`tui/internal/preset/preset.go:1395-1418`) ships
 provider `codex-pool`, exact model `gpt-5.6-sol`,
 `https://chatgpt.com/backend-api/codex`, `thinking: xhigh`, and an empty
 `api_key_env` because it selects from local ChatGPT OAuth token files. The
 manifest declares `vision` parity with `codex`; pooling changes account
-selection, not the model or endpoint.
+selection, not the model or endpoint. The editor's model row therefore
+offers exactly the `codex` lineup — `gpt-5.6-sol`, `gpt-5.6-terra`,
+`gpt-5.6-luna`, `gpt-5.5`, the latest two GPT-5.x generations under the TUI's
+model-curation rule (`tui/CONTRACT.md`). See `reference/codex/SKILL.md`.
 
 ## Template-specific settings
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: preset-skill-codex
 description: Official-source-led manual for the TUI `codex` template.
-version: 2.1.0
-last_changed_at: "2026-07-19T12:00:00Z"
+version: 2.2.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `codex`
 
-`codexPreset()` (`tui/internal/preset/preset.go:1301-1329`) uses provider
+`codexPreset()` (`tui/internal/preset/preset.go:1358-1386`) uses provider
 `codex`, model `gpt-5.6-sol`, the Codex endpoint
 `https://chatgpt.com/backend-api/codex`, and ChatGPT OAuth rather than an API
 key env-var. The manifest exposes provider-native `vision` and web search.
 
 ## Template-specific settings
+
+The editor's model row ships the latest two GPT-5.x generations only:
+`gpt-5.6-sol` (the default), `gpt-5.6-terra`, `gpt-5.6-luna` — three named
+routes of the one 5.6 generation — and `gpt-5.5`. Per the TUI's
+model-curation rule (`tui/CONTRACT.md`) the older `gpt-5.4`, `gpt-5.4-mini`,
+`gpt-5.3-codex`, and `gpt-5.2` ids are no longer offered. A saved preset
+already pinned to one of them keeps working — the TUI never rewrites
+`presets/saved/` — it simply is not reachable from the picker any more.
 
 Exact image support can depend on the current model/account; verify it rather
 than treating this manual as a promise.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `codex`
 
-`codexPreset()` (`tui/internal/preset/preset.go:1286-1314`) uses provider
+`codexPreset()` (`tui/internal/preset/preset.go:1301-1329`) uses provider
 `codex`, model `gpt-5.6-sol`, the Codex endpoint
 `https://chatgpt.com/backend-api/codex`, and ChatGPT OAuth rather than an API
 key env-var. The manifest exposes provider-native `vision` and web search.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `custom`
 
-`customPreset()` (`tui/internal/preset/preset.go:1394-1416`) is a
+`customPreset()` (`tui/internal/preset/preset.go:1451-1473`) is a
 user-supplied OpenAI-compatible template: model is empty until configured,
 the key slot is `LLM_API_KEY`, and the endpoint is user-supplied. Its
 `vision` capability inherits the configured LLM endpoint.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/custom/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `custom`
 
-`customPreset()` (`tui/internal/preset/preset.go:1379-1401`) is a
+`customPreset()` (`tui/internal/preset/preset.go:1394-1416`) is a
 user-supplied OpenAI-compatible template: model is empty until configured,
 the key slot is `LLM_API_KEY`, and the endpoint is user-supplied. Its
 `vision` capability inherits the configured LLM endpoint.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `deepseek`
 
-`deepseekPreset()` (`tui/internal/preset/preset.go:1190-1199`) uses the
+`deepseekPreset()` (`tui/internal/preset/preset.go:1205-1214`) uses the
 shared OpenAI-compatible text shape: provider `deepseek`, default model
 `deepseek-v4-pro`, `https://api.deepseek.com`, and `DEEPSEEK_API_KEY`.
 The shipped manifest has no `vision` capability, so this manual records no

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: preset-skill-deepseek
 description: Official-source-led manual for the TUI `deepseek` template.
-version: 2.1.3
+version: 2.1.4
 last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `deepseek`
 
-`deepseekPreset()` (`tui/internal/preset/preset.go:1205-1214`) uses the
+`deepseekPreset()` (`tui/internal/preset/preset.go:1240-1249`) uses the
 shared OpenAI-compatible text shape: provider `deepseek`, default model
 `deepseek-v4-pro`, `https://api.deepseek.com`, and `DEEPSEEK_API_KEY`.
 The shipped manifest has no `vision` capability, so this manual records no
@@ -32,11 +32,11 @@ editor (`ProviderRegionURLs["deepseek"]`):
   This option is scoped to **DeepSeek models served through the OpenCode Go
   subscription**: the preset keeps `provider: deepseek` and the model row
   stays on the DeepSeek lineup (`deepseek-v4-pro` / `deepseek-v4-flash`,
-  both served by `/zen/go/v1`). The `zhipu` and `minimax` presets carry
-  their own **OpenCode Go** `base_url` row (same URL, same
-  `OPENCODE_GO_API_KEY` slot) — route GLM and MiniMax through those, not
-  through this one. For the remaining Go models (grok, gpt-5.6-luna, kimi,
-  qwen, ...) create a **Custom** preset instead, where
+  both served by `/zen/go/v1`). The `zhipu`, `minimax`, `mimo`, `kimi`, and
+  `grok` presets carry their own **OpenCode Go** `base_url` row (same URL,
+  same `OPENCODE_GO_API_KEY` slot) — route GLM, MiniMax, MiMo, Kimi, and
+  Grok through those, not through this one. For the remaining Go models
+  (gpt-5.6-luna, qwen, ...) create a **Custom** preset instead, where
   the model row is free-text and `wire_api` stays selectable. See the
   official [OpenCode Go docs](https://opencode.ai/docs/go/). China-hosted
   `deepseek-v4-flash` requires opting in at the OpenCode workspace page

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `gemini`
 
-`geminiPreset()` (`tui/internal/preset/preset.go:1216-1243`) ships provider
+`geminiPreset()` (`tui/internal/preset/preset.go:1251-1278`) ships provider
 `gemini` with the exact default model `gemini-3-flash-preview` and
 `GEMINI_API_KEY`. It uses Google’s native adapter: there is no `base_url` or
 OpenAI-compat override. Its manifest includes

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `gemini`
 
-`geminiPreset()` (`tui/internal/preset/preset.go:1201-1228`) ships provider
+`geminiPreset()` (`tui/internal/preset/preset.go:1216-1243`) ships provider
 `gemini` with the exact default model `gemini-3-flash-preview` and
 `GEMINI_API_KEY`. It uses Google’s native adapter: there is no `base_url` or
 OpenAI-compat override. Its manifest includes

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
@@ -44,17 +44,27 @@ The TUI preset editor's `base_url` row offers two options
 
 Because the template default row declares its own `Env`, `grok` is the one
 provider where `grokPreset()`'s declared `api_key_env` (`OPENCODE_GO_API_KEY`)
-deliberately differs from `ProviderDefaultEnv["grok"]` (`GROK_API_KEY`). The
-latter is the provider-generic slot the editor adopts when the user *switches
-provider to* grok from another template — it is not the shipped template's
-slot, and it is not applied by base_url cycling. Keeping the two different is
-also what makes the editor treat the OpenCode Go slot as a shared
+deliberately differs from `ProviderDefaultEnv["grok"]` (`GROK_API_KEY`).
+`GROK_API_KEY` is the provider-generic fallback name — it is not the shipped
+template's slot, and it is not applied by base_url cycling. Keeping the two
+different is what makes the editor treat the OpenCode Go slot as a shared
 cross-provider account worth preserving across a save, rather than as this
 template's own slot to be replaced by a numbered one.
 
+**Switching an existing preset's provider *to* grok adopts
+`OPENCODE_GO_API_KEY`, not `GROK_API_KEY`.** A provider switch resets
+`base_url` to the new provider's first region row, and for grok that row *is*
+OpenCode Go, so the row's own declared `Env` wins over the provider-generic
+default: the credential slot always matches the endpoint you land on. (Every
+other provider's first row declares no `Env`, so they adopt their
+`ProviderDefaultEnv` name as before.) If you then cycle `base_url` to
+**Custom** and your endpoint takes an xAI key, set `api_key_env` yourself —
+the editor leaves the slot alone on the Custom row by design.
+
 ## Template-specific settings
 
-Model ids are LOWERCASE. The picker ships `grok-4.5` only — that is the id
+Grok ids are lowercase, and there is no uppercase form to avoid. The picker
+ships `grok-4.5` only — that is the id
 the OpenCode Go model list serves, and per the TUI's model-curation rule
 (`tui/CONTRACT.md`) only the latest two generations of a family may ship, so
 no older Grok generation is offered. Read the official

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
@@ -56,16 +56,17 @@ template's own slot to be replaced by a numbered one.
 `base_url` to the new provider's first region row, and for grok that row *is*
 OpenCode Go, so the row's own declared `Env` wins over the provider-generic
 default: the credential slot always matches the endpoint you land on. (Every
-other provider's first row declares no `Env`, so they adopt their
-`ProviderDefaultEnv` name as before.) If you then cycle `base_url` to
+other provider's first row declares either no `Env` or the same name as its
+`ProviderDefaultEnv` — deepseek — so only grok's adopted slot changes.) If
+you then cycle `base_url` to
 **Custom** and your endpoint takes an xAI key, set `api_key_env` yourself —
 the editor leaves the slot alone on the Custom row by design.
 
 ## Template-specific settings
 
 Grok ids are lowercase, and there is no uppercase form to avoid. The picker
-ships `grok-4.5` only — that is the id
-the OpenCode Go model list serves, and per the TUI's model-curation rule
+ships `grok-4.5` only — that is the id the OpenCode Go model list serves,
+and per the TUI's model-curation rule
 (`tui/CONTRACT.md`) only the latest two generations of a family may ship, so
 no older Grok generation is offered. Read the official
 [OpenCode Go docs](https://opencode.ai/docs/go/) for the current served-model

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: preset-skill-grok
+description: Official-source-led manual for the TUI `grok` template.
+version: 1.0.0
+last_changed_at: "2026-08-09T00:00:00Z"
+maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
+---
+
+# `grok`
+
+`grokPreset()` (`tui/internal/preset/preset.go:1294-1314`) ships provider
+`grok`, model `grok-4.5`, `api_compat: openai`, and the OpenCode Go endpoint
+`https://opencode.ai/zen/go/v1` with `OPENCODE_GO_API_KEY`. The manifest has
+no `vision` capability: the Go endpoint's image-input mapping for `grok-4.5`
+is not pinned, so this manual records no direct image route and no Grok
+vision MCP.
+
+Unlike every other provider template, this one's **default** endpoint is
+OpenCode Go. The TUI ships no native xAI route — no `api.x.ai` endpoint and
+model pairing has been verified here — so Grok is reached through the
+OpenCode Go subscription or not at all.
+
+The TUI preset editor's `base_url` row offers two options
+(`ProviderRegionURLs["grok"]`):
+
+- **OpenCode Go** — `https://opencode.ai/zen/go/v1` (the template default).
+  This row implies a credential: selecting it sets `api_key_env` to
+  `OPENCODE_GO_API_KEY`, the same shared OpenCode Go account the `deepseek`,
+  `zhipu`, `minimax`, `kimi`, and `mimo` templates use on their own OpenCode
+  Go rows. Saving an edited built-in **keeps** that slot rather than minting
+  a numbered one, so a user who already configured OpenCode Go for another
+  provider needs no second copy of the key.
+- **Custom** — free-typed endpoint (an xAI key against your own gateway, a
+  proxy, a relay). Selecting it clears `base_url` so Enter opens an inline
+  edit. Custom implies no `api_key_env`, and the editor deliberately leaves
+  the current slot alone on this row — your endpoint keeps whatever
+  credential it actually uses. **Because grok's default row is OpenCode Go,
+  arriving on Custom leaves the preset pointing at `OPENCODE_GO_API_KEY`.**
+  If your endpoint takes an xAI key instead, change `api_key_env` in the
+  preset JSON (`GROK_API_KEY` is the conventional name). A saved edited
+  built-in gets `stampAutoEnvVar`'s numbered slot instead —
+  `GROK_1_API_KEY`, the prefix being the uppercased provider name, not the
+  default slot name.
+
+Because the template default row declares its own `Env`, `grok` is the one
+provider where `grokPreset()`'s declared `api_key_env` (`OPENCODE_GO_API_KEY`)
+deliberately differs from `ProviderDefaultEnv["grok"]` (`GROK_API_KEY`). The
+latter is the provider-generic slot the editor adopts when the user *switches
+provider to* grok from another template — it is not the shipped template's
+slot, and it is not applied by base_url cycling. Keeping the two different is
+also what makes the editor treat the OpenCode Go slot as a shared
+cross-provider account worth preserving across a save, rather than as this
+template's own slot to be replaced by a numbered one.
+
+## Template-specific settings
+
+Model ids are LOWERCASE. The picker ships `grok-4.5` only — that is the id
+the OpenCode Go model list serves, and per the TUI's model-curation rule
+(`tui/CONTRACT.md`) only the latest two generations of a family may ship, so
+no older Grok generation is offered. Read the official
+[OpenCode Go docs](https://opencode.ai/docs/go/) for the current served-model
+list and the [xAI API docs](https://docs.x.ai/) for model-level capability
+facts; treat neither as evidence that a given id resolves on the other's
+endpoint. For an image request, report that this preset's shipped wiring is
+text-only. Do not guess credentials, switch providers, or auto-load/invoke an
+MCP. Verify the provider/model/endpoint/env-var fields in TUI source after a
+template change.
+
+## Operations
+
+For base URL/API-compat/model/capability declaration shape versus
+credentials, see `reference/operations/endpoint-capabilities/SKILL.md`.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
@@ -47,10 +47,13 @@ you want:
 
 - Native Kimi Code row: the subscription model `kimi-for-coding` (the
   template default).
-- OpenCode Go row: LOWERCASE K-series ids, currently `kimi-k3` and
-  `kimi-k2.7-code`. Only these two generations are current; older K2.x ids
-  may have been retired on the Go endpoint. Verify against the OpenCode Go
-  model list before relying on one.
+- OpenCode Go row: LOWERCASE K-series ids. This manual documents `kimi-k3`
+  and `kimi-k2.7-code` — the latest two generations under the TUI's
+  model-curation rule (`tui/CONTRACT.md`), which is why no older K2.x id is
+  written down here. That is a TUI documentation decision, not a statement
+  about what the endpoint serves: other Moonshot ids remain typeable on this
+  free-text row. Check the OpenCode Go model list for what is currently
+  served.
 
 ## Template-specific settings
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: preset-skill-kimi
 description: Official-source-led manual for the TUI `kimi` template.
-version: 2.1.0
+version: 2.2.0
 last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `kimi`
 
-`kimiPreset()` (`tui/internal/preset/preset.go:1245-1257`) ships Kimi Code
+`kimiPreset()` (`tui/internal/preset/preset.go:1280-1292`) ships Kimi Code
 model `kimi-for-coding` at the exact OpenAI-compatible endpoint
 `https://api.kimi.com/coding/v1` with `KIMI_CODE_API_KEY`. The manifest has
 no built-in `vision` capability, so this shipped preset remains unwired for
 LingTai-side vision.
 
-The TUI preset editor's `base_url` row offers two options
+The TUI preset editor's `base_url` row offers three options
 (`ProviderRegionURLs["kimi"]`):
 
 - **Kimi Code** — `https://api.kimi.com/coding/v1` (the template default).
@@ -22,15 +22,35 @@ The TUI preset editor's `base_url` row offers two options
   that implies a credential: selecting it sets `api_key_env` to
   `OPENCODE_GO_API_KEY` (the shared OpenCode Go account) and saving keeps
   that slot instead of minting a numbered one.
+- **Custom** — free-typed endpoint (a proxy, relay, or self-hosted gateway).
+  Selecting it clears `base_url` so Enter opens an inline edit. Custom
+  implies no `api_key_env`, and the editor deliberately leaves the current
+  slot alone on this row — your endpoint keeps whatever credential it
+  actually uses. If you arrived here from the OpenCode Go row the preset is
+  still pointing at `OPENCODE_GO_API_KEY`; change it in the preset JSON if
+  your endpoint takes a different key. A saved edited built-in gets
+  `stampAutoEnvVar`'s numbered slot instead, because an empty `base_url` is
+  not a row-declared cross-provider account.
 
 Kimi Code implies no `api_key_env`, so saving an edited built-in on that row
-yields a host-stamped numbered slot (`KIMI_1_API_KEY`) rather than
-overwriting the provider default. Cycling *off* OpenCode Go restores the slot
+yields a host-stamped numbered slot rather than overwriting the provider
+default. The slot name is derived from the PROVIDER name, not from
+`ProviderDefaultEnv`, so it is `KIMI_1_API_KEY` — not `KIMI_CODE_1_API_KEY`
+(`AutoEnvVarName`, `preset.go`). Cycling *off* OpenCode Go restores the slot
 that was in place before it was selected, so the choice is reversible.
 
-OpenCode Go model ids are LOWERCASE — `kimi-k3`, `kimi-k2.7-code`,
-`kimi-k2.6`, `kimi-k2.5`. The native Kimi Code row keeps the subscription
-model `kimi-for-coding`.
+The model row is FREE TEXT for kimi — there is deliberately no entry in the
+editor's `providerModels` picker (`tui/internal/tui/preset_editor.go`).
+Moonshot's catalog is wider than any list the TUI can verify, and a picker
+would let one `→` overwrite a typed id with the first list entry. Type the id
+you want:
+
+- Native Kimi Code row: the subscription model `kimi-for-coding` (the
+  template default).
+- OpenCode Go row: LOWERCASE K-series ids, currently `kimi-k3` and
+  `kimi-k2.7-code`. Only these two generations are current; older K2.x ids
+  may have been retired on the Go endpoint. Verify against the OpenCode Go
+  model list before relying on one.
 
 ## Template-specific settings
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
@@ -1,18 +1,36 @@
 ---
 name: preset-skill-kimi
 description: Official-source-led manual for the TUI `kimi` template.
-version: 2.0.0
-last_changed_at: "2026-07-19T00:00:00Z"
+version: 2.1.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `kimi`
 
-`kimiPreset()` (`tui/internal/preset/preset.go:1230-1242`) ships Kimi Code
+`kimiPreset()` (`tui/internal/preset/preset.go:1245-1257`) ships Kimi Code
 model `kimi-for-coding` at the exact OpenAI-compatible endpoint
 `https://api.kimi.com/coding/v1` with `KIMI_CODE_API_KEY`. The manifest has
 no built-in `vision` capability, so this shipped preset remains unwired for
 LingTai-side vision.
+
+The TUI preset editor's `base_url` row offers two options
+(`ProviderRegionURLs["kimi"]`):
+
+- **Kimi Code** — `https://api.kimi.com/coding/v1` (the template default).
+- **OpenCode Go** — `https://opencode.ai/zen/go/v1`. This is the only row
+  that implies a credential: selecting it sets `api_key_env` to
+  `OPENCODE_GO_API_KEY` (the shared OpenCode Go account) and saving keeps
+  that slot instead of minting a numbered one.
+
+Kimi Code implies no `api_key_env`, so saving an edited built-in on that row
+yields a host-stamped numbered slot (`KIMI_1_API_KEY`) rather than
+overwriting the provider default. Cycling *off* OpenCode Go restores the slot
+that was in place before it was selected, so the choice is reversible.
+
+OpenCode Go model ids are LOWERCASE — `kimi-k3`, `kimi-k2.7-code`,
+`kimi-k2.6`, `kimi-k2.5`. The native Kimi Code row keeps the subscription
+model `kimi-for-coding`.
 
 ## Template-specific settings
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: preset-skill-mimo
 description: Official-source-led manual for the TUI `mimo` template.
-version: 2.1.0
+version: 2.2.0
 last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `mimo`
 
-`mimoPreset()` (`tui/internal/preset/preset.go:1178-1203`) ships Xiaomi MiMo
+`mimoPreset()` (`tui/internal/preset/preset.go:1213-1238`) ships Xiaomi MiMo
 model `mimo-v2.5` at `https://api.xiaomimimo.com/v1` with OpenAI
 compatibility and `XIAOMI_API_KEY`. The manifest explicitly wires native
 vision to that exact default model.
 
-The TUI preset editor's `base_url` row offers two options
+The TUI preset editor's `base_url` row offers three options
 (`ProviderRegionURLs["mimo"]`):
 
 - **MiMo** — `https://api.xiaomimimo.com/v1` (the template default).
@@ -21,20 +21,40 @@ The TUI preset editor's `base_url` row offers two options
   that implies a credential: selecting it sets `api_key_env` to
   `OPENCODE_GO_API_KEY` (the shared OpenCode Go account) and saving keeps
   that slot instead of minting a numbered one.
+- **Custom** — free-typed endpoint (a proxy, relay, or self-hosted gateway).
+  Selecting it clears `base_url` so Enter opens an inline edit. Custom
+  implies no `api_key_env`, and the editor deliberately leaves the current
+  slot alone on this row — your endpoint keeps whatever credential it
+  actually uses. If you arrived here from the OpenCode Go row the preset is
+  still pointing at `OPENCODE_GO_API_KEY`; change it in the preset JSON if
+  your endpoint takes a different key. A saved edited built-in gets
+  `stampAutoEnvVar`'s numbered slot instead, because an empty `base_url` is
+  not a row-declared cross-provider account.
 
 MiMo implies no `api_key_env`, so saving an edited built-in on that row
-yields a host-stamped numbered slot (`XIAOMI_1_API_KEY`) rather than
-overwriting the provider default. Cycling *off* OpenCode Go restores the slot
-that was in place before it was selected, so the choice is reversible.
-
-OpenCode Go model ids are LOWERCASE — `mimo-v2.5`, `mimo-v2.5-pro`,
-`mimo-v2-pro`, `mimo-v2-omni`. LingTai-side vision is wired to the default
-`mimo-v2.5` only; switching model or endpoint does not re-verify that path.
+yields a host-stamped numbered slot rather than overwriting the provider
+default. **The slot is `MIMO_1_API_KEY`, not `XIAOMI_1_API_KEY`**:
+`AutoEnvVarName` (`preset.go`) builds the prefix by uppercasing the PROVIDER
+name (`mimo`), never from `ProviderDefaultEnv`. The `XIAOMI_` prefix appears
+only on `ProviderDefaultEnv["mimo"] = "XIAOMI_API_KEY"`, which is the
+template's shared slot — precisely the thing a numbered slot exists to
+replace. Cycling *off* OpenCode Go restores the slot that was in place before
+it was selected, so the choice is reversible.
 
 ## Template-specific settings
 
-The current TUI picker retains `mimo-v2.5-pro` as a text-only
-sibling; retired V2 Flash IDs are not shipped or selectable.
+The model picker ships `mimo-v2.5` and its text-only sibling
+`mimo-v2.5-pro`, and nothing else: per the TUI's model-curation rule
+(`tui/CONTRACT.md`) only the latest two generations of a family are shipped,
+so the older `mimo-v2-pro` / `mimo-v2-omni` ids and the retired V2 Flash IDs
+are not selectable. Both shipped ids are served by Xiaomi's own endpoint
+*and* by OpenCode Go, so the picker is valid on either `base_url` row — MiMo
+ids are lowercase on both, and there is no uppercase form to avoid.
+
+LingTai-side vision is wired to `mimo-v2.5` on Xiaomi's own endpoint only.
+Switching to `mimo-v2.5-pro` or to the OpenCode Go row does not re-verify
+that path, and `modelHasVision` records `mimo-v2.5-pro` as an explicit
+`false` rather than leaving it undeclared.
 
 Read the official [MiMo developer introduction](https://platform.xiaomimimo.com/llms.txt)
 and [OpenAI-compatible API page](https://platform.xiaomimimo.com/docs/zh-CN/api/chat/openai-api)

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
@@ -1,17 +1,35 @@
 ---
 name: preset-skill-mimo
 description: Official-source-led manual for the TUI `mimo` template.
-version: 2.0.0
-last_changed_at: "2026-07-19T00:00:00Z"
+version: 2.1.0
+last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `mimo`
 
-`mimoPreset()` (`tui/internal/preset/preset.go:1163-1188`) ships Xiaomi MiMo
+`mimoPreset()` (`tui/internal/preset/preset.go:1178-1203`) ships Xiaomi MiMo
 model `mimo-v2.5` at `https://api.xiaomimimo.com/v1` with OpenAI
 compatibility and `XIAOMI_API_KEY`. The manifest explicitly wires native
 vision to that exact default model.
+
+The TUI preset editor's `base_url` row offers two options
+(`ProviderRegionURLs["mimo"]`):
+
+- **MiMo** — `https://api.xiaomimimo.com/v1` (the template default).
+- **OpenCode Go** — `https://opencode.ai/zen/go/v1`. This is the only row
+  that implies a credential: selecting it sets `api_key_env` to
+  `OPENCODE_GO_API_KEY` (the shared OpenCode Go account) and saving keeps
+  that slot instead of minting a numbered one.
+
+MiMo implies no `api_key_env`, so saving an edited built-in on that row
+yields a host-stamped numbered slot (`XIAOMI_1_API_KEY`) rather than
+overwriting the provider default. Cycling *off* OpenCode Go restores the slot
+that was in place before it was selected, so the choice is reversible.
+
+OpenCode Go model ids are LOWERCASE — `mimo-v2.5`, `mimo-v2.5-pro`,
+`mimo-v2-pro`, `mimo-v2-omni`. LingTai-side vision is wired to the default
+`mimo-v2.5` only; switching model or endpoint does not re-verify that path.
 
 ## Template-specific settings
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
@@ -43,18 +43,19 @@ it was selected, so the choice is reversible.
 
 ## Template-specific settings
 
-The model picker ships `mimo-v2.5` and its text-only sibling
-`mimo-v2.5-pro`, and nothing else: per the TUI's model-curation rule
-(`tui/CONTRACT.md`) only the latest two generations of a family are shipped,
-so the older `mimo-v2-pro` / `mimo-v2-omni` ids and the retired V2 Flash IDs
-are not selectable. Both shipped ids are served by Xiaomi's own endpoint
-*and* by OpenCode Go, so the picker is valid on either `base_url` row — MiMo
-ids are lowercase on both, and there is no uppercase form to avoid.
+The model picker ships the latest two generations, per the TUI's
+model-curation rule (`tui/CONTRACT.md`): `mimo-v2.5` with its text-only
+sibling `mimo-v2.5-pro`, and the previous generation `mimo-v2-pro` /
+`mimo-v2-omni`. The retired V2 Flash ids and anything older are not
+selectable. All four shipped ids are served by Xiaomi's own endpoint *and* by
+OpenCode Go, so the picker is valid on either `base_url` row — MiMo ids are
+lowercase on both, and there is no uppercase form to avoid.
 
 LingTai-side vision is wired to `mimo-v2.5` on Xiaomi's own endpoint only.
-Switching to `mimo-v2.5-pro` or to the OpenCode Go row does not re-verify
-that path, and `modelHasVision` records `mimo-v2.5-pro` as an explicit
-`false` rather than leaving it undeclared.
+Switching to any other picker id, or to the OpenCode Go row, does not
+re-verify that path. `modelHasVision` records `mimo-v2.5-pro`, `mimo-v2-pro`,
+and `mimo-v2-omni` as explicit `false` rather than leaving them undeclared —
+including `-omni`, whose name is not evidence of a wired image route.
 
 Read the official [MiMo developer introduction](https://platform.xiaomimimo.com/llms.txt)
 and [OpenAI-compatible API page](https://platform.xiaomimimo.com/docs/zh-CN/api/chat/openai-api)

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `minimax`
 
-`minimaxPreset()` (`tui/internal/preset/preset.go:1117-1142`) ships provider
+`minimaxPreset()` (`tui/internal/preset/preset.go:1132-1157`) ships provider
 `minimax`, exact model `MiniMax-M3`, and `MINIMAX_API_KEY` at the
 Anthropic-compatible regional endpoint `https://api.minimaxi.com/anthropic`
 (CN default) or `https://api.minimax.io/anthropic` (INTL). Its manifest

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: preset-skill-minimax
 description: Official-source-led manual for the TUI `minimax` template.
-version: 2.1.0
+version: 2.2.0
 last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `minimax`
 
-`minimaxPreset()` (`tui/internal/preset/preset.go:1132-1157`) ships provider
+`minimaxPreset()` (`tui/internal/preset/preset.go:1167-1192`) ships provider
 `minimax`, exact model `MiniMax-M3`, and `MINIMAX_API_KEY` at the
 Anthropic-compatible regional endpoint `https://api.minimaxi.com/anthropic`
 (CN default) or `https://api.minimax.io/anthropic` (INTL). Its manifest
@@ -31,8 +31,15 @@ was in place before it was selected, so the choice is reversible.
 
 ## Template-specific settings
 
+The model picker ships the latest two M-series generations only —
+`MiniMax-M3` and `MiniMax-M2.7` with its `-highspeed` variant. Per the TUI's
+model-curation rule (`tui/CONTRACT.md`) the older `MiniMax-M2.5` /
+`MiniMax-M2.1` / `MiniMax-M2` ids are no longer selectable; a saved preset
+already pinned to one keeps working, the TUI just will not offer it again.
+
 MiniMax-M3 natively accepts image/video content blocks on that same
 endpoint; this native path does not depend on an MCP or a separate plan.
+Both shipped generations are recorded as image-capable in `modelHasVision`.
 
 MiniMax also publishes the separate optional
 [MiniMax-Coding-Plan-MCP](https://github.com/MiniMax-AI/MiniMax-Coding-Plan-MCP),

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `nvidia`
 
-`nvidiaPreset()` (`tui/internal/preset/preset.go:1244-1263`) ships exact
+`nvidiaPreset()` (`tui/internal/preset/preset.go:1259-1278`) ships exact
 model `meta/llama-3.3-70b-instruct` at `https://integrate.api.nvidia.com/v1`
 with OpenAI compatibility and `NVIDIA_API_KEY`. This default model is
 text-only and the manifest has no `vision` capability.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `nvidia`
 
-`nvidiaPreset()` (`tui/internal/preset/preset.go:1259-1278`) ships exact
+`nvidiaPreset()` (`tui/internal/preset/preset.go:1316-1335`) ships exact
 model `meta/llama-3.3-70b-instruct` at `https://integrate.api.nvidia.com/v1`
 with OpenAI compatibility and `NVIDIA_API_KEY`. This default model is
 text-only and the manifest has no `vision` capability.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `openrouter`
 
-`openrouterPreset()` (`tui/internal/preset/preset.go:1265-1284`) ships
+`openrouterPreset()` (`tui/internal/preset/preset.go:1280-1299`) ships
 gateway model `z-ai/glm-5.1`, provider `openrouter`, a provider-resolved
 base URL, and `OPENROUTER_API_KEY`. The exact shipped slug is
 text-in/text-out, and the manifest has no `vision` capability.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
@@ -8,7 +8,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 # `openrouter`
 
-`openrouterPreset()` (`tui/internal/preset/preset.go:1280-1299`) ships
+`openrouterPreset()` (`tui/internal/preset/preset.go:1337-1356`) ships
 gateway model `z-ai/glm-5.1`, provider `openrouter`, a provider-resolved
 base URL, and `OPENROUTER_API_KEY`. The exact shipped slug is
 text-in/text-out, and the manifest has no `vision` capability.

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: preset-skill-zhipu
 description: Official-source-led manual for the TUI `zhipu` template.
-version: 2.1.0
+version: 2.1.1
 last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `zhipu`
 
-`zhipuPreset()` (`tui/internal/preset/preset.go:1144-1161`) ships provider
+`zhipuPreset()` (`tui/internal/preset/preset.go:1159-1176`) ships provider
 `zhipu` with exact model `GLM-5.2`, `ZHIPU_API_KEY`, and the
 OpenAI-compatible regional endpoints
 `https://open.bigmodel.cn/api/coding/paas/v4` (CN) and
@@ -25,7 +25,10 @@ The TUI preset editor's `base_url` row offers three options
 - **OpenCode Go** — `https://opencode.ai/zen/go/v1`. This is the only row
   that implies a credential: selecting it sets `api_key_env` to
   `OPENCODE_GO_API_KEY` (the shared OpenCode Go account) and saving keeps
-  that slot instead of minting a region-suffixed one.
+  that slot instead of minting a region-suffixed one. Its model ids are
+  LOWERCASE (`glm-5.2`, `glm-5.1`, `glm-5`) — an uppercase id is rejected
+  with `Model GLM-5.2 is not supported`, even though the native CN/INTL
+  rows take the uppercase catalog names.
 
 CN and INTL imply no `api_key_env`, so cycling between them preserves
 whatever slot the host stamped (`ZHIPU_CN_1_API_KEY`,

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: preset-skill-zhipu
 description: Official-source-led manual for the TUI `zhipu` template.
-version: 2.1.1
+version: 2.2.0
 last_changed_at: "2026-08-09T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 
 # `zhipu`
 
-`zhipuPreset()` (`tui/internal/preset/preset.go:1159-1176`) ships provider
+`zhipuPreset()` (`tui/internal/preset/preset.go:1194-1211`) ships provider
 `zhipu` with exact model `GLM-5.2`, `ZHIPU_API_KEY`, and the
 OpenAI-compatible regional endpoints
 `https://open.bigmodel.cn/api/coding/paas/v4` (CN) and
@@ -26,14 +26,26 @@ The TUI preset editor's `base_url` row offers three options
   that implies a credential: selecting it sets `api_key_env` to
   `OPENCODE_GO_API_KEY` (the shared OpenCode Go account) and saving keeps
   that slot instead of minting a region-suffixed one. Its model ids are
-  LOWERCASE (`glm-5.2`, `glm-5.1`, `glm-5`) — an uppercase id is rejected
-  with `Model GLM-5.2 is not supported`, even though the native CN/INTL
-  rows take the uppercase catalog names.
+  LOWERCASE (`glm-5.2`, `glm-5.1`) — an uppercase id is rejected with
+  `Model GLM-5.2 is not supported`, even though the native CN/INTL rows take
+  the uppercase catalog names. `glm-5.2` is the verified datum (uppercase
+  rejected, lowercase accepted); `glm-5.1` is inferred from the native
+  catalog's `GLM-5.1` by the same lowercasing rule and has not been
+  separately confirmed on the Go endpoint. There is no `glm-5`: the catalog
+  has no standalone `GLM-5`, so no lowercase alias for one is shipped.
 
 CN and INTL imply no `api_key_env`, so cycling between them preserves
 whatever slot the host stamped (`ZHIPU_CN_1_API_KEY`,
 `ZHIPU_INTL_1_API_KEY`). Cycling *off* OpenCode Go restores the slot that
 was in place before it was selected, so the choice is reversible.
+
+The model picker holds two mutually exclusive id sets in a single cycle —
+`GLM-5.2`, `GLM-5.1` for the native rows and `glm-5.2`, `glm-5.1` for
+OpenCode Go — and the model row is not coupled to the selected `base_url`
+row, so it is possible to pair an id with an endpoint that rejects it. Match
+the case to the row you are on. Per the TUI's model-curation rule
+(`tui/CONTRACT.md`) only the latest two generations ship, so `GLM-5-Turbo`,
+`GLM-4.7`, and `GLM-4.5-Air` are no longer selectable.
 
 ## Template-specific settings
 

--- a/tui/internal/tui/SKILL.md
+++ b/tui/internal/tui/SKILL.md
@@ -88,8 +88,8 @@ After editing `providerModels["codex"]` / `modelHasVision`:
 ## Cross-references
 
 - `preset_editor.go:108` — `providerModels` map
-- `preset_editor.go:215` — `modelHasVision` map
-- `preset_editor.go:1623` — `mandatoryCapRow` (fixed, informational capabilities rendering)
+- `preset_editor.go:217` — `modelHasVision` map
+- `preset_editor.go:1647` — `mandatoryCapRow` (fixed, informational capabilities rendering)
 - `internal/preset/preset.go:codexPreset()` — built-in template, sets default model
 - `firstrun.go` `startCodexLogin` — first-run Codex browser/device-code login launcher
 - `firstrun.go` / `login.go` `CodexOAuthDoneMsg` handlers — save tokens after matching-epoch browser/device-code completion

--- a/tui/internal/tui/SKILL.md
+++ b/tui/internal/tui/SKILL.md
@@ -4,7 +4,7 @@ Bookkeeping notes for keeping `providerModels`, `modelHasVision`, and friends in
 
 ## What this file is for
 
-Each LLM provider in `providerModels` (preset_editor.go:134) feeds a model picker on the preset editor's model row. When a user clones a template and cycles ←/→ on the model row, the candidates come straight from this map. The map is the source of truth.
+Each LLM provider in `providerModels` (preset_editor.go:108) feeds a model picker on the preset editor's model row. When a user clones a template and cycles ←/→ on the model row, the candidates come straight from this map. The map is the source of truth.
 
 Drift here causes one of two failures:
 
@@ -17,15 +17,20 @@ The second failure mode is what this file exists to prevent.
 
 | Provider | Canonical list | Cadence | Notes |
 |---|---|---|---|
-| `minimax` | https://platform.minimaxi.com/document/Models | Quarterly | M-series, current = 2.7 |
-| `zhipu` | https://docs.bigmodel.cn/cn/guide/models | Quarterly | GLM-5.x family |
+| `minimax` | https://platform.minimaxi.com/document/Models | Quarterly | M-series, current = M3 |
+| `zhipu` | https://docs.bigmodel.cn/cn/guide/models | Quarterly | GLM-5.x family; OpenCode Go takes the same ids lowercased |
 | `mimo` | https://www.xiaomi-ai.com/cn/models | Quarterly | Xiaomi MiMo |
 | `deepseek` | https://api-docs.deepseek.com/quick_start/pricing | Quarterly | DS-V4 family |
+| `grok` | https://opencode.ai/docs/go/ | Monthly | reached only through OpenCode Go; no native xAI route is shipped |
 | `codex` | https://developers.openai.com/codex/models | Monthly | ChatGPT-OAuth only — not the standard OpenAI API list |
+
+`kimi` is deliberately absent from `providerModels`: its model row stays free text so a typed Moonshot id survives a `→`. Its OpenCode Go ids are documented in `internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md` instead.
 
 For codex specifically, **do not** consult `https://platform.openai.com/docs/models`. That's the standard API model list, which includes models the codex backend (`chatgpt.com/backend-api/codex/responses`) doesn't accept (e.g. `gpt-5.5-pro` exists in the standard API but 4xx's on the codex endpoint).
 
 ## Curation rules
+
+**Rule 0 — latest two generations only.** `tui/CONTRACT.md` ("Model list curation") caps every family at its latest two generations. Adding a new generation is the same change that removes the third-newest. Variants inside a generation (`-highspeed`, `-pro`, `-mini`, the `gpt-5.6-sol/-terra/-luna` routes, a lowercase respelling for another endpoint) are not generations and all stay. Read that section before touching the maps; the checklist below decides inclusion *within* the two generations the rule allows.
 
 For each candidate model, decide inclusion against this checklist:
 
@@ -82,9 +87,9 @@ After editing `providerModels["codex"]` / `modelHasVision`:
 
 ## Cross-references
 
-- `preset_editor.go:97` — `providerModels` map
-- `preset_editor.go:158` — `modelHasVision` map
-- `preset_editor.go:1412` — `mandatoryCapRow` (fixed, informational capabilities rendering)
+- `preset_editor.go:108` — `providerModels` map
+- `preset_editor.go:215` — `modelHasVision` map
+- `preset_editor.go:1623` — `mandatoryCapRow` (fixed, informational capabilities rendering)
 - `internal/preset/preset.go:codexPreset()` — built-in template, sets default model
 - `firstrun.go` `startCodexLogin` — first-run Codex browser/device-code login launcher
 - `firstrun.go` / `login.go` `CodexOAuthDoneMsg` handlers — save tokens after matching-epoch browser/device-code completion

--- a/tui/internal/tui/e2e_opencode_go_test.go
+++ b/tui/internal/tui/e2e_opencode_go_test.go
@@ -89,10 +89,16 @@ func committedLLM(t *testing.T, p preset.Preset) map[string]interface{} {
 }
 
 // TestE2EOpenCodeGoOptionSurvivesSave is the end-to-end contract for the
-// OpenCode Go base_url option on all three providers that offer it: opening
-// the shipped template, walking to the base_url row with ↓, pressing → until
-// OpenCode Go is selected, and saving with Tab+Enter must produce a preset
-// that actually resolves through OPENCODE_GO_API_KEY.
+// OpenCode Go base_url option on every provider whose template starts on a
+// different row and can be cycled onto it: opening the shipped template,
+// walking to the base_url row with ↓, pressing → until OpenCode Go is
+// selected, and saving with Tab+Enter must produce a preset that actually
+// resolves through OPENCODE_GO_API_KEY.
+//
+// grok is the one provider that offers OpenCode Go but is not in this table:
+// its template already ships on that row, so there is nothing to cycle onto
+// and no semantic edit to trigger the isBuiltin save branch.
+// TestE2EGrokTemplateRoundTripsOpenCodeGoSlot covers it instead.
 //
 // Every step goes through the production path — NewPresetEditorModel (so
 // isBuiltin is real), tea.KeyPressMsg through Update (so the →/l binding is
@@ -103,7 +109,7 @@ func committedLLM(t *testing.T, p preset.Preset) map[string]interface{} {
 func TestE2EOpenCodeGoOptionSurvivesSave(t *testing.T) {
 	tempTestHome(t)
 
-	for _, provider := range []string{"deepseek", "zhipu", "minimax"} {
+	for _, provider := range []string{"deepseek", "zhipu", "minimax", "kimi", "mimo"} {
 		t.Run(provider, func(t *testing.T) {
 			regions := preset.ProviderRegionURLs[provider]
 			ocgIdx := -1
@@ -162,6 +168,86 @@ func TestE2EOpenCodeGoOptionSurvivesSave(t *testing.T) {
 				t.Fatalf("[%s] after stampAutoEnvVar api_key_env = %q, want OPENCODE_GO_API_KEY", provider, got)
 			}
 		})
+	}
+}
+
+// TestE2EGrokTemplateRoundTripsOpenCodeGoSlot is grok's half of the OpenCode
+// Go contract. grok is the only provider whose template DEFAULT row is the
+// OpenCode Go row — there is no verified native xAI route — so the interesting
+// assertions are inverted: the shipped template must already resolve through
+// OPENCODE_GO_API_KEY (so an existing OpenCode Go user needs no second copy of
+// the key), and the Custom sentinel must clear base_url so a free-typed
+// endpoint is reachable at all — the capability the two-row tables shipped in
+// the previous commit removed for kimi/mimo.
+//
+// On the Custom row api_key_env is deliberately left alone, matching
+// TestPresetEditorDeepseekRegionCycleRoundTrip: the user is about to type
+// their own endpoint and keeps whatever slot it uses. For grok that means the
+// shared OpenCode Go slot is what carries over, and the user retypes the
+// env-var name if their endpoint needs a different one — see
+// reference/grok/SKILL.md.
+//
+// Everything runs through the production path: the host-shaped editor
+// (isBuiltin real), tea.KeyPressMsg through Update, and the [Save] row.
+func TestE2EGrokTemplateRoundTripsOpenCodeGoSlot(t *testing.T) {
+	tempTestHome(t)
+
+	regions := preset.ProviderRegionURLs["grok"]
+	if len(regions) != 2 || regions[0].URL != openCodeGoURL || regions[1].URL != "" {
+		t.Fatalf("grok region table = %#v, want [OpenCode Go, Custom sentinel]", regions)
+	}
+
+	m := openEditorAsHostDoes(t, "grok")
+	if got := asString(m.llmMap()["base_url"]); got != openCodeGoURL {
+		t.Fatalf("grok template base_url = %q, want the OpenCode Go endpoint", got)
+	}
+	if got := asString(m.llmMap()["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
+		t.Fatalf("grok template api_key_env = %q, want OPENCODE_GO_API_KEY — the shipped endpoint IS OpenCode Go", got)
+	}
+	if got := asString(m.llmMap()["model"]); got != "grok-4.5" {
+		t.Fatalf("grok template model = %q, want grok-4.5", got)
+	}
+
+	// → onto the Custom sentinel: base_url clears so Enter opens a free-text
+	// edit, which is the only in-editor path to any other endpoint.
+	m = walkCursorTo(t, m, feBaseURL)
+	m, _ = pressKey(t, m, tea.KeyRight)
+	if got := asString(m.llmMap()["base_url"]); got != "" {
+		t.Fatalf("grok Custom row base_url = %q, want cleared for free-text entry", got)
+	}
+
+	// → again wraps back onto OpenCode Go and re-adopts the shared slot.
+	m, _ = pressKey(t, m, tea.KeyRight)
+	if got := asString(m.llmMap()["base_url"]); got != openCodeGoURL {
+		t.Fatalf("grok wrap base_url = %q, want back on OpenCode Go", got)
+	}
+	if got := asString(m.llmMap()["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
+		t.Fatalf("grok wrap api_key_env = %q, want OPENCODE_GO_API_KEY re-adopted", got)
+	}
+
+	msg := saveViaKeyboard(t, m)
+	llm := committedLLM(t, msg.Preset)
+	if got := asString(llm["base_url"]); got != openCodeGoURL {
+		t.Fatalf("grok committed base_url = %q, want %q", got, openCodeGoURL)
+	}
+	if got := asString(llm["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
+		t.Fatalf("grok committed api_key_env = %q, want OPENCODE_GO_API_KEY", got)
+	}
+	stamped := stampAutoEnvVar(msg.Preset, map[string]string{"OPENCODE_GO_API_KEY": "sk-live"})
+	if got := asString(committedLLM(t, stamped)["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
+		t.Fatalf("grok after stampAutoEnvVar api_key_env = %q, want OPENCODE_GO_API_KEY — no GROK_N slot over a live shared account", got)
+	}
+
+	// Enter on the Custom row must open a free-text edit — otherwise the
+	// two-row table would be a dead end with no reachable endpoint but
+	// OpenCode Go. Checked on a fresh editor: openInline focuses the shared
+	// textarea, so a model it returns must not be cycled afterwards.
+	fresh := openEditorAsHostDoes(t, "grok")
+	fresh = walkCursorTo(t, fresh, feBaseURL)
+	fresh, _ = pressKey(t, fresh, tea.KeyRight) // -> Custom
+	opened, _ := fresh.openInline()
+	if opened.mode != emInline {
+		t.Fatalf("Enter on the grok Custom row mode = %v, want emInline so an endpoint is typeable", opened.mode)
 	}
 }
 

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -98,34 +98,58 @@ const (
 // Keep this in sync with each provider's official model list. When a
 // new flagship ships, add it (and remove deprecated entries — agents
 // will hit 4xx if they pick a retired model).
+//
+// CURATION RULE (tui/CONTRACT.md, "Model list curation"): every family
+// listed here ships only its LATEST TWO GENERATIONS. A third-newest
+// generation is removed in the same change that adds a new one. Variants
+// within one generation (-highspeed, -pro, -mini, -sol/-terra/-luna) are not
+// separate generations and all stay. See tui/internal/tui/SKILL.md for the
+// per-provider source list and the rest of the inclusion checklist.
 var providerModels = map[string][]string{
 	// MiniMax: official supported LLM model IDs (API Overview), newest first.
-	// M3 is the current flagship/default; the older M2.x IDs remain supported
-	// and are kept as selectable fallbacks.
+	// Latest two generations: M3 (flagship/default) and M2.7 with its
+	// -highspeed variant. M2.5/M2.1/M2 are retired from the picker.
 	"minimax": {
 		"MiniMax-M3",
 		"MiniMax-M2.7", "MiniMax-M2.7-highspeed",
-		"MiniMax-M2.5", "MiniMax-M2.5-highspeed",
-		"MiniMax-M2.1", "MiniMax-M2.1-highspeed",
-		"MiniMax-M2",
 	},
-	// Zhipu: the native CN/INTL endpoints take the uppercase catalog ids;
-	// OpenCode Go only accepts lowercase ("Model GLM-5.2 is not supported"),
-	// so the lowercase aliases are appended for that base_url row.
+	// Zhipu — two mutually exclusive id sets in one cycle, because the model
+	// row is not coupled to the selected base_url row (known debt):
+	//   * UPPERCASE: the native CN/INTL catalog names.
+	//   * lowercase: the same generations as OpenCode Go serves them; an
+	//     uppercase id there is rejected with "Model GLM-5.2 is not supported".
+	// Latest two generations only, both spellings: GLM-5.2 and GLM-5.1.
+	// GLM-5-Turbo/GLM-4.7/GLM-4.5-Air are older generations and dropped;
+	// there is no `glm-5`, so no lowercase alias exists for one.
 	"zhipu": {
-		"GLM-5.2", "GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air",
-		"glm-5.2", "glm-5.1", "glm-5",
+		// native CN/INTL
+		"GLM-5.2", "GLM-5.1",
+		// OpenCode Go
+		"glm-5.2", "glm-5.1",
 	},
-	// Kimi: `kimi-for-coding` is the native Kimi Code subscription model;
-	// the lowercase K-series ids are what OpenCode Go serves.
-	"kimi": {"kimi-for-coding", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5"},
-	// MiMo: the first two are Xiaomi's own endpoint; OpenCode Go additionally
-	// serves the V2 pro/omni ids.
-	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"},
+	// kimi deliberately has NO entry. Adding one would flip the model row from
+	// free text to picker-only (see openInline's feModel case), and cycleString
+	// lands an off-list value on entry [0] — one → would silently overwrite a
+	// saved `kimi-latest` / `moonshot-v1-*` / `kimi-k3` id with no undo. The
+	// Moonshot catalog is far wider than any list we can verify, so kimi keeps
+	// the free-text row it had before it gained a region table. The OpenCode Go
+	// ids to type are documented in reference/kimi/SKILL.md.
+	//
+	// MiMo: mimo-v2.5 and its text-only pro sibling — the latest generation
+	// plus its variant. Both are served by Xiaomi's endpoint AND by OpenCode
+	// Go; the older mimo-v2-pro / mimo-v2-omni ids are a previous generation
+	// and are not shipped.
+	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro"},
 	"deepseek": {"deepseek-v4-pro", "deepseek-v4-flash"},
+	// Grok (xAI) via OpenCode Go — the Go /models list serves grok-4.5 and
+	// nothing older that we have verified.
+	"grok": {"grok-4.5"},
 	// NVIDIA NIM catalog IDs (build.nvidia.com) served on the free tier.
 	// Default flagship first; the rest are popular open-weight options.
 	// Users can also free-text any other catalog ID on this row.
+	// Already compliant with the two-generation rule: the only family with
+	// more than one entry is meta/llama (3.3 and 3.1, the two shipped
+	// generations); every other vendor contributes a single current id.
 	"nvidia": {
 		"meta/llama-3.3-70b-instruct",
 		"meta/llama-3.1-70b-instruct",
@@ -141,12 +165,20 @@ var providerModels = map[string][]string{
 	// routes remain selectable when the endpoint/account
 	// enables them. See SKILL.md next to this file for the canonical source list
 	// and why each model is included or excluded (e.g. pro-only variants can 4xx).
-	"codex": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
+	//
+	// Latest two generations of the GPT-5.x ladder: 5.6 (its three named
+	// routes are variants of one generation, not three generations) and 5.5.
+	// gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex / gpt-5.2 are older generations
+	// and are no longer offered; a saved preset pinned to one keeps working —
+	// we never rewrite saved/ (see SKILL.md, "When you remove a retired model").
+	"codex": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"},
 	// codex-pool serves the same ChatGPT-OAuth models as codex — it only
 	// changes which token file each request routes through (the pool), not the
 	// model catalog. Keep the two lists identical.
-	"codex-pool": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
-	// Claude Code uses CLI aliases, not dated API IDs. Current Claude Code
+	"codex-pool": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"},
+	// Claude Code uses CLI aliases, not dated API IDs — `opus`/`fable`/
+	// `sonnet`/`haiku` name concurrent tiers of one generation, so the
+	// two-generation rule has nothing to trim here. Current Claude Code
 	// resolves fable to claude-fable-5. Keep the old provider spellings only
 	// so user-saved presets remain editable after the built-in moves to
 	// canonical provider "claude-code".
@@ -174,44 +206,46 @@ const presetEditorFieldLabelWidth = 18
 // capability — so this map is reference data for tests only, kept because
 // per-model vision support is still a real fact worth asserting against
 // regressions in providerModels/the model catalog above.
+//
+// One entry per id in providerModels — a shipped model with no entry here
+// reads as text-only via Go's zero value, which is an omission, not a
+// declaration. Ids retired by the two-generation curation rule are removed
+// from both maps together (tui/internal/tui/SKILL.md, "When you remove a
+// retired model").
 var modelHasVision = map[string]bool{
-	// MiniMax: keyed to the official supported LLM model IDs. Only the known
-	// multimodal entries auto-enable vision — M3 (current flagship) and the
-	// M2.7 variants, which prior code treated as image-capable. The older
-	// M2.5/M2.1/M2 IDs are marked false so the editor doesn't auto-enable
-	// vision for them when uncertain.
+	// MiniMax: keyed to the official supported LLM model IDs. Both shipped
+	// generations are multimodal — M3 (current flagship) and the M2.7
+	// variants, which prior code treated as image-capable.
 	"MiniMax-M3":             true,
 	"MiniMax-M2.7":           true,
 	"MiniMax-M2.7-highspeed": true,
-	"MiniMax-M2.5":           false,
-	"MiniMax-M2.5-highspeed": false,
-	"MiniMax-M2.1":           false,
-	"MiniMax-M2.1-highspeed": false,
-	"MiniMax-M2":             false,
-	// Zhipu coding-plan LLMs are text-only. Vision uses the separate GLM-4.6V
-	// model through the optional, manually registered official MCP server.
-	"GLM-5.2":     false,
-	"GLM-5.1":     false,
-	"GLM-5-Turbo": false,
-	"GLM-4.7":     false,
-	"GLM-4.5-Air": false,
+	// Zhipu coding-plan LLMs are text-only, in both the uppercase native
+	// spelling and the lowercase OpenCode Go spelling of the same model.
+	// Vision uses the separate GLM-4.6V model through the optional,
+	// manually registered official MCP server.
+	"GLM-5.2": false,
+	"GLM-5.1": false,
+	"glm-5.2": false,
+	"glm-5.1": false,
 	// MiMo: the default accepts images; the current pro sibling is text-only.
+	// Both are served on Xiaomi's endpoint and on OpenCode Go, and the Go
+	// route re-verifies neither — the LingTai-side vision wiring in
+	// mimoPreset() is scoped to mimo-v2.5 on Xiaomi's own endpoint.
 	"mimo-v2.5":     true,
 	"mimo-v2.5-pro": false,
 	// DeepSeek: text-only across the board.
 	"deepseek-v4-pro":   false,
 	"deepseek-v4-flash": false,
-	// Codex (ChatGPT OAuth): all GPT-5.x family currently accepts images,
-	// including the *-codex tunes. Verify on each model's docs page when
-	// adding new entries; see SKILL.md.
+	// Grok via OpenCode Go: the endpoint's image-input mapping for grok-4.5
+	// is unverified, so this is a declared false, not an unknown. A model
+	// name is never evidence of a wired vision route.
+	"grok-4.5": false,
+	// Codex (ChatGPT OAuth): the whole shipped GPT-5.x lineup accepts images.
+	// Verify on each model's docs page when adding new entries; see SKILL.md.
 	"gpt-5.5":       true,
 	"gpt-5.6-sol":   true,
 	"gpt-5.6-terra": true,
 	"gpt-5.6-luna":  true,
-	"gpt-5.4":       true,
-	"gpt-5.4-mini":  true,
-	"gpt-5.3-codex": true,
-	"gpt-5.2":       true,
 }
 
 // PresetEditorModel is a single-page preset editor. Hosted by the
@@ -964,7 +998,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feProvider:
 		// Order matches the builtin presets (preset.go BuiltinPresets).
 		// Keep this in sync when adding a new provider/builtin.
-		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "codex", "custom"}
+		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "grok", "nvidia", "openrouter", "codex", "custom"}
 		oldProvider := m.fieldString(f)
 		newProvider := cycleString(opts, oldProvider, dir)
 		m.llmMap()["provider"] = newProvider
@@ -1053,6 +1087,12 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 				// resolves to the Custom row, so cycling away from it goes
 				// straight to a real region and never clears the typed value
 				// as a side effect.
+				//
+				// api_key_env is deliberately NOT touched here (pinned by
+				// TestPresetEditorDeepseekRegionCycleRoundTrip): the user is
+				// about to type their own endpoint and keeps whatever slot
+				// that endpoint actually uses. Cycling on to a real region
+				// row re-applies that row's rule.
 				m.llmMap()["base_url"] = ""
 				break
 			}

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -109,8 +109,19 @@ var providerModels = map[string][]string{
 		"MiniMax-M2.1", "MiniMax-M2.1-highspeed",
 		"MiniMax-M2",
 	},
-	"zhipu":    {"GLM-5.2", "GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air"},
-	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro"},
+	// Zhipu: the native CN/INTL endpoints take the uppercase catalog ids;
+	// OpenCode Go only accepts lowercase ("Model GLM-5.2 is not supported"),
+	// so the lowercase aliases are appended for that base_url row.
+	"zhipu": {
+		"GLM-5.2", "GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air",
+		"glm-5.2", "glm-5.1", "glm-5",
+	},
+	// Kimi: `kimi-for-coding` is the native Kimi Code subscription model;
+	// the lowercase K-series ids are what OpenCode Go serves.
+	"kimi": {"kimi-for-coding", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5"},
+	// MiMo: the first two are Xiaomi's own endpoint; OpenCode Go additionally
+	// serves the V2 pro/omni ids.
+	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"},
 	"deepseek": {"deepseek-v4-pro", "deepseek-v4-flash"},
 	// NVIDIA NIM catalog IDs (build.nvidia.com) served on the free tier.
 	// Default flagship first; the rest are popular open-weight options.

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -135,11 +135,13 @@ var providerModels = map[string][]string{
 	// the free-text row it had before it gained a region table. The OpenCode Go
 	// ids to type are documented in reference/kimi/SKILL.md.
 	//
-	// MiMo: mimo-v2.5 and its text-only pro sibling — the latest generation
-	// plus its variant. Both are served by Xiaomi's endpoint AND by OpenCode
-	// Go; the older mimo-v2-pro / mimo-v2-omni ids are a previous generation
-	// and are not shipped.
-	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro"},
+	// MiMo: the latest TWO generations, per the curation rule — v2.5 (with
+	// its text-only -pro variant) and v2 (-pro, -omni). All four are served by
+	// Xiaomi's endpoint AND by OpenCode Go, so the picker is valid on either
+	// base_url row. The rule caps at two generations; it is not a floor, so v2
+	// stays until a generation newer than v2.5 ships and displaces it. The
+	// retired V2 Flash ids and anything older are not shipped.
+	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"},
 	"deepseek": {"deepseek-v4-pro", "deepseek-v4-flash"},
 	// Grok (xAI) via OpenCode Go — the Go /models list serves grok-4.5 and
 	// nothing older that we have verified.
@@ -227,12 +229,17 @@ var modelHasVision = map[string]bool{
 	"GLM-5.1": false,
 	"glm-5.2": false,
 	"glm-5.1": false,
-	// MiMo: the default accepts images; the current pro sibling is text-only.
-	// Both are served on Xiaomi's endpoint and on OpenCode Go, and the Go
-	// route re-verifies neither — the LingTai-side vision wiring in
-	// mimoPreset() is scoped to mimo-v2.5 on Xiaomi's own endpoint.
+	// MiMo: only the default has a verified image route. The -pro siblings are
+	// text-only, and mimo-v2-omni is a declared false rather than an
+	// omission — "omni" in a model name is not evidence of a wired vision
+	// route, and the previous generation's image mapping was never pinned
+	// here. All four are served on Xiaomi's endpoint and on OpenCode Go, and
+	// the Go route re-verifies none of them — the LingTai-side vision wiring
+	// in mimoPreset() is scoped to mimo-v2.5 on Xiaomi's own endpoint.
 	"mimo-v2.5":     true,
 	"mimo-v2.5-pro": false,
+	"mimo-v2-pro":   false,
+	"mimo-v2-omni":  false,
 	// DeepSeek: text-only across the board.
 	"deepseek-v4-pro":   false,
 	"deepseek-v4-flash": false,
@@ -996,8 +1003,12 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	f := editorFieldOrder[m.cursor]
 	switch f {
 	case feProvider:
-		// Order matches the builtin presets (preset.go BuiltinPresets).
-		// Keep this in sync when adding a new provider/builtin.
+		// The subset of builtins reachable from the provider cycle, in
+		// BuiltinPresets order; kimi/gemini/codex-pool/claude are
+		// intentionally reached only by opening their own template, so this
+		// list is deliberately shorter than BuiltinPresets() rather than out
+		// of sync with it. Anything added here must also be handled by the
+		// model/base_url/api_key_env resets below.
 		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "grok", "nvidia", "openrouter", "codex", "custom"}
 		oldProvider := m.fieldString(f)
 		newProvider := cycleString(opts, oldProvider, dir)
@@ -1035,7 +1046,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		// reports "no key" for someone who has ZHIPU_API_KEY set, or sends
 		// the wrong key to bigmodel.cn.
 		//
-		// The api_key_env reset is unconditional and comes from the
+		// The api_key_env reset is unconditional and normally comes from the
 		// provider map, NOT from regions[0].Env: zhipu/minimax region rows
 		// declare no Env precisely so a CN<->INTL base_url cycle preserves
 		// the region-suffixed slot the host stamped (ZHIPU_INTL_1_API_KEY)
@@ -1044,11 +1055,24 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		// keep their current api_key_env. The memoized pre-adoption slot goes
 		// with it: it was taken from the previous provider's region cycle and
 		// must not be restorable onto this one.
+		//
+		// The one exception: when the landing row (regions[0], which base_url
+		// adopts just above) declares its own Env, that declaration wins. Only
+		// grok is in that shape today — its default row IS OpenCode Go, so
+		// taking ProviderDefaultEnv["grok"] = GROK_API_KEY here would leave
+		// the preset pointed at https://opencode.ai/zen/go/v1 holding a
+		// credential slot that endpoint does not use, and the user would have
+		// to paste their OpenCode Go key into a second slot. The slot must
+		// match the row you land on.
 		if regions, ok := preset.ProviderRegionURLs[newProvider]; ok && len(regions) > 0 {
 			m.llmMap()["base_url"] = regions[0].URL
 		}
 		if env, ok := preset.ProviderDefaultEnv[newProvider]; ok {
-			m.llmMap()["api_key_env"] = env
+			want := env
+			if regions := preset.ProviderRegionURLs[newProvider]; len(regions) > 0 && regions[0].Env != "" {
+				want = regions[0].Env
+			}
+			m.llmMap()["api_key_env"] = want
 		}
 		m.regionEnvBeforeAdopt = ""
 	case feModel:

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -1057,8 +1057,8 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		// must not be restorable onto this one.
 		//
 		// The one exception: when the landing row (regions[0], which base_url
-		// adopts just above) declares its own Env, that declaration wins. Only
-		// grok is in that shape today — its default row IS OpenCode Go, so
+		// adopts just above) declares its own Env, that declaration wins.
+		// Only grok differs from its default — its row IS OpenCode Go, so
 		// taking ProviderDefaultEnv["grok"] = GROK_API_KEY here would leave
 		// the preset pointed at https://opencode.ai/zen/go/v1 holding a
 		// credential slot that endpoint does not use, and the user would have

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -93,7 +93,9 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	if got := providerModels["deepseek"][0]; got != "deepseek-v4-pro" {
 		t.Fatalf("deepseek default picker model = %q, want deepseek-v4-pro", got)
 	}
-	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro"}
+	// Xiaomi's own endpoint serves the first two; OpenCode Go additionally
+	// serves the V2 pro/omni ids, so both base_url rows are pickable.
+	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"}
 	if got := providerModels["mimo"]; !reflect.DeepEqual(got, wantMiMoModels) {
 		t.Fatalf("mimo provider models = %#v, want %#v", got, wantMiMoModels)
 	}

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -105,11 +105,12 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	if got := providerModels["minimax"]; !reflect.DeepEqual(got, wantMiniMaxModels) {
 		t.Fatalf("minimax provider models = %#v, want %#v", got, wantMiniMaxModels)
 	}
-	// MiMo ships the latest generation and its text-only variant; both are
-	// served by Xiaomi's endpoint AND by OpenCode Go, so the picker is valid
-	// on either base_url row. The older mimo-v2-pro / mimo-v2-omni ids are a
-	// previous generation and are not shipped.
-	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro"}
+	// MiMo ships the latest TWO generations: v2.5 (+ its text-only -pro
+	// variant) and v2 (-pro, -omni). All four are served by Xiaomi's endpoint
+	// AND by OpenCode Go, so the picker is valid on either base_url row. The
+	// curation rule caps at two generations and does not require trimming to
+	// one, so v2 stays until something newer than v2.5 displaces it.
+	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"}
 	if got := providerModels["mimo"]; !reflect.DeepEqual(got, wantMiMoModels) {
 		t.Fatalf("mimo provider models = %#v, want %#v", got, wantMiMoModels)
 	}
@@ -126,8 +127,13 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	if got := providerModels["claude-code"]; !reflect.DeepEqual(got, wantClaudeModels) {
 		t.Fatalf("claude-code provider models = %#v, want %#v", got, wantClaudeModels)
 	}
-	if !modelHasVision["mimo-v2.5"] || modelHasVision["mimo-v2.5-pro"] {
-		t.Fatal("MiMo picker must keep native vision only for mimo-v2.5")
+	if !modelHasVision["mimo-v2.5"] {
+		t.Fatal("MiMo picker must keep native vision for mimo-v2.5")
+	}
+	for _, model := range []string{"mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"} {
+		if modelHasVision[model] {
+			t.Fatalf("MiMo %s has no verified image route; it must stay text-only (a name is not evidence)", model)
+		}
 	}
 	for _, model := range providerModels["zhipu"] {
 		if modelHasVision[model] {
@@ -1926,6 +1932,12 @@ func TestPresetEditorProviderSwitchResetsAdoptedAPIKeyEnv(t *testing.T) {
 
 	// Switch the provider until it lands on each region-table provider and
 	// assert the stale OpenCode slot is gone every time.
+	//
+	// Coverage here is bounded by cycleFocused's `opts` list, NOT by
+	// ProviderRegionURLs: kimi is a region-table provider but is not on the
+	// provider cycle (it is reached only by opening its own template), so it
+	// is deliberately never seen by this loop. See the feProvider comment in
+	// preset_editor.go.
 	m.cursor = editorFieldOrderIndex(t, feProvider)
 	for i := 0; i < 24; i++ {
 		m.cycleFocused(+1)
@@ -1934,8 +1946,17 @@ func TestPresetEditorProviderSwitchResetsAdoptedAPIKeyEnv(t *testing.T) {
 		if !ok {
 			continue
 		}
-		if got := asString(m.llmMap()["api_key_env"]); got != preset.ProviderDefaultEnv[provider] {
-			t.Fatalf("after switch to %s api_key_env = %q, want the provider default %q", provider, got, preset.ProviderDefaultEnv[provider])
+		// The slot must match the row the switch lands on: the landing row's
+		// own declared Env wins over ProviderDefaultEnv when it has one. Only
+		// grok differs today — its regions[0] is OpenCode Go, so a switch to
+		// grok must adopt OPENCODE_GO_API_KEY, not GROK_API_KEY, or the user
+		// would be pointed at the Go endpoint holding a slot it does not use.
+		want := preset.ProviderDefaultEnv[provider]
+		if len(regions) > 0 && regions[0].Env != "" {
+			want = regions[0].Env
+		}
+		if got := asString(m.llmMap()["api_key_env"]); got != want {
+			t.Fatalf("after switch to %s api_key_env = %q, want %q (the slot declared by the landing base_url row, else the provider default)", provider, got, want)
 		}
 		if got := asString(m.llmMap()["base_url"]); got != regions[0].URL {
 			t.Fatalf("after switch to %s base_url = %q, want %q", provider, got, regions[0].URL)

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -87,17 +88,39 @@ func builtinPresetForEditorTest(t *testing.T, name string) preset.Preset {
 }
 
 func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
-	if got := providerModels["zhipu"][0]; got != "GLM-5.2" {
-		t.Fatalf("zhipu default picker model = %q, want GLM-5.2", got)
-	}
 	if got := providerModels["deepseek"][0]; got != "deepseek-v4-pro" {
 		t.Fatalf("deepseek default picker model = %q, want deepseek-v4-pro", got)
 	}
-	// Xiaomi's own endpoint serves the first two; OpenCode Go additionally
-	// serves the V2 pro/omni ids, so both base_url rows are pickable.
-	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"}
+	// Zhipu carries two spellings of the SAME two generations: uppercase for
+	// the native CN/INTL rows, lowercase for OpenCode Go (which rejects the
+	// uppercase form). There is no standalone GLM-5 in the catalog, so no
+	// `glm-5` alias exists for one — the picker must not invent it.
+	wantZhipuModels := []string{"GLM-5.2", "GLM-5.1", "glm-5.2", "glm-5.1"}
+	if got := providerModels["zhipu"]; !reflect.DeepEqual(got, wantZhipuModels) {
+		t.Fatalf("zhipu provider models = %#v, want %#v", got, wantZhipuModels)
+	}
+	// Latest two MiniMax generations: M3 and M2.7 (+ its -highspeed variant,
+	// which is not a separate generation).
+	wantMiniMaxModels := []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"}
+	if got := providerModels["minimax"]; !reflect.DeepEqual(got, wantMiniMaxModels) {
+		t.Fatalf("minimax provider models = %#v, want %#v", got, wantMiniMaxModels)
+	}
+	// MiMo ships the latest generation and its text-only variant; both are
+	// served by Xiaomi's endpoint AND by OpenCode Go, so the picker is valid
+	// on either base_url row. The older mimo-v2-pro / mimo-v2-omni ids are a
+	// previous generation and are not shipped.
+	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro"}
 	if got := providerModels["mimo"]; !reflect.DeepEqual(got, wantMiMoModels) {
 		t.Fatalf("mimo provider models = %#v, want %#v", got, wantMiMoModels)
+	}
+	if got := providerModels["grok"]; !reflect.DeepEqual(got, []string{"grok-4.5"}) {
+		t.Fatalf("grok provider models = %#v, want [grok-4.5]", got)
+	}
+	// kimi must NOT gain a picker: an entry here flips its model row from
+	// free text to picker-only, and one → then overwrites a typed off-list
+	// Moonshot id (kimi-latest, moonshot-v1-*) with entry [0], unrecoverably.
+	if models, ok := providerModels["kimi"]; ok {
+		t.Fatalf("kimi must keep a free-text model row, got picker %#v", models)
 	}
 	wantClaudeModels := []string{"opus", "fable", "sonnet", "haiku"}
 	if got := providerModels["claude-code"]; !reflect.DeepEqual(got, wantClaudeModels) {
@@ -111,10 +134,15 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 			t.Fatalf("Zhipu coding-plan model %s must remain text-only; GLM-4.6V uses the optional manual MCP path", model)
 		}
 	}
+	if modelHasVision["grok-4.5"] {
+		t.Fatal("grok-4.5 has no verified image-input route on OpenCode Go; it must stay text-only")
+	}
 
+	// Latest two GPT-5.x generations: 5.6 (three named routes of one
+	// generation) and 5.5. codex-pool changes account selection, not the
+	// catalog, so the two lists stay identical.
 	wantCodexModels := []string{
-		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
-		"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2",
+		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5",
 	}
 	for _, provider := range []string{"codex", "codex-pool"} {
 		models := providerModels[provider]
@@ -122,9 +150,43 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 			t.Fatalf("%s provider models = %#v, want %#v", provider, models, wantCodexModels)
 		}
 	}
-	for _, model := range wantCodexModels[:4] {
+	for _, model := range wantCodexModels {
 		if !modelHasVision[model] {
 			t.Fatalf("%s should be treated as vision-capable like the rest of the GPT-5.x Codex lineup", model)
+		}
+	}
+}
+
+// TestModelHasVisionDeclaresEveryShippedModel is the F8 contract: a shipped
+// model that is absent from modelHasVision reads as text-only through Go's
+// zero value, which is an omission rather than a declaration. `mimo-v2-omni`
+// was the case that made this matter — a name that suggests multimodality
+// with nothing in the map pushing back. Every id the picker can reach must
+// have an explicit entry, and the map must not accumulate entries for models
+// the two-generation curation rule has retired.
+func TestModelHasVisionDeclaresEveryShippedModel(t *testing.T) {
+	shipped := map[string]bool{}
+	for provider, models := range providerModels {
+		// The Claude Code aliases name CLI tiers, not API model ids; vision
+		// there is a property of the resolved model, not the alias.
+		if strings.HasPrefix(provider, "claude") {
+			continue
+		}
+		// The NVIDIA catalog is an open free-text gateway list, not a curated
+		// per-model vision inventory.
+		if provider == "nvidia" {
+			continue
+		}
+		for _, m := range models {
+			shipped[m] = true
+			if _, ok := modelHasVision[m]; !ok {
+				t.Errorf("providerModels[%q] ships %q with no modelHasVision entry — declare it false rather than relying on the zero value", provider, m)
+			}
+		}
+	}
+	for m := range modelHasVision {
+		if !shipped[m] {
+			t.Errorf("modelHasVision documents %q, which no provider ships any more — remove it with the id (SKILL.md, \"When you remove a retired model\")", m)
 		}
 	}
 }
@@ -2063,6 +2125,96 @@ func TestPresetEditorRegionCycleRestoresFromOffListBaseURL(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestPresetEditorOpenCodeGoRowAdoptsAndRestoresForEveryProvider is the F5
+// coverage fix: the five hand-written cycle tests above are all hardcoded to
+// zhipu/minimax, so kimi, mimo and grok shipped an OpenCode Go row whose Env
+// adoption and restore nothing pinned. This one is generic — it reads the
+// table, so a provider that gains a Go row is covered the moment it is added.
+//
+// It walks the single transition that matters, in both directions: the row
+// immediately before OpenCode Go -> OpenCode Go -> back. The expected slot on
+// the way back follows the three documented rules, in order: the row's own
+// declared Env when it has one (deepseek's DeepSeek API row); an untouched
+// api_key_env on the Custom sentinel (pinned by
+// TestPresetEditorDeepseekRegionCycleRoundTrip — a free-typed endpoint keeps
+// whatever slot it actually uses); otherwise the memoized pre-adoption slot
+// (every Env-less native row).
+func TestPresetEditorOpenCodeGoRowAdoptsAndRestoresForEveryProvider(t *testing.T) {
+	covered := 0
+	for _, provider := range sortedRegionProviders() {
+		regions := preset.ProviderRegionURLs[provider]
+		ocg := -1
+		for i, r := range regions {
+			if r.URL == openCodeGoURL {
+				ocg = i
+				break
+			}
+		}
+		if ocg < 0 {
+			continue
+		}
+		covered++
+		t.Run(provider, func(t *testing.T) {
+			from := (ocg - 1 + len(regions)) % len(regions)
+			// A host-stamped private slot, the thing the restore exists to
+			// hand back. Env-less rows carry one; an Env row overrides it.
+			slot := strings.ToUpper(provider) + "_7_API_KEY"
+			startEnv := regions[from].Env
+			if startEnv == "" {
+				startEnv = slot
+			}
+			p := preset.Preset{Name: "my-" + provider, Source: preset.SourceSaved, Manifest: map[string]interface{}{
+				"llm": map[string]interface{}{"provider": provider, "model": "m",
+					"base_url":    regions[from].URL,
+					"api_key_env": startEnv}}}
+			m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+			llm := m.llmMap()
+			m.cursor = editorFieldOrderIndex(t, feBaseURL)
+
+			m.cycleFocused(+1) // -> OpenCode Go
+			if got := asString(llm["base_url"]); got != openCodeGoURL {
+				t.Fatalf("[%s] +1 from %q base_url = %q, want the OpenCode Go row", provider, regions[from].Label, got)
+			}
+			if got := asString(llm["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
+				t.Fatalf("[%s] on OpenCode Go api_key_env = %q, want OPENCODE_GO_API_KEY", provider, got)
+			}
+
+			wantBack := startEnv
+			switch {
+			case regions[from].Env != "":
+				wantBack = regions[from].Env
+			case regions[from].URL == "":
+				// Custom sentinel: documented to keep whatever slot is set.
+				wantBack = "OPENCODE_GO_API_KEY"
+			}
+			m.cycleFocused(-1) // -> back where we came from
+			if got := asString(llm["base_url"]); got != regions[from].URL {
+				t.Fatalf("[%s] -1 base_url = %q, want %q", provider, got, regions[from].URL)
+			}
+			if got := asString(llm["api_key_env"]); got != wantBack {
+				t.Fatalf("[%s] -1 api_key_env = %q, want %q on the %q row",
+					provider, got, wantBack, regions[from].Label)
+			}
+		})
+	}
+	// Guards against the loop silently covering nothing if the table shape
+	// or the OpenCode Go URL ever changes.
+	if covered < 6 {
+		t.Fatalf("only %d providers offer an OpenCode Go row; want at least 6 (deepseek, zhipu, minimax, kimi, mimo, grok)", covered)
+	}
+}
+
+// sortedRegionProviders makes the generic table-driven tests deterministic —
+// Go map iteration order is randomized per run.
+func sortedRegionProviders() []string {
+	names := make([]string, 0, len(preset.ProviderRegionURLs))
+	for name := range preset.ProviderRegionURLs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // F1-r6 mirror: an off-list base_url paired with the adopted slot, then


### PR DESCRIPTION
## Summary\n\nExpands the OpenCode Go preset surface per Jason's direction (4114/4120/4124/4128):\n\n- **kimi/mimo**: add "OpenCode Go" base_url region rows (with Custom sentinel for free text), lowercase glm ids for OpenCode Go\n- **grok (new)**: grok-4.5 via OpenCode Go subscription only; template api_key_env = OPENCODE_GO_API_KEY (the only slot that works); ProviderDefaultEnv[grok]=GROK_API_KEY as fallback\n- **model curation rule** (tui/CONTRACT.md): latest two generations per model family — gpt 5.5+5.6, minimax M3/M2.7, kimi k3/k2.7-code, codex/codex-pool trimmed, mimo two gens restored, grok=[grok-4.5]\n- provider switch to grok adopts the landing row's Env (OPENCODE_GO_API_KEY), not the provider default — R2-F3, mutation-verified\n\n## Review history\n- fable r1 (F1-F11): fixed in 121b1317\n- fable r2 (R2-F1..F8): fixed in e9c1c7dd (mutation-verified)\n- fable r3: APPROVE (F3-1..F3-4 comment/doc nits fixed in 6f2891a2, line-count-neutral for router anchors)\n\n## Verification\n- Full suite: 14/14 packages ok, 1618/1618 top-level tests pass, 0 fail\n- Anchor router: all 13 provider anchors exact (preset.go untouched by e9c1c7dd; F3-1 rewords line-count-neutral)\n- Real endpoint verified: glm-5.2/glm-5/kimi-k3/mimo-v2.5/grok-4.5 via opencode.ai/zen/go/v1; OpenCode Go is lowercase-only\n\n— @homewinlingtaibot / 深一