### PR TITLE
Fix installer source archive Go builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2354,7 +2354,7 @@ build_from_source() {
   ensure_go_for_source "$BUILD_DIR"
 
   say "Building lingtai-tui ($VERSION) ..."
-  (cd "$BUILD_DIR/tui" && CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-tui" .)
+  (cd "$BUILD_DIR/tui" && CGO_ENABLED=0 go build -buildvcs=false -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-tui" .)
 
   PORTAL_BUILT=0
   if [[ "$SKIP_PORTAL" == "1" ]]; then
@@ -2362,7 +2362,7 @@ build_from_source() {
   else
     if ensure_node_for_portal; then
       say "Building lingtai-portal ($VERSION) ..."
-      if (cd "$BUILD_DIR/portal/web" && npm ci --silent && npm run build --silent) &&          (cd "$BUILD_DIR/portal" && CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-portal" .); then
+      if (cd "$BUILD_DIR/portal/web" && npm ci --silent && npm run build --silent) &&          (cd "$BUILD_DIR/portal" && CGO_ENABLED=0 go build -buildvcs=false -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-portal" .); then
         PORTAL_BUILT=1
       else
         warn "Skipping portal — portal build failed; continuing with lingtai-tui only."


### PR DESCRIPTION
## Summary
- Fixes #835.
- Adds `-buildvcs=false` to the two Go source-build invocations in `install.sh` (`lingtai-tui` and `lingtai-portal`).
- This lets the installer source-build fallback work from release archives / no usable VCS metadata contexts.

## Validation
- `bash -n install.sh`
- `git diff --check`
- Isolated sandbox install using patched local `install.sh`:
  - `HOME=<work>/home_patch`
  - `--prefix <work>/prefix_patch`
  - `--version v1.0.0 --non-interactive`
  - result: install completed successfully after the previous VCS-stamping failure point
- Sandbox binary smoke:
  - `lingtai-tui --version` -> `lingtai-tui v1.0.0`
  - `lingtai-portal --version` -> `lingtai-portal v1.0.0`
  - `lingtai-agent check-caps` returned capability JSON

## Notes
- This does not fix the missing/mismatched v1.0.0 bundle manifest/kernel pin tracked in #833.
- It only fixes the source-build fallback path after that fallback is selected.
- Validation was done under an isolated workdir HOME/prefix; no live manager runtime, PATH, config, or agent process was modified.
