### PR TITLE
feat(tui): show reasoning-effort row for anthropic and openai-compatible presets

### DIFF
--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -194,6 +194,14 @@ var codexServiceTierOptions = []string{"normal", "fast"}
 
 var codexThinkingOptions = []string{"low", "medium", "high", "xhigh"}
 
+// customResponsesThinkingOptions is the reasoning-effort ladder every
+// non-Codex thinking-capable provider offers: the kernel's canonical
+// THINKING_LEVELS tuple (lingtai/kernel/config.py) plus a leading
+// "default" pseudo-option. "default" is NOT a payload value — the kernel
+// treats an omitted manifest.llm.thinking as its own default, so selecting
+// it deletes the key. Anthropic maps these levels to a thinking budget;
+// OpenAI-compatible providers pass them through as Responses
+// reasoning.effort.
 var customResponsesThinkingOptions = []string{"default", "none", "minimal", "low", "medium", "high", "xhigh"}
 
 var wireAPIOptions = []string{"auto", "chat_completions", "responses"}
@@ -727,8 +735,55 @@ func (m PresetEditorModel) hasCodexThinking() bool {
 	return isCodexThinkingProvider(asString(m.llmMap()["provider"]))
 }
 
+// isThinkingLevel reports whether v is one of the kernel's canonical
+// THINKING_LEVELS payload values. "default" is deliberately absent: it is a
+// UI-only pseudo-option meaning "omit manifest.llm.thinking".
+func isThinkingLevel(v string) bool {
+	switch v {
+	case "none", "minimal", "low", "medium", "high", "xhigh":
+		return true
+	}
+	return false
+}
+
+// llmHasLevelThinking reports whether an llm block takes the canonical
+// THINKING_LEVELS ladder — every thinking-capable provider except the Codex
+// family, which keeps its own ladder and its own xhigh default.
+//
+// Scope: Anthropic (the adapter turns the level into an extended-thinking
+// budget) and every OpenAI-compatible provider (api_compat=openai), whose
+// level rides through as Responses reasoning.effort. wire_api does NOT gate
+// this: the field is accepted regardless of which OpenAI wire the preset
+// selects. Providers with a native non-OpenAI adapter and no api_compat
+// declaration — gemini, claude-code, minimax — stay out of scope.
+func llmHasLevelThinking(llm map[string]interface{}) bool {
+	if llm == nil {
+		return false
+	}
+	provider := asString(llm["provider"])
+	if isCodexThinkingProvider(provider) {
+		return false // Codex owns its ladder; see codexThinkingOptions.
+	}
+	switch provider {
+	case "anthropic", "openai":
+		return true
+	}
+	// api_compat is the explicit declaration of which wire protocol (and so
+	// which kernel adapter) the provider speaks; both adapters behind it
+	// honor a configured thinking level.
+	switch asString(llm["api_compat"]) {
+	case "openai", "anthropic":
+		return true
+	}
+	return false
+}
+
+func (m PresetEditorModel) hasLevelThinking() bool {
+	return llmHasLevelThinking(m.llmMap())
+}
+
 func (m PresetEditorModel) hasThinking() bool {
-	return m.hasCodexThinking() || m.isCustomOpenAIResponses()
+	return m.hasCodexThinking() || m.hasLevelThinking()
 }
 
 // isCustomOpenAI reports whether the working preset is in the narrow scope
@@ -743,8 +798,9 @@ func (m PresetEditorModel) isCustomOpenAI() bool {
 
 // isCustomOpenAIResponses is the narrow custom-provider scope built on the
 // only Kernel path that supports the Responses adapter: custom + OpenAI
-// compatibility + explicit Responses. It gates both the transport selector
-// and the reasoning.effort selector.
+// compatibility + explicit Responses. It gates the transport selector. The
+// reasoning-effort selector is NOT gated on it — see llmHasLevelThinking,
+// which accepts every OpenAI-compatible provider on any wire.
 func (m PresetEditorModel) isCustomOpenAIResponses() bool {
 	return m.isCustomOpenAI() && m.fieldString(feWireAPI) == "responses"
 }
@@ -856,13 +912,13 @@ func (m PresetEditorModel) thinkingValue() string {
 	if m.hasCodexThinking() {
 		return m.codexThinking()
 	}
-	if m.isCustomOpenAIResponses() {
-		switch asString(m.llmMap()["thinking"]) {
-		case "none", "minimal", "low", "medium", "high", "xhigh":
-			return asString(m.llmMap()["thinking"])
-		default:
-			return "default"
+	if m.hasLevelThinking() {
+		if v := asString(m.llmMap()["thinking"]); isThinkingLevel(v) {
+			return v
 		}
+		// Absent or invalid: the kernel's own default applies, which the
+		// editor shows (and stores) as omission.
+		return "default"
 	}
 	return ""
 }
@@ -871,7 +927,7 @@ func (m PresetEditorModel) thinkingOptions() []string {
 	if m.hasCodexThinking() {
 		return codexThinkingOptions
 	}
-	if m.isCustomOpenAIResponses() {
+	if m.hasLevelThinking() {
 		return customResponsesThinkingOptions
 	}
 	return nil
@@ -883,16 +939,13 @@ func (m *PresetEditorModel) setThinking(effort string) {
 		return
 	}
 	llm := m.llmMap()
-	if !m.isCustomOpenAIResponses() || effort == "default" {
+	if !m.hasLevelThinking() || !isThinkingLevel(effort) {
+		// Out of scope, "default", or an unknown value — all of which mean
+		// "carry no thinking field".
 		delete(llm, "thinking")
 		return
 	}
-	switch effort {
-	case "none", "minimal", "low", "medium", "high", "xhigh":
-		llm["thinking"] = effort
-	default:
-		delete(llm, "thinking")
-	}
+	llm["thinking"] = effort
 }
 
 func normalizeServiceTier(manifest map[string]interface{}) {
@@ -923,18 +976,15 @@ func normalizeThinking(manifest map[string]interface{}) {
 			return
 		}
 	}
-	if asString(llm["provider"]) == "custom" &&
-		asString(llm["api_compat"]) == "openai" &&
-		asString(llm["wire_api"]) == "responses" {
-		switch asString(llm["thinking"]) {
-		case "none", "minimal", "low", "medium", "high", "xhigh":
-			return
-		default:
-			// Custom's "default" is represented by omission. The Kernel's
-			// existing main-session default then remains "high".
-			delete(llm, "thinking")
+	if llmHasLevelThinking(llm) {
+		if isThinkingLevel(asString(llm["thinking"])) {
 			return
 		}
+		// "default" is represented by omission for every non-Codex provider:
+		// the Kernel's own main-session default then applies. No default is
+		// forced here, so an absent field stays absent.
+		delete(llm, "thinking")
+		return
 	}
 	delete(llm, "thinking")
 }
@@ -1733,8 +1783,8 @@ func (m PresetEditorModel) thinkingRadioStrip(focused bool, valStyle lipgloss.St
 		}
 	}
 	separator := "  "
-	if m.isCustomOpenAIResponses() {
-		// Seven custom choices still need to fit in the standard 80-column form.
+	if m.hasLevelThinking() {
+		// Seven level choices still need to fit in the standard 80-column form.
 		separator = " "
 	}
 	return strings.Join(parts, separator)

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -384,9 +384,7 @@ func TestPresetEditorAPIKeyBlankEditKeepsStoredKey(t *testing.T) {
 	m := NewPresetEditorModel(p, "en", keys, "")
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 
-	for i := 0; i < 9; i++ {
-		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	}
+	m.cursor = editorFieldOrderIndex(t, feAPIKey)
 	if editorFieldOrder[m.cursor] != feAPIKey {
 		t.Fatalf("expected cursor on feAPIKey, got %v", editorFieldOrder[m.cursor])
 	}
@@ -814,31 +812,39 @@ func TestPresetEditorCodexThinkingDisplayAndCommitNormalization(t *testing.T) {
 	}
 }
 
-func TestPresetEditorThinkingHiddenAndRemovedForNonCodex(t *testing.T) {
+// Providers with a native, non-OpenAI/Anthropic kernel adapter (gemini,
+// claude-code) do not accept manifest.llm.thinking at all: the row stays
+// hidden and a stale value is stripped on commit.
+func TestPresetEditorThinkingHiddenAndRemovedForNonThinkingProvider(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
 	llm := m.working.Manifest["llm"].(map[string]interface{})
+	llm["provider"] = "gemini"
+	delete(llm, "api_compat")
 	llm["thinking"] = "low"
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
 	view := m.View()
 
 	if m.fieldVisible(feThinking) {
-		t.Fatalf("reasoning effort row should be hidden for non-codex provider")
+		t.Fatalf("reasoning effort row should be hidden for a non-thinking provider")
+	}
+	if m.isCyclable(feThinking) {
+		t.Fatalf("reasoning effort row should not be cyclable for a non-thinking provider")
 	}
 	if strings.Contains(view, "Reasoning effort") || strings.Contains(view, "llm.thinking") {
-		t.Fatalf("non-codex editor should not render thinking row; view:\n%s", view)
+		t.Fatalf("non-thinking editor should not render thinking row; view:\n%s", view)
 	}
 
 	m.cursor = editorFieldOrderIndex(t, feServiceTier)
 	m.normalizeCursor()
 	if editorFieldOrder[m.cursor] == feThinking {
-		t.Fatalf("cursor landed on hidden thinking field for non-codex preset")
+		t.Fatalf("cursor landed on hidden thinking field for non-thinking preset")
 	}
 
 	_, cmd := m.commit()
 	commit := cmd().(PresetEditorCommitMsg)
 	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
 	if _, ok := committedLLM["thinking"]; ok {
-		t.Fatalf("non-codex commit should remove llm.thinking; got %#v", committedLLM["thinking"])
+		t.Fatalf("non-thinking commit should remove llm.thinking; got %#v", committedLLM["thinking"])
 	}
 }
 
@@ -864,7 +870,9 @@ func TestPresetEditorProviderSwitchClearsThinking(t *testing.T) {
 }
 
 func TestPresetEditorServiceTierHiddenForNonCodexAndPreserved(t *testing.T) {
-	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
+	// gemini has no api_compat and is outside the thinking scope, so the field
+	// layout matches the classic non-codex editor (thinking row hidden).
+	m := NewPresetEditorModelWithBuiltinFlag(testLevelThinkingPreset("gemini", "", nil), "en", nil, "", false)
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
 	view := m.View()
 
@@ -1585,29 +1593,293 @@ func TestPresetEditorCustomResponsesThinkingCyclesAndOmitsDefault(t *testing.T) 
 	}
 }
 
-func TestPresetEditorCustomThinkingCleansWhenResponsesScopeEnds(t *testing.T) {
-	for _, tc := range []struct {
-		name  string
-		field editorField
-	}{
-		{name: "provider", field: feProvider},
-		{name: "api compat", field: feAPICompat},
-		{name: "wire api", field: feWireAPI},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			p := testCustomOpenAIPresetEditorPreset()
-			llm := p.Manifest["llm"].(map[string]interface{})
-			llm["wire_api"] = "responses"
-			llm["thinking"] = "xhigh"
-			m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+// Leaving the thinking-capable scope entirely (api_compat cleared, so the
+// preset declares no OpenAI/Anthropic wire) strips the value and hides the
+// row. Switching wire_api does NOT: manifest.llm.thinking is accepted on
+// either OpenAI wire, so the level survives.
+func TestPresetEditorThinkingCleansWhenCompatScopeEnds(t *testing.T) {
+	p := testCustomOpenAIPresetEditorPreset()
+	llm := p.Manifest["llm"].(map[string]interface{})
+	llm["wire_api"] = "responses"
+	llm["thinking"] = "xhigh"
+	m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
 
-			m.cursor = editorFieldOrderIndex(t, tc.field)
-			m.cycleFocused(+1)
-			if _, ok := m.llmMap()["thinking"]; ok {
-				t.Fatal("leaving custom Responses scope must remove thinking")
+	m.cursor = editorFieldOrderIndex(t, feAPICompat)
+	m.cycleFocused(-1) // openai -> "" (no declared wire compatibility)
+	if got := m.llmMap()["api_compat"]; got != "" {
+		t.Fatalf("api_compat after cycling = %#v, want empty", got)
+	}
+	if _, ok := m.llmMap()["thinking"]; ok {
+		t.Fatal("leaving the OpenAI/Anthropic compat scope must remove thinking")
+	}
+	if m.fieldVisible(feThinking) {
+		t.Fatal("thinking must be hidden after leaving the compat scope")
+	}
+}
+
+func TestPresetEditorThinkingSurvivesWireAPIChange(t *testing.T) {
+	p := testCustomOpenAIPresetEditorPreset()
+	llm := p.Manifest["llm"].(map[string]interface{})
+	llm["wire_api"] = "responses"
+	llm["thinking"] = "high"
+	m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+
+	m.cursor = editorFieldOrderIndex(t, feWireAPI)
+	m.cycleFocused(+1) // responses -> auto (wraps)
+	if got := m.fieldString(feWireAPI); got != "auto" {
+		t.Fatalf("wire_api after cycling = %q, want auto", got)
+	}
+	if got := m.llmMap()["thinking"]; got != "high" {
+		t.Fatalf("thinking after wire_api change = %#v, want high", got)
+	}
+	if !m.fieldVisible(feThinking) || !m.isCyclable(feThinking) {
+		t.Fatal("thinking must stay visible and cyclable on any OpenAI wire")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reasoning effort for every non-Codex thinking-capable provider
+// ─────────────────────────────────────────────────────────────────────────────
+
+// testLevelThinkingPreset builds a minimal preset for a provider that takes
+// the canonical THINKING_LEVELS ladder. A nil thinking omits the field.
+func testLevelThinkingPreset(provider, apiCompat string, thinking interface{}) preset.Preset {
+	llm := map[string]interface{}{
+		"provider":    provider,
+		"model":       "test-model",
+		"base_url":    "https://api.example.com/v1",
+		"api_key_env": "TEST_API_KEY",
+	}
+	if apiCompat != "" {
+		llm["api_compat"] = apiCompat
+	}
+	if thinking != nil {
+		llm["thinking"] = thinking
+	}
+	return preset.Preset{
+		Name:        provider + "-thinking-test",
+		Description: preset.PresetDescription{Summary: "Thinking-capable editor test preset"},
+		Manifest: map[string]interface{}{
+			"llm":          llm,
+			"capabilities": map[string]interface{}{},
+		},
+	}
+}
+
+func TestPresetEditorThinkingRowVisibleForThinkingCapableProviders(t *testing.T) {
+	cases := []struct {
+		name      string
+		provider  string
+		compat    string
+		wantShown bool
+	}{
+		{name: "anthropic", provider: "anthropic", compat: "", wantShown: true},
+		{name: "custom anthropic compat", provider: "custom", compat: "anthropic", wantShown: true},
+		{name: "openai", provider: "openai", compat: "", wantShown: true},
+		// No wire_api anywhere in these manifests: the row must not depend on
+		// an explicit Responses selection.
+		{name: "deepseek openai compat", provider: "deepseek", compat: "openai", wantShown: true},
+		{name: "custom openai compat", provider: "custom", compat: "openai", wantShown: true},
+		{name: "minimax native", provider: "minimax", compat: "", wantShown: false},
+		{name: "gemini", provider: "gemini", compat: "", wantShown: false},
+		{name: "claude code", provider: "claude-code", compat: "", wantShown: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testLevelThinkingPreset(tc.provider, tc.compat, nil), "en", nil, "", false)
+			m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+
+			if got := m.fieldVisible(feThinking); got != tc.wantShown {
+				t.Fatalf("fieldVisible(feThinking) = %v, want %v", got, tc.wantShown)
 			}
-			if m.fieldVisible(feThinking) {
-				t.Fatal("thinking must be hidden after leaving custom Responses scope")
+			if got := m.isCyclable(feThinking); got != tc.wantShown {
+				t.Fatalf("isCyclable(feThinking) = %v, want %v", got, tc.wantShown)
+			}
+			view := m.View()
+			if got := strings.Contains(view, "Reasoning effort"); got != tc.wantShown {
+				t.Fatalf("view renders Reasoning effort = %v, want %v; view:\n%s", got, tc.wantShown, view)
+			}
+			if !tc.wantShown {
+				if got := m.thinkingValue(); got != "" {
+					t.Fatalf("thinkingValue() = %q, want empty for a non-thinking provider", got)
+				}
+				if got := m.thinkingOptions(); got != nil {
+					t.Fatalf("thinkingOptions() = %#v, want nil", got)
+				}
+				return
+			}
+			if got := m.thinkingValue(); got != "default" {
+				t.Fatalf("absent thinking displays %q, want default", got)
+			}
+			if got := m.thinkingOptions(); !reflect.DeepEqual(got, customResponsesThinkingOptions) {
+				t.Fatalf("thinking options = %#v, want %#v", got, customResponsesThinkingOptions)
+			}
+			for _, effort := range customResponsesThinkingOptions {
+				if !strings.Contains(view, effort) {
+					t.Fatalf("thinking picker does not render %q; view:\n%s", effort, view)
+				}
+			}
+		})
+	}
+}
+
+func TestPresetEditorLevelThinkingCyclesAndCommits(t *testing.T) {
+	for _, provider := range []struct{ name, compat string }{
+		{name: "anthropic", compat: ""},
+		{name: "deepseek", compat: "openai"},
+	} {
+		t.Run(provider.name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testLevelThinkingPreset(provider.name, provider.compat, nil), "en", nil, "", false)
+			m.cursor = editorFieldOrderIndex(t, feThinking)
+
+			for _, want := range customResponsesThinkingOptions[1:] {
+				m.cycleFocused(+1)
+				if got := m.fieldString(feThinking); got != want {
+					t.Fatalf("thinking cycle = %q, want %q", got, want)
+				}
+				if got := m.llmMap()["thinking"]; got != want {
+					t.Fatalf("manifest thinking = %#v, want %q", got, want)
+				}
+			}
+
+			// xhigh wraps back to default, represented by an omitted field.
+			m.cycleFocused(+1)
+			if got := m.fieldString(feThinking); got != "default" {
+				t.Fatalf("thinking wrap = %q, want default", got)
+			}
+			if _, ok := m.llmMap()["thinking"]; ok {
+				t.Fatal("default must omit manifest.llm.thinking")
+			}
+
+			_, cmd := m.commit()
+			committed := cmd().(PresetEditorCommitMsg).Preset.Manifest["llm"].(map[string]interface{})
+			if _, ok := committed["thinking"]; ok {
+				t.Fatal("committed default must omit manifest.llm.thinking")
+			}
+		})
+	}
+}
+
+func TestPresetEditorLevelThinkingSetPersistsThroughCommit(t *testing.T) {
+	cases := []struct {
+		name      string
+		provider  string
+		compat    string
+		set       string
+		wantSaved bool
+		wantValue string
+	}{
+		{name: "anthropic high", provider: "anthropic", set: "high", wantSaved: true, wantValue: "high"},
+		{name: "anthropic none", provider: "anthropic", set: "none", wantSaved: true, wantValue: "none"},
+		{name: "anthropic default", provider: "anthropic", set: "default"},
+		{name: "anthropic invalid", provider: "anthropic", set: "turbo"},
+		{name: "openai compat xhigh", provider: "deepseek", compat: "openai", set: "xhigh", wantSaved: true, wantValue: "xhigh"},
+		{name: "openai compat default", provider: "deepseek", compat: "openai", set: "default"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testLevelThinkingPreset(tc.provider, tc.compat, "medium"), "en", nil, "", false)
+			m.setThinking(tc.set)
+
+			wantDisplay := tc.wantValue
+			if !tc.wantSaved {
+				wantDisplay = "default"
+			}
+			if got := m.fieldString(feThinking); got != wantDisplay {
+				t.Fatalf("thinking display = %q, want %q", got, wantDisplay)
+			}
+
+			_, cmd := m.commit()
+			committed := cmd().(PresetEditorCommitMsg).Preset.Manifest["llm"].(map[string]interface{})
+			got, saved := committed["thinking"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("committed thinking saved=%v, want %v; value=%#v", saved, tc.wantSaved, committed["thinking"])
+			}
+			if saved && got != tc.wantValue {
+				t.Fatalf("committed thinking = %q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}
+
+// An invalid stored value is normalized away for level providers (omitted ==
+// the kernel default) while Codex keeps its explicit xhigh default.
+func TestNormalizeThinkingByProviderScope(t *testing.T) {
+	cases := []struct {
+		name      string
+		llm       map[string]interface{}
+		wantSaved bool
+		wantValue string
+	}{
+		{
+			name:      "anthropic invalid dropped",
+			llm:       map[string]interface{}{"provider": "anthropic", "thinking": "turbo"},
+			wantSaved: false,
+		},
+		{
+			name:      "anthropic wrong type dropped",
+			llm:       map[string]interface{}{"provider": "anthropic", "thinking": 12},
+			wantSaved: false,
+		},
+		{
+			name:      "anthropic valid kept",
+			llm:       map[string]interface{}{"provider": "anthropic", "thinking": "medium"},
+			wantSaved: true,
+			wantValue: "medium",
+		},
+		{
+			name:      "anthropic absent stays absent",
+			llm:       map[string]interface{}{"provider": "anthropic"},
+			wantSaved: false,
+		},
+		{
+			name:      "openai compat invalid dropped",
+			llm:       map[string]interface{}{"provider": "deepseek", "api_compat": "openai", "thinking": "turbo"},
+			wantSaved: false,
+		},
+		{
+			name:      "openai compat valid kept without wire_api",
+			llm:       map[string]interface{}{"provider": "deepseek", "api_compat": "openai", "thinking": "minimal"},
+			wantSaved: true,
+			wantValue: "minimal",
+		},
+		{
+			name:      "out of scope dropped",
+			llm:       map[string]interface{}{"provider": "gemini", "thinking": "high"},
+			wantSaved: false,
+		},
+		{
+			name:      "codex invalid falls back to xhigh",
+			llm:       map[string]interface{}{"provider": "codex", "thinking": "turbo"},
+			wantSaved: true,
+			wantValue: "xhigh",
+		},
+		{
+			name:      "codex absent gains xhigh",
+			llm:       map[string]interface{}{"provider": "codex"},
+			wantSaved: true,
+			wantValue: "xhigh",
+		},
+		{
+			name:      "codex valid kept",
+			llm:       map[string]interface{}{"provider": "codex-pool", "thinking": "low"},
+			wantSaved: true,
+			wantValue: "low",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := map[string]interface{}{"llm": tc.llm}
+			normalizeThinking(manifest)
+			got, saved := tc.llm["thinking"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("normalized thinking saved=%v, want %v; value=%#v", saved, tc.wantSaved, tc.llm["thinking"])
+			}
+			if saved && got != tc.wantValue {
+				t.Fatalf("normalized thinking = %q, want %q", got, tc.wantValue)
 			}
 		})
 	}


### PR DESCRIPTION
# feat(tui): show reasoning-effort row for anthropic and openai-compatible presets

Per Jason's direction (TUI cannot configure thinking effort; use canonical Responses API thinking effort + Claude thinking effort with two semantics; traditional OpenAI gets a translation), this PR widens the preset-editor Reasoning effort row so it appears for every provider the kernel will accept `manifest.llm.thinking` for.

## Changes

- **`isThinkingLevel(v)`** (new) — matches the kernel's canonical `THINKING_LEVELS` (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`). `default` is the UI pseudo-option meaning "omit the key".
- **`llmHasLevelThinking(llm)`** (new) — the non-Codex thinking scope: `provider == anthropic`, `provider == openai`, and any preset declaring `api_compat` of `openai` or `anthropic` (both map onto kernel adapters that honor a thinking level). `wire_api` no longer gates the row. Codex keeps its own ladder.
- **`hasThinking()`** now `hasCodexThinking() || hasLevelThinking()`; `fieldVisible`/`isCyclable` delegate to it, so both widen automatically.
- **`thinkingValue`/`thinkingOptions`/`setThinking`** key off `hasLevelThinking()`: level providers read/write `manifest.llm.thinking` from the level list; `default` and invalid values delete the key. Codex path untouched.
- **`normalizeThinking()`** — Codex branch unchanged (absent/invalid → explicit `xhigh`); the old custom+openai+responses branch is replaced by the level scope: valid level kept, invalid/wrong-type deleted, absent stays absent (no forced default for anthropic/openai-compatible). Everything outside both scopes still strips `thinking`.
- **`thinkingRadioStrip()`** separator keys off `hasLevelThinking()`.
- No i18n changes needed — the row label `preset_editor.field_thinking` is provider-neutral in all three locales.

## Tests

Rewrote the two tests that pinned the old narrow scope (non-codex preset now uses a genuinely out-of-scope `gemini` provider; compat-scope-exit vs wire-api-change-survives split), and added coverage for: row visibility/cyclability across 8 providers, level cycling + commit for anthropic/deepseek, set-persists (`high`/`none`/`xhigh` persist, `default`/invalid delete), and a `normalizeThinking` scope table. Untouched Codex thinking tests still encode the unchanged `xhigh` default.

## Verification

`go test ./internal/tui/ -count=1` — full package PASS; `go vet ./internal/tui/` PASS; `go build ./...` PASS; `gofmt` clean. The claude-p worker had its sandbox deny the Go toolchain, so I ran the full verification independently.

Companion kernel PR: `Lingtai-AI/lingtai-kernel#1352` (widens the kernel thinking gate to anthropic + all OpenAI-compatible wires and completes the Anthropic budget mapping). The two must land in the same release.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
