### PR TITLE
fix(ci): publish-last release gating (lingtai #842)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,20 @@ jobs:
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "GitHub release $TAG already exists; preserving it."
           else
-            gh release create "$TAG" --repo "$REPO" --verify-tag \
+            # Draft-first: the release must not become public/latest until
+            # windows-release has validated, built, packaged, and uploaded the
+            # Windows assets. source-release never publishes; windows-release
+            # flips the draft to a public release only after its upload passes.
+            gh release create "$TAG" --repo "$REPO" --verify-tag --draft \
               --title "$TAG" --notes "Release $TAG"
           fi
 
   update-homebrew:
+    # Wait for the same publication boundary: this job must only run after
+    # windows-release has validated, built, packaged, uploaded, and published
+    # the release, so the formula can never advertise a tag whose Windows
+    # assets (or whose public release itself) do not yet exist.
+    needs: windows-release
     runs-on: ubuntu-latest
     steps:
       - name: Compute source tarball checksum
@@ -40,7 +49,10 @@ jobs:
             exit 1
           fi
           url="https://github.com/Lingtai-AI/lingtai/archive/refs/tags/${TAG}.tar.gz"
-          sha=$(curl -sL "$url" | shasum -a 256 | cut -d' ' -f1)
+          # Fail closed: curl -f turns any HTTP error status into a non-zero
+          # exit, and pipefail (set above) propagates it through the pipeline,
+          # so a checksum of an error response can never reach the formula.
+          sha=$(curl -fsSL "$url" | shasum -a 256 | cut -d' ' -f1)
           echo "source=$sha" >> "$GITHUB_OUTPUT"
           echo "Source tarball SHA256: $sha"
 
@@ -333,3 +345,21 @@ jobs:
           set -euo pipefail
           gh release upload "$TAG" --repo "$REPO" --clobber \
             "$zip_name" "$zip_name.sha256" lingtai-bundle-manifest.json
+
+      - name: Publish GitHub release after Windows assets verified and uploaded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The source release was created as a draft; it only becomes
+          # public/latest here, after every kernel/validation/build/package/
+          # manifest/upload gate in this job has passed. Any earlier failure
+          # leaves the draft unpublished (never a partially public release).
+          names="$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')"
+          for asset in "$zip_name" "$zip_name.sha256" lingtai-bundle-manifest.json; do
+            if ! grep -qx "$asset" <<< "$names"; then
+              echo "::error::release $TAG is missing required Windows asset $asset" >&2
+              exit 1
+            fi
+          done
+          gh release edit "$TAG" --repo "$REPO" --draft=false

--- a/scripts/test-release-workflow-publish-gating.py
+++ b/scripts/test-release-workflow-publish-gating.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Static assertions for the tag release workflow.
 
-The tag workflow must create a GitHub source release, update the Homebrew
-source-build formula, and publish exactly one prebuilt asset: a Windows
-AMD64 TUI/portal archive plus its checksum sidecar and bundle manifest. Only
-the windows-release job may upload release assets; source-release must
-remain upload-free and Homebrew must remain source-tarball-based. The Windows
-archive must fail closed unless both binaries are built and packaged, and
-exact-tag smoke must verify both installed binaries.
+The tag workflow must create a GitHub source release as a DRAFT, update the
+Homebrew source-build formula only after the Windows publication boundary,
+and publish exactly one prebuilt asset: a Windows AMD64 TUI/portal archive
+plus its checksum sidecar and bundle manifest. Only the windows-release job
+may upload release assets or flip the draft to public; source-release must
+remain upload-free and draft-only, and Homebrew must remain
+source-tarball-based. The Windows archive must fail closed unless both
+binaries are built and packaged, the Homebrew checksum must fail closed on
+HTTP error status, and exact-tag smoke must verify both installed binaries
+through the maintained bounded version-probe helper.
 """
 from __future__ import annotations
 
@@ -55,12 +58,22 @@ def main() -> int:
         script = create.get("run", "")
         check("gh release create" in script, "source-release must create the GitHub release")
         check("--verify-tag" in script, "source-release must verify the pushed tag")
+        check("--draft" in script, "source-release must create the release as a draft (draft-first)")
+        check("--draft=false" not in script, "source-release must never publish the draft")
         check("gh release upload" not in script, "source-release must not upload binary assets")
 
     homebrew = jobs.get("update-homebrew", {})
+    check(homebrew.get("needs") == "windows-release",
+          "update-homebrew must depend on windows-release so it waits for the same publication boundary")
     checksum = find_step(homebrew, "compute source tarball checksum")
     formula = find_step(homebrew, "write formula")
     check(checksum is not None, "update-homebrew must checksum the GitHub source tarball")
+    if checksum:
+        script = checksum.get("run", "")
+        check("curl -fsSL" in script or "curl -fSL" in script or "curl --fail" in script,
+              "update-homebrew checksum must fail closed on HTTP error status (curl -f)")
+        check("curl -sL" not in script,
+              "update-homebrew checksum must not use bare curl -sL (an HTTP error body must not be hashed)")
     check(formula is not None, "update-homebrew must write the source-build formula")
     if formula:
         script = formula.get("run", "")
@@ -94,6 +107,21 @@ def main() -> int:
         check("gh release upload" in script, "windows-release must upload the Windows assets")
         check("$zip_name" in script and "$zip_name.sha256" in script and "lingtai-bundle-manifest.json" in script,
               "windows-release must upload the ZIP, its sha256 sidecar, and the bundle manifest")
+
+    publish_step = find_step(windows, "publish github release after windows assets")
+    check(publish_step is not None,
+          "windows-release must publish the draft after the Windows assets are verified and uploaded")
+    if publish_step:
+        script = publish_step.get("run", "")
+        check("gh release edit" in script and "--draft=false" in script,
+              "windows-release must publish the draft via gh release edit --draft=false")
+        check("gh release upload" not in script, "publish step must not upload assets")
+        check("grep -qx" in script and "missing required Windows asset" in script,
+              "publish step must verify the required Windows assets exist on the release before publishing")
+    if upload_step and publish_step:
+        steps = windows.get("steps", [])
+        check(steps.index(upload_step) < steps.index(publish_step),
+              "draft publish must come after the Windows asset upload step (publish-last)")
 
     portal_build = find_step(windows, "build lingtai-portal.exe")
     check(portal_build is not None, "windows-release must have a portal build step")
@@ -131,6 +159,10 @@ def main() -> int:
 
     check(text.count("gh release upload") == 1,
           "gh release upload must appear exactly once, in windows-release")
+    check(text.count("gh release edit") == 1,
+          "gh release edit must appear exactly once, in windows-release")
+    check(text.count("--draft=false") == 1,
+          "the draft must be published exactly once (--draft=false), in windows-release")
 
     smoke = yaml.safe_load(SMOKE_WORKFLOW_PATH.read_text())
     exact_smoke = smoke.get("jobs", {}).get("windows-release-asset-smoke", {})
@@ -139,12 +171,16 @@ def main() -> int:
           "exact-tag smoke must install with -SkipVenv")
     check("lingtai-portal.exe" in exact_steps and "Test-Path" in exact_steps,
           "exact-tag smoke must require the installed portal executable")
-    check("$portalPath" in exact_steps and "& $portalPath version" in exact_steps,
-          "exact-tag smoke must execute the portal version surface")
-    check('"lingtai-portal $env:LINGTAI_VERSION"' in exact_steps,
-          "exact-tag smoke must assert the portal version")
-    check("& $tuiPath version" in exact_steps and '"lingtai-tui $env:LINGTAI_VERSION"' in exact_steps,
-          "exact-tag smoke must preserve the TUI version assertion")
+    check("function Invoke-BoundedVersion" in exact_steps,
+          "exact-tag smoke must define the bounded version-probe helper Invoke-BoundedVersion")
+    check("WaitForExit" in exact_steps and "$p.ExitCode -ne 0" in exact_steps,
+          "Invoke-BoundedVersion must bound the probe timeout and fail closed on a non-zero exit")
+    check("$reported -ne $Expected" in exact_steps,
+          "Invoke-BoundedVersion must assert the probed version output against the expected string")
+    check('Invoke-BoundedVersion $tuiPath "lingtai-tui $env:LINGTAI_VERSION"' in exact_steps,
+          "exact-tag smoke must run the TUI version surface through Invoke-BoundedVersion and assert its output")
+    check('Invoke-BoundedVersion $portalPath "lingtai-portal $env:LINGTAI_VERSION"' in exact_steps,
+          "exact-tag smoke must run the portal version surface through Invoke-BoundedVersion and assert its output")
 
     if FAILURES:
         print("FAILED release workflow checks:", file=sys.stderr)


### PR DESCRIPTION
Closes #842

## Summary

Fixes the P1 publish-last defect in the release workflow. The release is now created as a **draft**, Windows assets are validated/uploaded first, and only then is the draft flipped public. Homebrew waits for the Windows publication boundary and its source checksum fails closed on HTTP errors.

## Changes

- `.github/workflows/release.yml`
  - `source-release`: `gh release create` now uses `--draft` — the release is never public until explicitly published; failed runs leave only an unpublished draft.
  - `update-homebrew`: added `needs: windows-release` (waits for the same publication boundary); checksum now uses `curl -fsSL` (fail-closed on HTTP error status).
  - `windows-release`: final step verifies the required Windows assets exist on the release, then `gh release edit --draft=false` publishes (publish-last).
- `scripts/test-release-workflow-publish-gating.py`: static assertions updated to enforce draft-first/publish-last ordering, Homebrew boundary dependency + `curl -f`, single `gh release upload`, single `--draft=false`, and the maintained Invoke-BoundedVersion smoke-helper shape.

## Validation

- `scripts/test-release-workflow-publish-gating.py` passes (baseline failed with the new literal-command assertions)
- Both workflows YAML-parse; `py_compile` clean

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
