### PR TITLE
fix(discovery): keep malformed agent manifests visible; stable agent_id (lingtai #846)

### DIFF
--- a/portal/internal/fs/agent.go
+++ b/portal/internal/fs/agent.go
@@ -11,6 +11,7 @@ import (
 
 // agentManifest is the raw JSON shape of .agent.json.
 type agentManifest struct {
+	AgentID   string           `json:"agent_id"` // kernel-published stable identity; empty on older manifests
 	AgentName string           `json:"agent_name"`
 	Nickname  string           `json:"nickname"`
 	Address   string           `json:"address"`
@@ -41,6 +42,7 @@ func ReadAgent(dir string) (AgentNode, error) {
 	caps := ParseCapabilities(m.Capabilities)
 
 	return AgentNode{
+		AgentID:      m.AgentID,
 		Address:      m.Address,
 		AgentName:    m.AgentName,
 		Nickname:     m.Nickname,
@@ -198,6 +200,14 @@ func ReadAgentRaw(dir string) (map[string]interface{}, error) {
 }
 
 // DiscoverAgents scans baseDir for subdirectories with .agent.json manifests.
+//
+// Manifest presence is tri-state, mirroring the kernel: a directory whose
+// manifest is absent is not an agent and is excluded, while a directory whose
+// manifest is present but unreadable, unparseable, or not an object is
+// malformed but still identifies an agent by file presence. Malformed
+// manifests therefore stay discoverable as repair targets, surfaced with an
+// explicit MALFORMED state and the read/parse error, instead of being
+// silently omitted (issue #846).
 func DiscoverAgents(baseDir string) ([]AgentNode, error) {
 	entries, err := os.ReadDir(baseDir)
 	if err != nil {
@@ -210,13 +220,33 @@ func DiscoverAgents(baseDir string) ([]AgentNode, error) {
 			continue
 		}
 		agentDir := filepath.Join(baseDir, entry.Name())
+		if _, err := os.Stat(filepath.Join(agentDir, ".agent.json")); err != nil {
+			if os.IsNotExist(err) {
+				continue // no manifest: not an agent
+			}
+			// Present but not stat-able: keep it discoverable for repair.
+			nodes = append(nodes, malformedAgentNode(agentDir, fmt.Errorf("stat manifest: %w", err)))
+			continue
+		}
 		node, err := ReadAgent(agentDir)
 		if err != nil {
-			continue // skip non-agent dirs
+			nodes = append(nodes, malformedAgentNode(agentDir, err))
+			continue
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, nil
+}
+
+// malformedAgentNode builds the node for a directory whose .agent.json is
+// present but cannot be read or parsed. The node keeps the agent visible in
+// the topology with an explicit error/repair state.
+func malformedAgentNode(dir string, err error) AgentNode {
+	return AgentNode{
+		State:      "MALFORMED",
+		Error:      err.Error(),
+		WorkingDir: dir,
+	}
 }
 
 // AgentStatus holds live runtime status from .status.json, the same snapshot

--- a/portal/internal/fs/discovery_test.go
+++ b/portal/internal/fs/discovery_test.go
@@ -1,0 +1,209 @@
+package fs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkAgentDir creates a subdirectory under base and returns its path.
+func mkAgentDir(t *testing.T, base, name string) string {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestDiscoverAgents_MissingManifestExcluded(t *testing.T) {
+	base := t.TempDir()
+	mkAgentDir(t, base, "not-an-agent") // no .agent.json
+	writeAgentManifest(t, filepath.Join(base, "real-agent"), "real-agent", false)
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1 (absent manifest must be excluded)", len(nodes))
+	}
+	if nodes[0].AgentName != "real-agent" {
+		t.Errorf("agent_name = %q, want real-agent", nodes[0].AgentName)
+	}
+}
+
+func TestDiscoverAgents_MalformedManifestStillDiscoverable(t *testing.T) {
+	base := t.TempDir()
+
+	// Valid manifest: parsed normally.
+	writeAgentManifest(t, mkAgentDir(t, base, "ok"), "ok", false)
+
+	// Malformed JSON (truncated object): present but unparseable.
+	badJSON := mkAgentDir(t, base, "bad-json")
+	if err := os.WriteFile(filepath.Join(badJSON, ".agent.json"), []byte(`{"agent_name": "bad",`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Syntactically valid JSON that is not an object: still malformed as a manifest.
+	nonObject := mkAgentDir(t, base, "non-object")
+	if err := os.WriteFile(filepath.Join(nonObject, ".agent.json"), []byte(`["not", "an", "object"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("nodes = %d, want 3 (malformed manifests must stay discoverable)", len(nodes))
+	}
+
+	byDir := map[string]AgentNode{}
+	for _, n := range nodes {
+		byDir[filepath.Base(n.WorkingDir)] = n
+	}
+	for _, name := range []string{"bad-json", "non-object"} {
+		n, ok := byDir[name]
+		if !ok {
+			t.Fatalf("malformed agent %q missing from discovery: %+v", name, nodes)
+		}
+		if n.State != "MALFORMED" {
+			t.Errorf("%s: state = %q, want MALFORMED", name, n.State)
+		}
+		if n.Error == "" {
+			t.Errorf("%s: error = %q, want explicit error", name, n.Error)
+		}
+	}
+}
+
+func TestDiscoverAgents_UnreadableManifestStillDiscoverable(t *testing.T) {
+	base := t.TempDir()
+	dir := mkAgentDir(t, base, "unreadable")
+	// A directory at the .agent.json path is present but cannot be read as a
+	// file — a portable stand-in for an unreadable manifest.
+	if err := os.MkdirAll(filepath.Join(dir, ".agent.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1 (unreadable manifest must stay discoverable)", len(nodes))
+	}
+	if nodes[0].State != "MALFORMED" || nodes[0].Error == "" {
+		t.Errorf("unreadable node = %+v, want MALFORMED state with explicit error", nodes[0])
+	}
+}
+
+func TestReadAgent_PreservesAgentID(t *testing.T) {
+	dir := t.TempDir()
+	withID := map[string]interface{}{
+		"agent_id":   "id-stable-42",
+		"agent_name": "alice",
+		"address":    "alice",
+	}
+	data, _ := json.Marshal(withID)
+	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	node, err := ReadAgent(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if node.AgentID != "id-stable-42" {
+		t.Errorf("agent_id = %q, want id-stable-42", node.AgentID)
+	}
+
+	// Older manifests that omit agent_id must keep parsing to an empty value.
+	legacy := map[string]interface{}{
+		"agent_name": "bob",
+		"address":    "bob",
+	}
+	data, _ = json.Marshal(legacy)
+	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	node, err = ReadAgent(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if node.AgentID != "" {
+		t.Errorf("legacy agent_id = %q, want empty (older manifests omit it)", node.AgentID)
+	}
+}
+
+// TestBuildNetwork_SerializesAgentIDThroughTopology pins the stable identifier
+// in the Portal topology response: BuildNetwork is what the API handler feeds
+// to json.NewEncoder, so marshaling the Network mirrors the wire format.
+func TestBuildNetwork_SerializesAgentIDThroughTopology(t *testing.T) {
+	base := t.TempDir()
+	aliceDir := filepath.Join(base, "alice")
+	writeAgentManifest(t, aliceDir, "alice", false)
+
+	// Stamp the kernel-published stable identifier into the manifest.
+	manifestPath := filepath.Join(aliceDir, ".agent.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["agent_id"] = "id-alice-1"
+	out, _ := json.Marshal(m)
+	if err := os.WriteFile(manifestPath, out, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	net, err := BuildNetwork(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(net)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		Nodes []map[string]interface{} `json:"nodes"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(decoded.Nodes))
+	}
+	if got := decoded.Nodes[0]["agent_id"]; got != "id-alice-1" {
+		t.Errorf("serialized agent_id = %#v, want id-alice-1", got)
+	}
+}
+
+// TestBuildNetwork_KeepsMalformedState ensures the explicit repair state of a
+// present-but-malformed manifest survives BuildNetwork's liveness
+// normalization (it must not be relabeled SUSPENDED).
+func TestBuildNetwork_KeepsMalformedState(t *testing.T) {
+	base := t.TempDir()
+	bad := mkAgentDir(t, base, "bad")
+	if err := os.WriteFile(filepath.Join(bad, ".agent.json"), []byte(`{not json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	net, err := BuildNetwork(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(net.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(net.Nodes))
+	}
+	if net.Nodes[0].State != "MALFORMED" {
+		t.Errorf("state = %q, want MALFORMED (must not be relabeled SUSPENDED)", net.Nodes[0].State)
+	}
+	if net.Nodes[0].Error == "" {
+		t.Error("error = empty, want explicit error for malformed manifest")
+	}
+}

--- a/portal/internal/fs/network.go
+++ b/portal/internal/fs/network.go
@@ -27,8 +27,11 @@ func BuildNetworkWithOptions(baseDir string, opts NetworkOptions) (Network, erro
 			nodes[i].Alive = true
 		} else {
 			nodes[i].Alive = IsAlive(nodes[i].WorkingDir, AgentAliveThresholdSec)
-			// Heartbeat is ground truth — no heartbeat means SUSPENDED
-			if !nodes[i].Alive && nodes[i].State != "" {
+			// Heartbeat is ground truth — no heartbeat means SUSPENDED.
+			// Malformed manifests keep their explicit repair state instead of
+			// being relabeled as suspended (issue #846).
+			if !nodes[i].Alive && nodes[i].State != "" && nodes[i].State != "MALFORMED" {
+
 				nodes[i].State = "SUSPENDED"
 			}
 		}

--- a/portal/internal/fs/types.go
+++ b/portal/internal/fs/types.go
@@ -13,15 +13,21 @@ type Location struct {
 
 // AgentNode represents a discovered agent in the network.
 type AgentNode struct {
-	Address      string   `json:"address"`
-	AgentName    string   `json:"agent_name"`
-	Nickname     string   `json:"nickname"`
-	State        string   `json:"state"`
-	Alive        bool     `json:"alive"`
-	IsHuman      bool     `json:"is_human"`
-	Capabilities []string `json:"capabilities"`
+	AgentID      string    `json:"agent_id"` // kernel-published stable identity; empty on older manifests that omit it
+	Address      string    `json:"address"`
+	AgentName    string    `json:"agent_name"`
+	Nickname     string    `json:"nickname"`
+	State        string    `json:"state"`
+	Alive        bool      `json:"alive"`
+	IsHuman      bool      `json:"is_human"`
+	Capabilities []string  `json:"capabilities"`
 	Location     *Location `json:"location,omitempty"`
-	WorkingDir   string   `json:"-"` // not serialized to API
+	// Error is set when .agent.json is present but unreadable or malformed:
+	// the directory still identifies an agent and stays discoverable as a
+	// repair target (issue #846). Absent manifests are not agents and are
+	// excluded without an error.
+	Error      string `json:"error,omitempty"`
+	WorkingDir string `json:"-"` // not serialized to API
 }
 
 // AvatarEdge is a parent → child spawning relationship.
@@ -70,14 +76,14 @@ type Network struct {
 
 // MailMessage is the schema for messages written to mailbox/inbox/{uuid}/message.json.
 type MailMessage struct {
-	ID         string                 `json:"id"`
-	MailboxID  string                 `json:"_mailbox_id"`
-	From       string                 `json:"from"`
-	To         interface{}            `json:"to"` // string or []string
-	CC         []string               `json:"cc"`
-	BCC        []string               `json:"bcc"`
-	Subject    string                 `json:"subject"`
-	Message    string                 `json:"message"`
+	ID          string                 `json:"id"`
+	MailboxID   string                 `json:"_mailbox_id"`
+	From        string                 `json:"from"`
+	To          interface{}            `json:"to"` // string or []string
+	CC          []string               `json:"cc"`
+	BCC         []string               `json:"bcc"`
+	Subject     string                 `json:"subject"`
+	Message     string                 `json:"message"`
 	Type        string                 `json:"type"`
 	ReceivedAt  string                 `json:"received_at"`
 	SentAt      string                 `json:"sent_at,omitempty"`

--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -56,7 +56,10 @@ func normalizeAgentLiveness(nodes []AgentNode) {
 			continue
 		}
 		nodes[i].Alive = IsAlive(nodes[i].WorkingDir, AgentAliveThresholdSec)
-		if !nodes[i].Alive && nodes[i].State != "" {
+		// Heartbeat is ground truth — no heartbeat means SUSPENDED. Malformed
+		// manifests keep their explicit repair state instead of being
+		// relabeled as suspended (issue #846).
+		if !nodes[i].Alive && nodes[i].State != "" && nodes[i].State != "MALFORMED" {
 			nodes[i].State = "SUSPENDED"
 		}
 	}

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -268,6 +268,14 @@ func IsOrchestratorManifest(manifest map[string]interface{}) bool {
 }
 
 // DiscoverAgents scans baseDir for subdirectories with .agent.json manifests.
+//
+// Manifest presence is tri-state, mirroring the kernel: a directory whose
+// manifest is absent is not an agent and is excluded, while a directory whose
+// manifest is present but unreadable, unparseable, or not an object is
+// malformed but still identifies an agent by file presence. Malformed
+// manifests therefore stay discoverable as repair targets, surfaced with an
+// explicit MALFORMED state and the read/parse error, instead of being
+// silently omitted (issue #846).
 func DiscoverAgents(baseDir string) ([]AgentNode, error) {
 	entries, err := os.ReadDir(baseDir)
 	if err != nil {
@@ -280,13 +288,33 @@ func DiscoverAgents(baseDir string) ([]AgentNode, error) {
 			continue
 		}
 		agentDir := filepath.Join(baseDir, entry.Name())
+		if _, err := os.Stat(filepath.Join(agentDir, ".agent.json")); err != nil {
+			if os.IsNotExist(err) {
+				continue // no manifest: not an agent
+			}
+			// Present but not stat-able: keep it discoverable for repair.
+			nodes = append(nodes, malformedAgentNode(agentDir, fmt.Errorf("stat manifest: %w", err)))
+			continue
+		}
 		node, err := ReadAgent(agentDir)
 		if err != nil {
-			continue // skip non-agent dirs
+			nodes = append(nodes, malformedAgentNode(agentDir, err))
+			continue
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, nil
+}
+
+// malformedAgentNode builds the node for a directory whose .agent.json is
+// present but cannot be read or parsed. The node keeps the agent visible in
+// the topology with an explicit error/repair state.
+func malformedAgentNode(dir string, err error) AgentNode {
+	return AgentNode{
+		State:      "MALFORMED",
+		Error:      err.Error(),
+		WorkingDir: dir,
+	}
 }
 
 // AgentStatus holds live runtime status from .status.json (same as system("show")).

--- a/tui/internal/fs/discovery_test.go
+++ b/tui/internal/fs/discovery_test.go
@@ -1,0 +1,184 @@
+// internal/fs/discovery_test.go
+package fs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeDiscoveryManifest writes a minimal .agent.json into agentDir.
+func writeDiscoveryManifest(t *testing.T, agentDir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := map[string]interface{}{
+		"agent_name": name,
+		"address":    name,
+		"state":      "ACTIVE",
+		"admin":      agentDir, // non-nil admin -> is_human=false
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, ".agent.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverAgents_MissingManifestExcluded(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "not-an-agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDiscoveryManifest(t, filepath.Join(base, "real-agent"), "real-agent")
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1 (absent manifest must be excluded)", len(nodes))
+	}
+	if nodes[0].AgentName != "real-agent" {
+		t.Errorf("agent_name = %q, want real-agent", nodes[0].AgentName)
+	}
+}
+
+func TestDiscoverAgents_MalformedManifestStillDiscoverable(t *testing.T) {
+	base := t.TempDir()
+	writeDiscoveryManifest(t, filepath.Join(base, "ok"), "ok")
+
+	// Malformed JSON (truncated object): present but unparseable.
+	badJSON := filepath.Join(base, "bad-json")
+	if err := os.MkdirAll(badJSON, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badJSON, ".agent.json"), []byte(`{"agent_name": "bad",`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Syntactically valid JSON that is not an object: still malformed as a manifest.
+	nonObject := filepath.Join(base, "non-object")
+	if err := os.MkdirAll(nonObject, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nonObject, ".agent.json"), []byte(`"just a string"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("nodes = %d, want 3 (malformed manifests must stay discoverable)", len(nodes))
+	}
+
+	byDir := map[string]AgentNode{}
+	for _, n := range nodes {
+		byDir[filepath.Base(n.WorkingDir)] = n
+	}
+	for _, name := range []string{"bad-json", "non-object"} {
+		n, ok := byDir[name]
+		if !ok {
+			t.Fatalf("malformed agent %q missing from discovery: %+v", name, nodes)
+		}
+		if n.State != "MALFORMED" {
+			t.Errorf("%s: state = %q, want MALFORMED", name, n.State)
+		}
+		if n.Error == "" {
+			t.Errorf("%s: error = %q, want explicit error", name, n.Error)
+		}
+	}
+}
+
+func TestDiscoverAgents_UnreadableManifestStillDiscoverable(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "unreadable")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A directory at the .agent.json path is present but cannot be read as a
+	// file — a portable stand-in for an unreadable manifest.
+	if err := os.MkdirAll(filepath.Join(dir, ".agent.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1 (unreadable manifest must stay discoverable)", len(nodes))
+	}
+	if nodes[0].State != "MALFORMED" || nodes[0].Error == "" {
+		t.Errorf("unreadable node = %+v, want MALFORMED state with explicit error", nodes[0])
+	}
+}
+
+// TestDiscoverAgents_MalformedNodeSerializesError pins the wire format of the
+// repair target: the error is visible in the serialized node, not hidden.
+func TestDiscoverAgents_MalformedNodeSerializesError(t *testing.T) {
+	base := t.TempDir()
+	bad := filepath.Join(base, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, ".agent.json"), []byte(`{oops`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := DiscoverAgents(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(nodes))
+	}
+	payload, err := json.Marshal(nodes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if got := decoded["error"]; got == nil || got == "" {
+		t.Errorf("serialized error = %#v, want explicit error string", got)
+	}
+	if got := decoded["state"]; got != "MALFORMED" {
+		t.Errorf("serialized state = %#v, want MALFORMED", got)
+	}
+}
+
+// TestBuildNetwork_KeepsMalformedState ensures the explicit repair state of a
+// present-but-malformed manifest survives BuildNetwork's liveness
+// normalization (it must not be relabeled SUSPENDED).
+func TestBuildNetwork_KeepsMalformedState(t *testing.T) {
+	base := t.TempDir()
+	bad := filepath.Join(base, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, ".agent.json"), []byte(`{not json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	net, err := BuildNetwork(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(net.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(net.Nodes))
+	}
+	if net.Nodes[0].State != "MALFORMED" {
+		t.Errorf("state = %q, want MALFORMED (must not be relabeled SUSPENDED)", net.Nodes[0].State)
+	}
+	if net.Nodes[0].Error == "" {
+		t.Error("error = empty, want explicit error for malformed manifest")
+	}
+}

--- a/tui/internal/fs/types.go
+++ b/tui/internal/fs/types.go
@@ -22,7 +22,12 @@ type AgentNode struct {
 	IsHuman      bool      `json:"is_human"`
 	Capabilities []string  `json:"capabilities"`
 	Location     *Location `json:"location,omitempty"`
-	WorkingDir   string    `json:"-"` // not serialized to API
+	// Error is set when .agent.json is present but unreadable or malformed:
+	// the directory still identifies an agent and stays discoverable as a
+	// repair target (issue #846). Absent manifests are not agents and are
+	// excluded without an error.
+	Error      string `json:"error,omitempty"`
+	WorkingDir string `json:"-"` // not serialized to API
 }
 
 // AvatarEdge is a parent → child spawning relationship.


### PR DESCRIPTION
Closes #846

## Summary

Go discovery silently dropped directories whose `.agent.json` was present but malformed/unreadable — those agents vanished from topology even though they exist and need repair. This PR makes discovery tri-state (mirroring the kernel) and surfaces the stable `agent_id`:

- **Tri-state discovery** (`portal/internal/fs/agent.go`, `tui/internal/fs/agent.go`): absent manifest → excluded (not an agent); present-but-malformed/unreadable/non-object → kept discoverable with explicit `MALFORMED` state + the read/parse error; valid → normal node.
- **State preservation**: `BuildNetworkWithOptions` no longer relabels `MALFORMED` nodes as `SUSPENDED` when the heartbeat is stale — they keep their repair state.
- **Stable identity**: `AgentNode` gains `agent_id` from the kernel-published `.agent.json` field (empty on older manifests), so topology identity is stable across renames.
- **Tests**: `discovery_test.go` added in both `portal/internal/fs` and `tui/internal/fs` covering absent/malformed/unreadable/non-object/valid cases and `agent_id` propagation.

## Validation

- `go test -count=1 ./internal/fs/...` passes in both `tui/` and `portal/` modules
- `go vet ./internal/fs/...` clean
- `git diff --check` clean

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
