### PR TITLE
fix(heartbeat): align TUI/portal liveness to kernel 5s contract (lingtai #845)

### DIFF
--- a/portal/internal/fs/heartbeat.go
+++ b/portal/internal/fs/heartbeat.go
@@ -8,6 +8,14 @@ import (
 	"time"
 )
 
+// AgentAliveThresholdSec is the heartbeat-liveness window shared with the
+// kernel. The kernel fixes the heartbeat tick at one second and liveness at
+// five ticks (src/lingtai/kernel/config.py:132-133), and applies a strict
+// age < threshold comparison (src/lingtai/kernel/agent_presence/__init__.py).
+// Go consumers must use the same window and the same strict boundary so a
+// live agent is never reported dead or suspended (issue #845).
+const AgentAliveThresholdSec = 5.0
+
 func IsAlive(dir string, thresholdSec float64) bool {
 	data, err := os.ReadFile(filepath.Join(dir, ".agent.heartbeat"))
 	if err != nil {

--- a/portal/internal/fs/heartbeat_test.go
+++ b/portal/internal/fs/heartbeat_test.go
@@ -1,0 +1,100 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestAgentAliveThresholdSec_MatchesKernelContract pins the Portal's liveness
+// window to the kernel contract: one-second heartbeat tick and five-second
+// liveness (src/lingtai/kernel/config.py:132-133), applied with a strict
+// age < threshold comparison (src/lingtai/kernel/agent_presence/__init__.py).
+// Drift back to 2s (issue #845) fails here so the disagreement stays visible.
+func TestAgentAliveThresholdSec_MatchesKernelContract(t *testing.T) {
+	if AgentAliveThresholdSec != 5.0 {
+		t.Fatalf("AgentAliveThresholdSec = %v, want 5.0 (kernel heartbeat liveness, issue #845)", AgentAliveThresholdSec)
+	}
+}
+
+func TestIsAlive_ThreeSecondOldHeartbeat_Alive(t *testing.T) {
+	// Regression for issue #845: a heartbeat ~3s old is alive to the kernel
+	// (3 < 5) and must be alive to the Portal too, never reported dead.
+	dir := t.TempDir()
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-3*time.Second).Unix()))
+	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
+	if !IsAlive(dir, AgentAliveThresholdSec) {
+		t.Error("expected alive for 3s-old heartbeat under the kernel 5s contract")
+	}
+}
+
+func TestIsAlive_FiveSecondOldHeartbeat_Stale(t *testing.T) {
+	// Strict boundary: an age at or beyond the 5s threshold is stale
+	// (kernel compares age < threshold, not age <= threshold).
+	dir := t.TempDir()
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-5*time.Second).Unix()))
+	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
+	if IsAlive(dir, AgentAliveThresholdSec) {
+		t.Error("expected stale for 5s-old heartbeat (strict age < threshold boundary)")
+	}
+}
+
+// TestBuildNetwork_HeartbeatAgeDrivesAliveState is the Portal topology-level
+// regression for issue #845: a 3s-old heartbeat (alive to the kernel) must not
+// be marked dead or SUSPENDED, while an 8s-old heartbeat (stale even to the
+// kernel) is not alive and is mapped to SUSPENDED.
+func TestBuildNetwork_HeartbeatAgeDrivesAliveState(t *testing.T) {
+	base := t.TempDir()
+
+	bobDir := filepath.Join(base, "bob")
+	writeAgentManifest(t, bobDir, "bob", false) // manifest state "ACTIVE"
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-3*time.Second).Unix()))
+	os.WriteFile(filepath.Join(bobDir, ".agent.heartbeat"), []byte(ts), 0o644)
+
+	net, err := BuildNetwork(base)
+	if err != nil {
+		t.Fatalf("build network: %v", err)
+	}
+	var bob *AgentNode
+	for i := range net.Nodes {
+		if net.Nodes[i].Address == "bob" {
+			bob = &net.Nodes[i]
+		}
+	}
+	if bob == nil {
+		t.Fatal("bob node not found")
+	}
+	if !bob.Alive {
+		t.Errorf("bob with 3s-old heartbeat should be alive under the kernel 5s contract, got Alive=false")
+	}
+	if bob.State == "SUSPENDED" {
+		t.Errorf("bob with 3s-old heartbeat must not be SUSPENDED, got State=%q", bob.State)
+	}
+
+	// An 8s-old heartbeat is stale to the kernel too: not alive and, having a
+	// state, mapped to SUSPENDED by the topology build.
+	staleTs := fmt.Sprintf("%f", float64(time.Now().Add(-8*time.Second).Unix()))
+	os.WriteFile(filepath.Join(bobDir, ".agent.heartbeat"), []byte(staleTs), 0o644)
+
+	net, err = BuildNetwork(base)
+	if err != nil {
+		t.Fatalf("rebuild network: %v", err)
+	}
+	bob = nil
+	for i := range net.Nodes {
+		if net.Nodes[i].Address == "bob" {
+			bob = &net.Nodes[i]
+		}
+	}
+	if bob == nil {
+		t.Fatal("bob node not found after stale heartbeat")
+	}
+	if bob.Alive {
+		t.Error("bob with 8s-old heartbeat should not be alive")
+	}
+	if bob.State != "SUSPENDED" {
+		t.Errorf("bob with 8s-old heartbeat and a state should be SUSPENDED, got State=%q", bob.State)
+	}
+}

--- a/portal/internal/fs/network.go
+++ b/portal/internal/fs/network.go
@@ -26,7 +26,7 @@ func BuildNetworkWithOptions(baseDir string, opts NetworkOptions) (Network, erro
 		if nodes[i].IsHuman {
 			nodes[i].Alive = true
 		} else {
-			nodes[i].Alive = IsAlive(nodes[i].WorkingDir, 2.0)
+			nodes[i].Alive = IsAlive(nodes[i].WorkingDir, AgentAliveThresholdSec)
 			// Heartbeat is ground truth — no heartbeat means SUSPENDED
 			if !nodes[i].Alive && nodes[i].State != "" {
 				nodes[i].State = "SUSPENDED"

--- a/portal/internal/fs/signal.go
+++ b/portal/internal/fs/signal.go
@@ -32,14 +32,14 @@ func CleanSignals(dir string) {
 // SuspendAndWait sends a suspend signal and waits for the agent to die.
 // Returns after the agent stops heartbeating or after timeout.
 func SuspendAndWait(dir string, timeout time.Duration) {
-	if !IsAlive(dir, 2.0) {
+	if !IsAlive(dir, AgentAliveThresholdSec) {
 		return
 	}
 	TouchSignal(dir, SignalSuspend)
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)
-		if !IsAlive(dir, 2.0) {
+		if !IsAlive(dir, AgentAliveThresholdSec) {
 			return
 		}
 	}

--- a/tui/internal/fs/heartbeat.go
+++ b/tui/internal/fs/heartbeat.go
@@ -8,7 +8,13 @@ import (
 	"time"
 )
 
-const AgentAliveThresholdSec = 2.0
+// AgentAliveThresholdSec is the heartbeat-liveness window shared with the
+// kernel. The kernel fixes the heartbeat tick at one second and liveness at
+// five ticks (src/lingtai/kernel/config.py:132-133), and applies a strict
+// age < threshold comparison (src/lingtai/kernel/agent_presence/__init__.py).
+// Go consumers must use the same window and the same strict boundary so a
+// live agent is never reported dead or suspended (issue #845).
+const AgentAliveThresholdSec = 5.0
 
 type HeartbeatStatus struct {
 	Exists     bool    `json:"exists"`

--- a/tui/internal/fs/heartbeat_test.go
+++ b/tui/internal/fs/heartbeat_test.go
@@ -8,27 +8,60 @@ import (
 	"time"
 )
 
+// TestAgentAliveThresholdSec_MatchesKernelContract pins the Go consumer's
+// liveness window to the kernel contract: one-second heartbeat tick and
+// five-second liveness (src/lingtai/kernel/config.py:132-133), applied with a
+// strict age < threshold comparison (src/lingtai/kernel/agent_presence/__init__.py).
+// Drift back to 2s (issue #845) fails here so the disagreement stays visible.
+func TestAgentAliveThresholdSec_MatchesKernelContract(t *testing.T) {
+	if AgentAliveThresholdSec != 5.0 {
+		t.Fatalf("AgentAliveThresholdSec = %v, want 5.0 (kernel heartbeat liveness, issue #845)", AgentAliveThresholdSec)
+	}
+}
+
 func TestIsAlive_FreshHeartbeat(t *testing.T) {
 	dir := t.TempDir()
 	ts := fmt.Sprintf("%f", float64(time.Now().Unix()))
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
-	if !IsAlive(dir, 2.0) {
+	if !IsAlive(dir, AgentAliveThresholdSec) {
 		t.Error("expected alive for fresh heartbeat")
 	}
 }
 
-func TestIsAlive_StaleHeartbeat(t *testing.T) {
+func TestIsAlive_ThreeSecondOldHeartbeat_Alive(t *testing.T) {
+	// Regression for issue #845: a heartbeat ~3s old is alive to the kernel
+	// (3 < 5) and must be alive to the TUI too, never dead or suspended.
+	dir := t.TempDir()
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-3*time.Second).Unix()))
+	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
+	if !IsAlive(dir, AgentAliveThresholdSec) {
+		t.Error("expected alive for 3s-old heartbeat under the kernel 5s contract")
+	}
+}
+
+func TestIsAlive_FiveSecondOldHeartbeat_Stale(t *testing.T) {
+	// Strict boundary: an age at or beyond the 5s threshold is stale
+	// (kernel compares age < threshold, not age <= threshold).
 	dir := t.TempDir()
 	ts := fmt.Sprintf("%f", float64(time.Now().Add(-5*time.Second).Unix()))
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
-	if IsAlive(dir, 2.0) {
-		t.Error("expected dead for stale heartbeat")
+	if IsAlive(dir, AgentAliveThresholdSec) {
+		t.Error("expected stale for 5s-old heartbeat (strict age < threshold boundary)")
+	}
+}
+
+func TestIsAlive_SixSecondOldHeartbeat_Stale(t *testing.T) {
+	dir := t.TempDir()
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-6*time.Second).Unix()))
+	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
+	if IsAlive(dir, AgentAliveThresholdSec) {
+		t.Error("expected dead for 6s-old heartbeat")
 	}
 }
 
 func TestIsAlive_MissingFile(t *testing.T) {
 	dir := t.TempDir()
-	if IsAlive(dir, 2.0) {
+	if IsAlive(dir, AgentAliveThresholdSec) {
 		t.Error("expected dead when heartbeat file missing")
 	}
 }

--- a/tui/internal/fs/signal.go
+++ b/tui/internal/fs/signal.go
@@ -41,14 +41,14 @@ func CleanSignals(dir string) {
 // SuspendAndWait sends a suspend signal and waits for the agent to die.
 // Returns after the agent stops heartbeating or after timeout.
 func SuspendAndWait(dir string, timeout time.Duration) {
-	if !IsAlive(dir, 2.0) {
+	if !IsAlive(dir, AgentAliveThresholdSec) {
 		return
 	}
 	TouchSignal(dir, SignalSuspend)
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		time.Sleep(200 * time.Millisecond)
-		if !IsAlive(dir, 2.0) {
+		if !IsAlive(dir, AgentAliveThresholdSec) {
 			return
 		}
 	}

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -886,7 +886,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 				if agent.IsHuman {
 					continue
 				}
-				if fs.IsAlive(agent.WorkingDir, 3.0) {
+				if fs.IsAlive(agent.WorkingDir, fs.AgentAliveThresholdSec) {
 					os.WriteFile(filepath.Join(agent.WorkingDir, ".sleep"), []byte(""), 0o644)
 					count++
 				}
@@ -905,7 +905,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 				if agent.IsHuman {
 					continue
 				}
-				if fs.IsAlive(agent.WorkingDir, 3.0) {
+				if fs.IsAlive(agent.WorkingDir, fs.AgentAliveThresholdSec) {
 					os.WriteFile(filepath.Join(agent.WorkingDir, ".suspend"), []byte(""), 0o644)
 					count++
 				}
@@ -925,7 +925,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 				if agent.IsHuman {
 					continue
 				}
-				if !fs.IsAlive(agent.WorkingDir, 3.0) && a.lingtaiCmd != "" {
+				if !fs.IsAlive(agent.WorkingDir, fs.AgentAliveThresholdSec) && a.lingtaiCmd != "" {
 					count++
 					if err := reviveDir(a.lingtaiCmd, agent.WorkingDir); err != nil {
 						failures = append(failures, fmt.Sprintf("%s (%s)", filepath.Base(agent.WorkingDir), firstLine(err)))
@@ -938,7 +938,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 				addMsg(i18n.TF("mail.cpr_all", count))
 			}
 		} else if targetDir != "" && a.lingtaiCmd != "" {
-			if !fs.IsAlive(targetDir, 3.0) {
+			if !fs.IsAlive(targetDir, fs.AgentAliveThresholdSec) {
 				if err := reviveDir(a.lingtaiCmd, targetDir); err != nil {
 					addMsg(i18n.TF("mail.launch_failed", firstLine(err)))
 				} else {
@@ -1097,7 +1097,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 			addMsg(i18n.T("mail.goal_no_agent"))
 			return a, nil
 		}
-		if !fs.IsAlive(targetDir, 3.0) {
+		if !fs.IsAlive(targetDir, fs.AgentAliveThresholdSec) {
 			addMsg(i18n.T("mail.btw_suspended"))
 			return a, nil
 		}
@@ -1166,7 +1166,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 			addMsg(i18n.T("export.no_agent"))
 			return a, nil
 		}
-		if !fs.IsAlive(targetDir, 3.0) {
+		if !fs.IsAlive(targetDir, fs.AgentAliveThresholdSec) {
 			addMsg(i18n.T("mail.btw_suspended"))
 			return a, nil
 		}
@@ -1177,7 +1177,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 		if targetDir == "" {
 			return a, nil
 		}
-		if !fs.IsAlive(targetDir, 3.0) {
+		if !fs.IsAlive(targetDir, fs.AgentAliveThresholdSec) {
 			addMsg(i18n.T("mail.btw_suspended"))
 			return a, nil
 		}
@@ -1193,7 +1193,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 		return a, nil
 	case "insights":
 		if targetDir != "" {
-			if !fs.IsAlive(targetDir, 3.0) {
+			if !fs.IsAlive(targetDir, fs.AgentAliveThresholdSec) {
 				addMsg(i18n.T("mail.btw_suspended"))
 				return a, nil
 			}
@@ -1204,7 +1204,7 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 		return a, nil
 	case "btw":
 		if targetDir != "" && args != "" {
-			if !fs.IsAlive(targetDir, 3.0) {
+			if !fs.IsAlive(targetDir, fs.AgentAliveThresholdSec) {
 				addMsg(i18n.T("mail.btw_suspended"))
 				return a, nil
 			}
@@ -1769,7 +1769,7 @@ func waitForLaunchHeartbeat(cmd *exec.Cmd, dir string, timeout time.Duration) er
 	started := time.Now()
 	deadline := started.Add(timeout)
 	for {
-		if launchHeartbeatIsAlive(dir, 3.0) {
+		if launchHeartbeatIsAlive(dir, fs.AgentAliveThresholdSec) {
 			return nil
 		}
 		if cmd != nil && !launchHeartbeatIsRunning(dir) {

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -650,7 +650,7 @@ func (m MailModel) issueRefreshRequest() (MailModel, tea.Cmd) {
 }
 
 func resolveAgentLifecycle(directory string) (bool, string, fs.AgentNode) {
-	alive := directory != "" && fs.IsAlive(directory, 3.0)
+	alive := directory != "" && fs.IsAlive(directory, fs.AgentAliveThresholdSec)
 	var node fs.AgentNode
 	if directory != "" {
 		node, _ = fs.ReadAgent(directory)

--- a/tui/internal/tui/nirvana.go
+++ b/tui/internal/tui/nirvana.go
@@ -129,7 +129,7 @@ func (m NirvanaModel) doClean() tea.Cmd {
 			if agent.IsHuman {
 				continue
 			}
-			if fs.IsAlive(agent.WorkingDir, 3.0) {
+			if fs.IsAlive(agent.WorkingDir, fs.AgentAliveThresholdSec) {
 				fs.SuspendAndWait(agent.WorkingDir, 5*time.Second)
 			}
 		}

--- a/tui/main.go
+++ b/tui/main.go
@@ -916,7 +916,7 @@ func cleanProject(lingtaiDir string, force bool, waitTimeout time.Duration) erro
 		if err := os.WriteFile(suspendFile, []byte(""), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to signal %s: %v\n", agent.WorkingDir, err)
 		}
-		if fs.IsAlive(agent.WorkingDir, 3.0) {
+		if fs.IsAlive(agent.WorkingDir, fs.AgentAliveThresholdSec) {
 			alive = append(alive, agent.WorkingDir)
 		}
 	}
@@ -927,7 +927,7 @@ func cleanProject(lingtaiDir string, force bool, waitTimeout time.Duration) erro
 		for time.Now().Before(deadline) {
 			allDead := true
 			for _, dir := range alive {
-				if fs.IsAlive(dir, 3.0) {
+				if fs.IsAlive(dir, fs.AgentAliveThresholdSec) {
 					allDead = false
 					break
 				}
@@ -958,7 +958,7 @@ func cleanProject(lingtaiDir string, force bool, waitTimeout time.Duration) erro
 	}
 	var survivors []string
 	for _, dir := range guarded {
-		if fs.IsAlive(dir, 3.0) {
+		if fs.IsAlive(dir, fs.AgentAliveThresholdSec) {
 			survivors = append(survivors, dir)
 		}
 	}

--- a/tui/suspend_unix.go
+++ b/tui/suspend_unix.go
@@ -64,7 +64,7 @@ func suspendMain() {
 
 		// Wait for the agent to actually stop before reporting success
 		fs.SuspendAndWait(agentDir, 5*time.Second)
-		if fs.IsAlive(agentDir, 2.0) {
+		if fs.IsAlive(agentDir, fs.AgentAliveThresholdSec) {
 			fmt.Printf("Warning: %s did not stop (still alive after 5s)\n", entry.Name())
 			failed++
 		} else {

--- a/tui/suspend_windows.go
+++ b/tui/suspend_windows.go
@@ -63,7 +63,7 @@ func suspendMain() {
 
 		// Wait for the agent to actually stop before reporting success
 		fs.SuspendAndWait(agentDir, 5*time.Second)
-		if fs.IsAlive(agentDir, 2.0) {
+		if fs.IsAlive(agentDir, fs.AgentAliveThresholdSec) {
 			fmt.Printf("Warning: %s did not stop (still alive after 5s)\n", entry.Name())
 			failed++
 		} else {


### PR DESCRIPTION
Closes #845

## Summary

Go consumers (TUI + portal) used a 2-second heartbeat-liveness window while the kernel fixes heartbeat tick at 1s and liveness at 5 ticks (`src/lingtai/kernel/config.py:132-133`, strict `age < threshold` in `agent_presence/__init__.py`). A live agent could therefore be reported dead/suspended by the TUI/portal. This PR aligns the Go window to the kernel 5s contract.

## Changes

- `AgentAliveThresholdSec` 2.0 → **5.0** in both `tui/internal/fs/heartbeat.go` and `portal/internal/fs/heartbeat.go`, with a comment citing the kernel contract.
- All lifecycle-wait call sites aligned: `signal.go` (SuspendAndWait), `suspend_unix.go`, `suspend_windows.go`, `main.go`, `internal/tui/{app,mail,nirvana}.go`.
- `portal/internal/fs/network.go` now uses the shared constant.
- Tests: new `TestAgentAliveThresholdSec_MatchesKernelContract` (pins 5.0, fails on regression); `TestIsAlive_ThreeSecondOldHeartbeat_Alive` (regression for #845); `TestIsAlive_FiveSecondOldHeartbeat_Stale` (strict boundary); added `portal/internal/fs/heartbeat_test.go`.

## Validation

- `go test -count=1 ./internal/fs/...` passes in both `tui/` and `portal/` modules
- `go vet` clean; `git diff --check` clean

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
