### PR TITLE
fix(preset): contain agent/preset names before spawn writes (lingtai #849)

### DIFF
--- a/tui/internal/headless/spawn.go
+++ b/tui/internal/headless/spawn.go
@@ -71,6 +71,16 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 	}
 	opts.Dir = absDir
 
+	// The agent name doubles as a directory segment under .lingtai/, so it
+	// must be a single contained path segment: reject absolute paths,
+	// parent segments, and either platform's separators before any project
+	// write (issue #849).
+	agentName := opts.resolveAgentName()
+	if err := preset.ValidateSafeName(agentName); err != nil {
+		WriteError(stderr, fmt.Sprintf("invalid agent name %q: %s", agentName, err.Error()), "invalid_args")
+		return 1
+	}
+
 	// Validate: target must not already have .lingtai/
 	lingtaiDir := filepath.Join(opts.Dir, ".lingtai")
 	if _, err := os.Stat(lingtaiDir); err == nil {
@@ -123,7 +133,8 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 		return 1
 	}
 
-	agentName := opts.resolveAgentName()
+	// agentName was resolved and validated at the top of RunSpawn (before
+	// any project write).
 	lang := opts.Language
 	if lang == "" {
 		lang = "en"

--- a/tui/internal/headless/spawn_test.go
+++ b/tui/internal/headless/spawn_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -283,5 +284,89 @@ func TestRunSpawn_LanguageDefault(t *testing.T) {
 	manifest := initJSON["manifest"].(map[string]interface{})
 	if manifest["language"] != "zh" {
 		t.Errorf("language = %q, want %q", manifest["language"], "zh")
+	}
+}
+
+// TestRunSpawn_RejectsUnsafeAgentName proves issue #849 at the headless
+// boundary: path-form agent names (relative-parent, absolute, slash, and
+// backslash forms) are rejected with a clear error before any project write,
+// and cannot create an artifact outside the owning directory.
+func TestRunSpawn_RejectsUnsafeAgentName(t *testing.T) {
+	unsafe := []string{
+		"..",
+		".",
+		"../escape",
+		"..\\escape",
+		"..\\..\\escape",
+		"a/b",
+		"a\\b",
+		"/abs",
+		"a/../b",
+	}
+	for _, name := range unsafe {
+		withTempHome(t)
+		globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+		preset.RefreshTemplates()
+		preset.Bootstrap(globalDir)
+
+		parent := t.TempDir()
+		dir := filepath.Join(parent, "project")
+
+		var stdout, stderr bytes.Buffer
+		code := RunSpawn(&stdout, &stderr, SpawnOpts{
+			Dir:        dir,
+			Preset:     "minimax",
+			AgentName:  name,
+			Language:   "en",
+			SkipLaunch: true,
+		})
+		if code != 1 {
+			t.Fatalf("agent name %q: exit code = %d, want 1\nstderr: %s", name, code, stderr.String())
+		}
+		var errResp map[string]string
+		if err := json.Unmarshal(stderr.Bytes(), &errResp); err != nil {
+			t.Fatalf("agent name %q: stderr not valid JSON: %v\nbody: %s", name, err, stderr.String())
+		}
+		if errResp["code"] != "invalid_args" {
+			t.Errorf("agent name %q: error code = %q, want invalid_args", name, errResp["code"])
+		}
+		if !strings.Contains(errResp["error"], "invalid agent name") {
+			t.Errorf("agent name %q: error = %q, want a clear validation error", name, errResp["error"])
+		}
+		// No project write may have happened, and nothing may exist at the
+		// escaped target path (parent/escape for "../escape").
+		if _, err := os.Stat(filepath.Join(dir, ".lingtai")); err == nil {
+			t.Errorf("agent name %q: .lingtai/ was created despite rejection", name)
+		}
+		if _, err := os.Stat(filepath.Join(parent, "escape")); err == nil {
+			t.Errorf("agent name %q: escaped artifact created at %s", name, filepath.Join(parent, "escape"))
+		}
+	}
+}
+
+// TestRunSpawn_AcceptsNormalAgentName is the positive control: a normal
+// single-segment agent name still creates the agent dir and init.json.
+func TestRunSpawn_AcceptsNormalAgentName(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	preset.Bootstrap(globalDir)
+
+	dir := filepath.Join(t.TempDir(), "test-project")
+	os.MkdirAll(dir, 0o755)
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{
+		Dir:        dir,
+		Preset:     "minimax",
+		AgentName:  "ok-agent",
+		Language:   "en",
+		SkipLaunch: true,
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".lingtai", "ok-agent", "init.json")); err != nil {
+		t.Errorf("init.json not created for normal agent name: %v", err)
 	}
 }

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -442,10 +442,37 @@ func (p Preset) Validate() []error {
 	return errs
 }
 
+// ValidateSafeName rejects any name that isn't a single, non-empty path
+// segment safe to use as a directory name or filename stem beneath an
+// owning directory. It rejects blank values, "." and "..", and any path
+// separator — both "/" and "\" — so escapes are blocked regardless of the
+// platform the binary runs on (POSIX treats "\" as a literal filename
+// character; Windows treats it as a separator). A name that passes is
+// guaranteed to stay a direct child of whatever base directory it is
+// joined to (issue #849).
+func ValidateSafeName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("must not be blank")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("must not be %q", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("must not contain a path separator")
+	}
+	return nil
+}
+
 // Save writes a preset to the saved/ directory. Save NEVER writes to
 // templates/ — that's owned by Bootstrap. Callers that want to seed
 // a template must use writeTemplate (preset package internal).
 func Save(p Preset) error {
+	// The preset name becomes the filename stem under SavedDir(); enforce
+	// the owning-layer containment invariant here so every caller — current
+	// and future — is protected (issue #849).
+	if err := ValidateSafeName(p.Name); err != nil {
+		return fmt.Errorf("invalid preset name %q: %w", p.Name, err)
+	}
 	if err := p.NormalizeLegacyCapabilities(); err != nil {
 		return fmt.Errorf("canonicalize preset capabilities: %w", err)
 	}
@@ -488,6 +515,12 @@ func Clone(src Preset, newName string) Preset {
 // Bootstrap re-extracts the file anyway). Returns an error only when
 // a saved file existed and the unlink failed.
 func Delete(name string) error {
+	// The name becomes the filename stem under SavedDir(); enforce the
+	// owning-layer containment invariant here so Delete can never target a
+	// path outside saved/ regardless of caller (issue #849).
+	if err := ValidateSafeName(name); err != nil {
+		return fmt.Errorf("invalid preset name %q: %w", name, err)
+	}
 	path := filepath.Join(SavedDir(), name+".json")
 	err := os.Remove(path)
 	if os.IsNotExist(err) {
@@ -1891,6 +1924,12 @@ func stripObsoleteInitFields(initJSON map[string]interface{}) {
 
 // GenerateInitJSONWithOpts creates a full init.json from a preset with explicit agent options.
 func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDir string, opts AgentOpts) error {
+	// The directory derived from dirName must remain a single contained
+	// child of lingtaiDir: reject absolute paths, parent segments, and
+	// either platform's separators before any join or mkdir (issue #849).
+	if err := ValidateSafeName(dirName); err != nil {
+		return fmt.Errorf("invalid agent directory name %q: %w", dirName, err)
+	}
 	if err := p.NormalizeLegacyCapabilities(); err != nil {
 		return fmt.Errorf("canonicalize preset capabilities: %w", err)
 	}

--- a/tui/internal/preset/preset_name_containment_test.go
+++ b/tui/internal/preset/preset_name_containment_test.go
@@ -1,0 +1,154 @@
+package preset
+
+// Regression tests for issue #849: agent directory names and saved-preset
+// filename stems must be single, contained path segments so relative-parent
+// or path-form names cannot escape their owning directories.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// unsafeNames covers the forms the owning-layer containment check must
+// reject: blank, "." and "..", forward/backslash separators (both
+// platforms), absolute paths, and parent-relative paths.
+var unsafeNames = []string{
+	"",
+	"   ",
+	".",
+	"..",
+	"../escape",
+	"..\\escape",
+	"..\\..\\escape",
+	"a/b",
+	"a\\b",
+	"/abs",
+	"abs/",
+	"a/../b",
+}
+
+func TestValidateSafeName_RejectsUnsafeNames(t *testing.T) {
+	for _, name := range unsafeNames {
+		if err := ValidateSafeName(name); err == nil {
+			t.Errorf("ValidateSafeName(%q) = nil, want error", name)
+		}
+	}
+}
+
+func TestValidateSafeName_AcceptsNormalNames(t *testing.T) {
+	for _, name := range []string{
+		"my-preset",
+		"test-agent",
+		"foo.bar",
+		"hello world",
+		"preset-1",
+		"中文-agent",
+	} {
+		if err := ValidateSafeName(name); err != nil {
+			t.Errorf("ValidateSafeName(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestSave_RejectsUnsafeNamesAndWritesNothingOutside(t *testing.T) {
+	withTempPresets(t, func() {
+		for _, name := range unsafeNames {
+			p := DefaultPreset()
+			p.Name = name
+			if err := Save(p); err == nil {
+				t.Errorf("Save(name=%q) = nil, want error", name)
+			}
+			// The would-be join target must not exist anywhere.
+			if _, err := os.Lstat(filepath.Join(SavedDir(), name+".json")); err == nil {
+				t.Errorf("Save(name=%q) created an artifact at the join target", name)
+			}
+		}
+		// A "../escape" name would target presets/escape.json, just outside
+		// saved/; it must not have been written.
+		if _, err := os.Lstat(filepath.Join(PresetsDir(), "escape.json")); err == nil {
+			t.Errorf("Save wrote an escape artifact outside saved/")
+		}
+	})
+}
+
+func TestSave_AcceptsNormalName(t *testing.T) {
+	withTempPresets(t, func() {
+		p := DefaultPreset()
+		p.Name = "my-saved-preset"
+		if err := Save(p); err != nil {
+			t.Fatalf("Save(normal name) error: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(SavedDir(), "my-saved-preset.json")); err != nil {
+			t.Errorf("normal-name preset not written: %v", err)
+		}
+	})
+}
+
+func TestDelete_RejectsUnsafeNamesAndDoesNotTouchOutsideFiles(t *testing.T) {
+	withTempPresets(t, func() {
+		// Plant a decoy exactly where a "../escape" delete would target:
+		// presets/escape.json (just outside saved/). It must survive.
+		decoy := filepath.Join(PresetsDir(), "escape.json")
+		if err := os.MkdirAll(PresetsDir(), 0o755); err != nil {
+			t.Fatalf("mkdir presets: %v", err)
+		}
+		if err := os.WriteFile(decoy, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write decoy: %v", err)
+		}
+
+		for _, name := range unsafeNames {
+			if err := Delete(name); err == nil {
+				t.Errorf("Delete(name=%q) = nil, want error", name)
+			}
+		}
+
+		if _, err := os.Stat(decoy); err != nil {
+			t.Errorf("decoy %s was removed by an unsafe Delete: %v", decoy, err)
+		}
+	})
+}
+
+func TestGenerateInitJSONWithOpts_RejectsUnsafeDirName(t *testing.T) {
+	for _, name := range unsafeNames {
+		tmp := t.TempDir()
+		lingtaiDir := filepath.Join(tmp, "project", ".lingtai")
+		if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+			t.Fatalf("mkdir lingtai: %v", err)
+		}
+		globalDir := filepath.Join(tmp, "global")
+
+		err := GenerateInitJSONWithOpts(DefaultPreset(), "alice", name, lingtaiDir, globalDir, DefaultAgentOpts())
+		if err == nil {
+			t.Errorf("GenerateInitJSONWithOpts(dirName=%q) = nil, want error", name)
+		}
+		// The would-be joined agent dir must not exist: check for an init.json
+		// at the join target, which an escaped write would have produced
+		// (plain "", "." and ".." resolve to already-existing ancestors, so
+		// only their subpaths are meaningful).
+		if _, err := os.Lstat(filepath.Join(lingtaiDir, name, "init.json")); err == nil {
+			t.Errorf("GenerateInitJSONWithOpts(dirName=%q) created an artifact at the join target", name)
+		}
+		// A "../escape" dirName would target <project>/escape (outside
+		// .lingtai/); it must not exist.
+		if _, err := os.Lstat(filepath.Join(tmp, "project", "escape")); err == nil {
+			t.Errorf("GenerateInitJSONWithOpts created an agent dir outside .lingtai/")
+		}
+	}
+}
+
+func TestGenerateInitJSONWithOpts_AcceptsNormalDirName(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, "project", ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatalf("mkdir lingtai: %v", err)
+	}
+	globalDir := filepath.Join(tmp, "global")
+
+	if err := GenerateInitJSONWithOpts(DefaultPreset(), "alice", "alice", lingtaiDir, globalDir, DefaultAgentOpts()); err != nil {
+		t.Fatalf("GenerateInitJSONWithOpts(normal dirName) error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(lingtaiDir, "alice", "init.json")); err != nil {
+		t.Errorf("init.json not written for normal dirName: %v", err)
+	}
+}

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -1365,6 +1365,13 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 			m.saveErr = "name cannot be empty"
 			return m, nil
 		}
+		// The name becomes a filename stem under presets/saved/ via
+		// preset.Save; reject path forms up front so the user sees a
+		// clear error instead of an escape attempt (issue #849).
+		if err := preset.ValidateSafeName(newName); err != nil {
+			m.saveErr = "invalid name: " + err.Error()
+			return m, nil
+		}
 		if newName == m.original.Name {
 			m.saveErr = "pick a different name (or press Ctrl+E to overwrite the built-in)"
 			return m, nil


### PR DESCRIPTION
Closes #849

## Summary

Headless spawn and preset save used the supplied agent/preset name as a directory segment without containment validation — a name like `../escape` could write outside the owning directory. This PR adds owning-layer name validation before any project write.

## Changes

- `tui/internal/preset/preset.go` — new exported `ValidateSafeName`: rejects blank, `"."`, `".."`, and any `/` or `\` separator (single contained path segment).
- `tui/internal/headless/spawn.go` — `RunSpawn` validates the resolved agent name via `preset.ValidateSafeName` **before** any project write; unsafe names exit 1 with a clear `invalid_args` JSON error.
- `tui/internal/tui/preset_editor.go` — saved preset names validated with the same rule.
- Tests: `TestRunSpawn_RejectsUnsafeAgentName` (10 path-form names: parent, absolute, slash, backslash — all rejected with no `.lingtai/` created and no escaped artifact) + positive control; `preset_name_containment_test.go` for `ValidateSafeName`.

## Validation

- `go test -count=1 ./internal/headless/... ./internal/preset/... ./internal/tui/...` passes (all in `tui/`)
- `go vet` clean; `git diff --check` clean

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
