### PR TITLE
fix(config): validate legacy addon keys before interpreter construction (lingtai #848)

### DIFF
--- a/portal/internal/migrate/m028_addons_to_mcp.go
+++ b/portal/internal/migrate/m028_addons_to_mcp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -92,6 +93,16 @@ var addonSpecs = map[string]addonSpec{
 	"whatsapp": {module: "lingtai.mcp_servers.whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
 }
 
+// addonKeyRe mirrors the TUI's legacy addon key validation contract
+// (tui/internal/config.ValidateAddonKey). The portal is a separate Go module
+// and cannot import the TUI package, so the identical identifier grammar is
+// enforced locally: legacy "addons" object keys must be valid addon/module
+// identifiers (dot-separated Python identifier segments) before they are
+// accepted anywhere. Keys containing semicolons or any other
+// source-boundary/non-identifier characters are not addon names and must
+// never be carried into a converted file.
+var addonKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
+
 // convertAddonsInInitFile is the per-init.json workhorse. A returned error
 // means the file is still in legacy form and the migration must not be
 // considered complete.
@@ -139,6 +150,15 @@ func convertAddonsInInitFile(initPath, agentDir, globalDir string) error {
 	}
 
 	for addonName, addonCfgRaw := range addonsDict {
+		// Same structured identifier contract as the TUI's launch-time addon
+		// check: a legacy key containing a semicolon or any other
+		// source-boundary/non-identifier character is not an addon name and
+		// must never be carried into the converted file.
+		if !addonKeyRe.MatchString(addonName) {
+			fmt.Fprintf(os.Stderr,
+				"m028: %s — invalid legacy addon key %q, skipping\n", initPath, addonName)
+			continue
+		}
 		spec, known := addonSpecs[addonName]
 		if !known {
 			fmt.Fprintf(os.Stderr,

--- a/portal/internal/migrate/m028_addons_to_mcp_test.go
+++ b/portal/internal/migrate/m028_addons_to_mcp_test.go
@@ -1,6 +1,11 @@
 package migrate
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestM028AddonSpecsUseBundledModules(t *testing.T) {
 	want := map[string]addonSpec{
@@ -23,5 +28,74 @@ func TestM028AddonSpecsUseBundledModules(t *testing.T) {
 		if got != wantSpec {
 			t.Errorf("addonSpecs[%q] = %#v, want %#v", name, got, wantSpec)
 		}
+	}
+}
+
+// TestM028AddonKeyReMatchesTUIModuleIdentifierContract mirrors the TUI's
+// legacy addon key validation contract (tui/internal/config.ValidateAddonKey):
+// keys containing semicolons or any other source-boundary/non-identifier
+// characters are not valid addon/module identifiers and must be rejected.
+func TestM028AddonKeyReMatchesTUIModuleIdentifierContract(t *testing.T) {
+	valid := []string{"imap", "telegram", "_private", "a1", "x_y", "imap.telegram"}
+	invalid := []string{
+		"", "imap;rm", ";", "imap\nprint(1)", "imap#comment", "imap x",
+		"1imap", "-imap", ".imap", "imap.", "imap..x", "imap\"x",
+		"imap'x", "imap\\x", "imap/x", "__import__('os')",
+		"import os; os.system('id')",
+	}
+	for _, name := range valid {
+		if !addonKeyRe.MatchString(name) {
+			t.Errorf("addonKeyRe should accept %q", name)
+		}
+	}
+	for _, name := range invalid {
+		if addonKeyRe.MatchString(name) {
+			t.Errorf("addonKeyRe must reject %q", name)
+		}
+	}
+}
+
+// TestM028SkipsInvalidAddonKey proves the same contract applies when the
+// portal reads legacy addon objects: a key with a source-boundary character
+// is skipped and never carried into the converted file, while valid keys are
+// still converted.
+func TestM028SkipsInvalidAddonKey(t *testing.T) {
+	tmp := t.TempDir()
+	agentDir := filepath.Join(tmp, "alice")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initPath := filepath.Join(agentDir, "init.json")
+	doc := map[string]interface{}{
+		"manifest": map[string]interface{}{"agent_name": "alice"},
+		"addons": map[string]interface{}{
+			"imap":    map[string]interface{}{"config": ".secrets/imap.json"},
+			"imap;rm": map[string]interface{}{"config": ".secrets/evil.json"},
+		},
+	}
+	data, _ := json.Marshal(doc)
+	if err := os.WriteFile(initPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := convertAddonsInInitFile(initPath, agentDir, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(updated, &got); err != nil {
+		t.Fatal(err)
+	}
+	addons, _ := got["addons"].([]interface{})
+	if len(addons) != 1 || addons[0] != "imap" {
+		t.Errorf("addons = %v, want [\"imap\"]", addons)
+	}
+	mcp, _ := got["mcp"].(map[string]interface{})
+	if _, ok := mcp["imap;rm"]; ok {
+		t.Error("invalid addon key should not have an mcp entry")
 	}
 }

--- a/tui/internal/config/addon_key.go
+++ b/tui/internal/config/addon_key.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// addonKeyRe matches an allowed legacy addon/module identifier: a non-empty
+// dot-separated sequence of Python identifier segments (letters, digits and
+// underscores, each segment starting with a letter or underscore).
+//
+// Legacy init.json "addons" object keys are interpolated verbatim into
+// generated Python import source before agent launch
+// ("import lingtai.addons.<key>"), so only characters that cannot alter the
+// constructed program are allowed. A semicolon, newline, quote, comment
+// marker, whitespace, or any other source-boundary character changes the
+// generated program instead of remaining addon-name data and must be
+// rejected before any interpreter source or command is constructed.
+var addonKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
+
+// ValidateAddonKey reports whether name is an allowed addon/module
+// identifier that may safely be interpolated into generated Python import
+// source (e.g. "import lingtai.addons.<name>").
+//
+// Every legacy addon object key must pass this check before any interpreter
+// source or command is constructed from it. Keys containing semicolons or
+// any other source-boundary/non-identifier characters return an error so
+// callers can fail fast at the validation boundary instead of building a
+// program that a malformed or untrusted key has altered.
+func ValidateAddonKey(name string) error {
+	if !addonKeyRe.MatchString(name) {
+		return fmt.Errorf(
+			"addon key %q is not a valid addon/module identifier: only letters, digits, "+
+				"underscores and dot-separated segments are allowed, each segment must start "+
+				"with a letter or underscore, and semicolons, whitespace, quotes, and other "+
+				"source-boundary characters are rejected",
+			name,
+		)
+	}
+	return nil
+}

--- a/tui/internal/config/addon_key_test.go
+++ b/tui/internal/config/addon_key_test.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateAddonKey(t *testing.T) {
+	valid := []string{
+		"imap", "telegram", "wechat", "whatsapp", "feishu",
+		"_private", "a1", "x_y", "imap.telegram", "a.b.c", "x2.y_3",
+	}
+	for _, name := range valid {
+		if err := ValidateAddonKey(name); err != nil {
+			t.Errorf("ValidateAddonKey(%q) = %v, want nil", name, err)
+		}
+	}
+
+	// Every one of these must be rejected BEFORE it could be interpolated
+	// into generated Python import source. Semicolons, newlines, quotes,
+	// comment markers, whitespace, path separators, leading digits, empty
+	// names, and stray punctuation are all source-boundary/non-identifier
+	// characters that could alter the constructed program.
+	invalid := []string{
+		"",
+		"imap;rm",
+		";",
+		"imap\nprint(1)",
+		"imap\r\nimport os",
+		"imap#comment",
+		"imap x",
+		" imap",
+		"imap ",
+		"imap\t",
+		"imap\"x",
+		"imap'x",
+		"imap\\x",
+		"imap/x",
+		"imap(x)",
+		"imap$x",
+		"imap~x",
+		"1imap",
+		"-imap",
+		".imap",
+		"imap.",
+		"imap..x",
+		"imap\u00e9",
+		"__import__('os')",
+		"os.system('ls')",
+		"import os; os.system('id')",
+	}
+	for _, name := range invalid {
+		if err := ValidateAddonKey(name); err == nil {
+			t.Errorf("ValidateAddonKey(%q) = nil, want validation error", name)
+		}
+	}
+}
+
+// writeStubPython writes a POSIX shell stub that records every invocation
+// (one argument per line) to logPath and then exits with the given status.
+// It lets tests prove whether an interpreter process is (or is not) started
+// during addon validation without running a real Python.
+func writeStubPython(t *testing.T, dir, logPath string, exitStatus int) string {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" >> %q\nexit %d\n", logPath, exitStatus)
+	p := filepath.Join(dir, "python")
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func readInvocationLog(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read invocation log: %v", err)
+	}
+	var args []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+	return args
+}
+
+func writeAgentInitJSON(t *testing.T, agentDir, initJSON string) {
+	t.Helper()
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte(initJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestEnsureAddonsRejectsInvalidLegacyKeyBeforeInterpreter proves that a
+// legacy addon key containing a source-boundary character (semicolon) fails
+// at the validation boundary and that no interpreter process is started for
+// it: the stub python's invocation log must never be created.
+func TestEnsureAddonsRejectsInvalidLegacyKeyBeforeInterpreter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub interpreter not available on Windows")
+	}
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "python-calls.log")
+	stub := writeStubPython(t, dir, logPath, 0)
+
+	agentDir := filepath.Join(dir, "alice")
+	writeAgentInitJSON(t, agentDir, `{"addons": {"imap;__import__('os').system('id')": {}}}`)
+
+	err := EnsureAddons(stub, agentDir)
+	if err == nil {
+		t.Fatal("expected validation error for invalid legacy addon key")
+	}
+	if !strings.Contains(err.Error(), "invalid legacy addon key") {
+		t.Fatalf("error = %v, want validation-boundary error", err)
+	}
+	if _, statErr := os.Stat(logPath); !os.IsNotExist(statErr) {
+		t.Fatalf("interpreter was started despite invalid addon key; invocation log exists: %v", logPath)
+	}
+}
+
+// TestEnsureAddonsValidKeyRunsImportabilityCheck proves valid legacy addon
+// keys retain the existing importability check: the stub interpreter is
+// invoked exactly once with the constructed import statement, and its exit
+// status drives the result.
+func TestEnsureAddonsValidKeyRunsImportabilityCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub interpreter not available on Windows")
+	}
+
+	t.Run("importable", func(t *testing.T) {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "python-calls.log")
+		stub := writeStubPython(t, dir, logPath, 0)
+		agentDir := filepath.Join(dir, "alice")
+		writeAgentInitJSON(t, agentDir, `{"addons": {"imap": {}}}`)
+
+		if err := EnsureAddons(stub, agentDir); err != nil {
+			t.Fatalf("EnsureAddons = %v, want nil for importable addon", err)
+		}
+		calls := readInvocationLog(t, logPath)
+		if len(calls) != 2 || calls[0] != "-c" || calls[1] != "import lingtai.addons.imap" {
+			t.Fatalf("interpreter calls = %v, want [-c import lingtai.addons.imap]", calls)
+		}
+	})
+
+	t.Run("not importable", func(t *testing.T) {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "python-calls.log")
+		stub := writeStubPython(t, dir, logPath, 1)
+		agentDir := filepath.Join(dir, "alice")
+		writeAgentInitJSON(t, agentDir, `{"addons": {"imap": {}}}`)
+
+		err := EnsureAddons(stub, agentDir)
+		if err == nil {
+			t.Fatal("expected importability error for failing stub")
+		}
+		if !strings.Contains(err.Error(), "not importable") {
+			t.Fatalf("error = %v, want importability error", err)
+		}
+		calls := readInvocationLog(t, logPath)
+		if len(calls) != 2 || calls[0] != "-c" || calls[1] != "import lingtai.addons.imap" {
+			t.Fatalf("interpreter calls = %v, want [-c import lingtai.addons.imap]", calls)
+		}
+	})
+}

--- a/tui/internal/config/venv.go
+++ b/tui/internal/config/venv.go
@@ -385,6 +385,13 @@ func CheckTUIUpgrade(currentVersion string) string {
 // pip-install per addon. This function only checks importability and returns
 // a clear error if an addon is missing, so callers can surface the failure
 // instead of silently launching an agent that will crash on first use.
+//
+// Legacy addon object keys (the pre-m028 "addons" dict shape) are validated
+// structurally as addon/module identifiers BEFORE any interpreter source or
+// command is constructed: a key containing a semicolon or any other
+// source-boundary/non-identifier character fails here instead of altering
+// the generated "import lingtai.addons.<key>" program during an ordinary
+// launch-time check.
 func EnsureAddons(python, agentDir string) error {
 	initPath := filepath.Join(agentDir, "init.json")
 	data, err := os.ReadFile(initPath)
@@ -398,6 +405,16 @@ func EnsureAddons(python, agentDir string) error {
 	addonsRaw, ok := init["addons"].(map[string]interface{})
 	if !ok || len(addonsRaw) == 0 {
 		return nil // no addons declared
+	}
+
+	// Validate every legacy addon key up front so a malformed or untrusted
+	// key can never reach interpreter construction. The importability check
+	// below interpolates each key verbatim into Python source, so the
+	// validation boundary must come first.
+	for addonName := range addonsRaw {
+		if err := ValidateAddonKey(addonName); err != nil {
+			return fmt.Errorf("invalid legacy addon key in init.json at %s: %w", initPath, err)
+		}
 	}
 
 	for addonName := range addonsRaw {

--- a/tui/internal/migrate/m028_addons_to_mcp.go
+++ b/tui/internal/migrate/m028_addons_to_mcp.go
@@ -164,6 +164,16 @@ func convertAddonsInInitFile(initPath, agentDir, globalDir string) error {
 	}
 
 	for addonName, addonCfgRaw := range addonsDict {
+		// Same structured identifier contract as the launch-time addon check
+		// (config.ValidateAddonKey): a legacy key containing a semicolon or
+		// any other source-boundary/non-identifier character is not an addon
+		// name and must never be carried into the converted file.
+		if err := config.ValidateAddonKey(addonName); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"m028: %s — invalid legacy addon key %q, skipping (file unchanged for this entry)\n",
+				initPath, addonName)
+			continue
+		}
 		spec, known := addonSpecs[addonName]
 		if !known {
 			fmt.Fprintf(os.Stderr,

--- a/tui/internal/migrate/m028_addons_to_mcp_test.go
+++ b/tui/internal/migrate/m028_addons_to_mcp_test.go
@@ -477,6 +477,44 @@ func TestM028SkipsUnknownAddon(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Legacy addon keys that are not valid addon/module identifiers (semicolons,
+// other source-boundary characters) are skipped and never carried into the
+// converted file
+// ---------------------------------------------------------------------------
+
+func TestM028SkipsInvalidAddonKey(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeM028Init(t, lingtaiDir, "alice", map[string]interface{}{
+		"manifest": map[string]interface{}{"agent_name": "alice"},
+		"addons": map[string]interface{}{
+			"imap":    map[string]interface{}{"config": ".secrets/imap.json"},
+			"imap;rm": map[string]interface{}{"config": ".secrets/evil.json"}, // source-boundary char
+		},
+	})
+
+	if err := migrateAddonsToMCP(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readM028Init(t, initPath)
+	addons, _ := got["addons"].([]interface{})
+	for _, a := range addons {
+		if a == "imap;rm" {
+			t.Errorf("invalid addon key should have been skipped (got %v)", addons)
+		}
+	}
+	mcp, _ := got["mcp"].(map[string]interface{})
+	if _, ok := mcp["imap;rm"]; ok {
+		t.Error("invalid addon key should not have an mcp entry")
+	}
+	// The valid key must still be converted.
+	if len(addons) != 1 || addons[0] != "imap" {
+		t.Errorf("addons = %v, want [\"imap\"]", addons)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Empty addons dict -> empty list
 // ---------------------------------------------------------------------------
 

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -2115,8 +2115,14 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	case []interface{}:
 		existingAddonsList = v
 	case map[string]interface{}:
-		// Legacy dict shape — extract just the names.
+		// Legacy dict shape — extract just the names. Apply the same
+		// identifier validation contract as the launch-time addon check so a
+		// malformed or untrusted key can never be carried into a regenerated
+		// init.json.
 		for name := range v {
+			if config.ValidateAddonKey(name) != nil {
+				continue
+			}
 			existingAddonsList = append(existingAddonsList, name)
 		}
 	}

--- a/tui/internal/preset/preset_addons_default_test.go
+++ b/tui/internal/preset/preset_addons_default_test.go
@@ -245,6 +245,54 @@ func TestGenerateInitJSONNormalizesLegacyDictShape(t *testing.T) {
 	}
 }
 
+// Verifies that a legacy dict-shape addons object containing a key that is
+// not a valid addon/module identifier (semicolon source-boundary character)
+// has that key dropped during regen instead of being carried into the
+// regenerated init.json, while valid keys are preserved.
+func TestGenerateInitJSONDropsInvalidLegacyDictKey(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	globalDir := filepath.Join(tmp, ".lingtai-tui")
+	agentDir := filepath.Join(lingtaiDir, "alice")
+	os.MkdirAll(agentDir, 0o755)
+	os.MkdirAll(globalDir, 0o755)
+
+	legacy := map[string]interface{}{
+		"manifest": map[string]interface{}{},
+		"addons": map[string]interface{}{
+			"imap":    map[string]interface{}{"config": ".secrets/imap.json"},
+			"imap;rm": map[string]interface{}{"config": ".secrets/evil.json"},
+		},
+	}
+	data, _ := json.Marshal(legacy)
+	os.WriteFile(filepath.Join(agentDir, "init.json"), data, 0o644)
+
+	p := DefaultPreset()
+	if err := GenerateInitJSONWithOpts(p, "alice", "alice", lingtaiDir, globalDir, AgentOpts{}); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedData, _ := os.ReadFile(filepath.Join(agentDir, "init.json"))
+	var got map[string]interface{}
+	json.Unmarshal(updatedData, &got)
+	addons, ok := got["addons"].([]interface{})
+	if !ok {
+		t.Fatalf("addons should now be a list, got %T (%v)", got["addons"], got["addons"])
+	}
+	names := map[string]bool{}
+	for _, raw := range addons {
+		if s, ok := raw.(string); ok {
+			names[s] = true
+		}
+	}
+	if !names["imap"] {
+		t.Errorf("expected imap preserved from legacy dict, got %v", addons)
+	}
+	if names["imap;rm"] {
+		t.Errorf("invalid legacy key must not be preserved, got %v", addons)
+	}
+}
+
 // Cosmetic: confirm runtime.GOOS-aware venv python path resolution
 // produces a sensible string. Not a behavior test; just makes sure the
 // fragment matching in TestGenerateInitJSONWritesNewShapeWithLocalVenv

--- a/tui/internal/process/launcher_test.go
+++ b/tui/internal/process/launcher_test.go
@@ -1,9 +1,13 @@
 package process
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestInitProject(t *testing.T) {
@@ -37,5 +41,112 @@ func TestInitProject(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(lingtaiDir, "meta.json")); !os.IsNotExist(err) {
 		t.Errorf("InitProject wrote retired migration progress meta.json (err=%v)", err)
+	}
+}
+
+// writeStubPython writes a POSIX shell stub that records every invocation
+// (one argument per line) to logPath and then exits with the given status.
+// It lets tests prove whether an interpreter process is (or is not) started
+// during agent launch without running a real Python.
+func writeStubPython(t *testing.T, dir, logPath string, exitStatus int) string {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" >> %q\nexit %d\n", logPath, exitStatus)
+	p := filepath.Join(dir, "python")
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func readInvocationLog(t *testing.T, logPath string) string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read invocation log: %v", err)
+	}
+	return string(data)
+}
+
+// TestLaunchAgentUnsafeRejectsInvalidAddonKeyBeforeInterpreter proves that a
+// legacy addon key containing a source-boundary character (semicolon) is
+// rejected at the validation boundary during launch and that NO interpreter
+// process is started for it: the stub python's invocation log must never be
+// created.
+func TestLaunchAgentUnsafeRejectsInvalidAddonKeyBeforeInterpreter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub interpreter not available on Windows")
+	}
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "python-calls.log")
+	stub := writeStubPython(t, dir, logPath, 0)
+
+	agentDir := filepath.Join(dir, "alice")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initJSON := `{"addons": {"imap;__import__('os').system('id')": {}}}`
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte(initJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := launchAgentUnsafe(stub, agentDir)
+	if err == nil {
+		t.Fatal("expected validation error for invalid legacy addon key")
+	}
+	if cmd != nil {
+		t.Errorf("expected no command for invalid addon key, got %v", cmd)
+	}
+	if !strings.Contains(err.Error(), "invalid legacy addon key") {
+		t.Fatalf("error = %v, want validation-boundary error", err)
+	}
+	if _, statErr := os.Stat(logPath); !os.IsNotExist(statErr) {
+		t.Fatalf("interpreter was started despite invalid addon key; invocation log exists: %v", logPath)
+	}
+}
+
+// TestLaunchAgentUnsafeValidAddonKeyKeepsLaunchBehavior proves that valid
+// legacy addon keys retain the existing importability check AND the existing
+// launch behavior: the stub interpreter is first invoked for the import
+// probe, then the agent command (-m lingtai run) is started.
+func TestLaunchAgentUnsafeValidAddonKeyKeepsLaunchBehavior(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub interpreter not available on Windows")
+	}
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "python-calls.log")
+	stub := writeStubPython(t, dir, logPath, 0)
+
+	agentDir := filepath.Join(dir, "alice")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initJSON := `{"addons": {"imap": {}}}`
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte(initJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := launchAgentUnsafe(stub, agentDir)
+	if err != nil {
+		t.Fatalf("launchAgentUnsafe = %v, want nil for valid addon key", err)
+	}
+	if cmd == nil {
+		t.Fatal("expected a started agent command")
+	}
+
+	// The stub exits immediately, so wait for it to reap the child.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+
+	calls := readInvocationLog(t, logPath)
+	for _, want := range []string{"-c", "import lingtai.addons.imap", "-m", "lingtai", "run"} {
+		if !strings.Contains(calls, want) {
+			t.Errorf("interpreter log missing %q; got:\n%s", want, calls)
+		}
 	}
 }

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -872,7 +872,13 @@ func checkAddonSecrets(orchDir string) []doctorLine {
 			}
 		}
 	case map[string]interface{}:
+		// Legacy dict shape — keys must satisfy the same addon/module
+		// identifier contract as the launch-time addon check; anything else
+		// is not an addon name and cannot be diagnosed.
 		for name := range v {
+			if config.ValidateAddonKey(name) != nil {
+				continue
+			}
 			addons = append(addons, name)
 		}
 	}

--- a/tui/internal/tui/doctor_startup_test.go
+++ b/tui/internal/tui/doctor_startup_test.go
@@ -167,6 +167,25 @@ func TestCheckAddonSecrets_LegacyConfigPath(t *testing.T) {
 	assertLineFlag(t, lines, "imap secrets present", true, false)
 }
 
+func TestCheckAddonSecrets_SkipsInvalidLegacyKey(t *testing.T) {
+	// A legacy dict key with a source-boundary character is not an addon
+	// name and must never surface in doctor output; the valid key is still
+	// diagnosed normally.
+	orchDir, _ := startupFixture(t,
+		`{"addons": {"imap": {"config": ".secrets/imap.json"}, "imap;rm -rf /": {"config": ".secrets/evil.json"}}}`,
+		"", "",
+	)
+	writeTestFile(t, filepath.Join(orchDir, ".secrets", "imap.json"), `{"host": "x"}`)
+
+	lines := checkAddonSecrets(orchDir)
+	assertLineFlag(t, lines, "imap secrets present", true, false)
+	for _, line := range lines {
+		if strings.Contains(line.Text, "imap;rm") {
+			t.Errorf("invalid legacy addon key leaked into doctor output: %q", line.Text)
+		}
+	}
+}
+
 func TestCheckAddonSecrets_NoAddons(t *testing.T) {
 	orchDir, _ := startupFixture(t, `{}`, "", "")
 	lines := checkAddonSecrets(orchDir)

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -706,7 +706,13 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 						}
 					}
 				case map[string]interface{}:
+					// Legacy dict shape — apply the same addon/module identifier
+					// validation contract as the launch-time addon check so
+					// malformed keys are never offered as selectable addons.
 					for name := range v {
+						if config.ValidateAddonKey(name) != nil {
+							continue
+						}
 						m.setupLoadedAddonNames = append(m.setupLoadedAddonNames, name)
 					}
 				}


### PR DESCRIPTION
Closes #848

## Summary

Legacy `init.json` `addons` object keys were carried directly into Python import/interpreter construction paths without validation — a key containing `;`, newline, quote, or comment marker could inject into the constructed command. This PR validates addon keys at the boundary before interpreter construction.

## Changes

- New `tui/internal/config/addon_key.go`: `ValidateAddonKey(name)` enforces a dot-separated Python-identifier grammar (`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`), rejecting semicolons/newlines/quotes/comments/whitespace/non-identifiers.
- `tui/internal/config/venv.go`: addon-derived interpreter/module construction validates keys first; invalid keys are rejected with a clear error instead of being formatted into a command.
- `tui/internal/migrate/m028_addons_to_mcp.go` + `portal/internal/migrate/m028_addons_to_mcp.go`: invalid legacy addon keys are skipped and never carried into the converted file (same grammar enforced locally in both Go modules).
- `doctor.go`/`firstrun.go` addon handling wired to the validator.
- Tests: `addon_key_test.go`, `TestM028AddonKeyReMatchesTUIModuleIdentifierContract`, `TestM028SkipsInvalidAddonKey`, `preset_addons_default_test.go`, `launcher_test.go`, `doctor_startup_test.go` — valid/invalid matrix incl. injection payloads.

## Validation

- `go test -count=1` passes in tui (`config/migrate/preset/process/tui`) and portal (`migrate`)
- `go vet` clean; `git diff --check` clean

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
