### PR TITLE
test: consolidate runtime mechanics coverage

### DIFF
--- a/tui/internal/config/global_test.go
+++ b/tui/internal/config/global_test.go
@@ -224,17 +224,6 @@ func TestDefaultTUIConfig_MailPageSize(t *testing.T) {
 	}
 }
 
-func TestLoadTUIConfig_MigratesLegacySmallMailPageSizeToDefault(t *testing.T) {
-	dir := t.TempDir()
-	payload := []byte(`{"language":"en","mail_page_size":50}`)
-	if err := os.WriteFile(filepath.Join(dir, "tui_config.json"), payload, 0o644); err != nil {
-		t.Fatalf("write tui_config.json: %v", err)
-	}
-	if cfg := LoadTUIConfig(dir); cfg.MailPageSize != 200 {
-		t.Fatalf("legacy small mail_page_size loaded as %d, want 200 (the finite default)", cfg.MailPageSize)
-	}
-}
-
 func TestLoadTUIConfig_PreservesHundredMailPageSize(t *testing.T) {
 	dir := t.TempDir()
 	payload := []byte(`{"language":"en","mail_page_size":100}`)
@@ -299,17 +288,6 @@ func TestSaveTUIConfig_NormalizesUnsupportedMailPageSize(t *testing.T) {
 	}
 	if loaded := LoadTUIConfig(dir); loaded.MailPageSize != 200 {
 		t.Fatalf("saved unsupported page size loaded as %d, want 200", loaded.MailPageSize)
-	}
-}
-
-func TestLoadTUIConfig_RemovedUnlimitedSentinelUsesFiniteDefault(t *testing.T) {
-	dir := t.TempDir()
-	payload := []byte(`{"language":"en","mail_page_size":0}`)
-	if err := os.WriteFile(filepath.Join(dir, "tui_config.json"), payload, 0o644); err != nil {
-		t.Fatalf("write tui_config.json: %v", err)
-	}
-	if cfg := LoadTUIConfig(dir); cfg.MailPageSize != 200 {
-		t.Fatalf("removed mail_page_size=0 loaded as %d, want finite default 200", cfg.MailPageSize)
 	}
 }
 

--- a/tui/internal/config/global_test.go
+++ b/tui/internal/config/global_test.go
@@ -260,15 +260,31 @@ func TestLoadTUIConfig_PreservesExplicitTwoHundred(t *testing.T) {
 }
 
 func TestLoadTUIConfig_NormalizesUnsupportedMailPageSizes(t *testing.T) {
-	for _, value := range []int{-1, 0, 50, 300, 2001, 5000, 999999} {
-		t.Run(fmt.Sprintf("value_%d", value), func(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int
+	}{
+		{name: "value_-1", value: -1},
+		// Zero was the removed "unlimited" sentinel; loading it must use the
+		// finite default rather than resurrecting unbounded pagination.
+		{name: "removed_unlimited_sentinel_0", value: 0},
+		// Fifty was the legacy small page size; loading it migrates to the
+		// current finite default.
+		{name: "legacy_small_page_size_50", value: 50},
+		{name: "value_300", value: 300},
+		{name: "value_2001", value: 2001},
+		{name: "value_5000", value: 5000},
+		{name: "value_999999", value: 999999},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			payload := []byte(fmt.Sprintf(`{"language":"en","mail_page_size":%d}`, value))
+			payload := []byte(fmt.Sprintf(`{"language":"en","mail_page_size":%d}`, tc.value))
 			if err := os.WriteFile(filepath.Join(dir, "tui_config.json"), payload, 0o644); err != nil {
 				t.Fatal(err)
 			}
 			if cfg := LoadTUIConfig(dir); cfg.MailPageSize != 200 {
-				t.Fatalf("unsupported mail_page_size=%d loaded as %d, want 200", value, cfg.MailPageSize)
+				t.Fatalf("unsupported mail_page_size=%d loaded as %d, want 200", tc.value, cfg.MailPageSize)
 			}
 		})
 	}

--- a/tui/internal/fs/agent_test.go
+++ b/tui/internal/fs/agent_test.go
@@ -753,25 +753,6 @@ func TestReadStatusLegacyAndMalformedStatusOmitSinceMoltCounters(t *testing.T) {
 	}
 }
 
-func TestReadStatusTypeErrorKeepsSafeFieldsAndOmitsEconomy(t *testing.T) {
-	agentDir := t.TempDir()
-	body := `{"runtime":{"pid":4242,"running":true,"uptime_seconds":3.5},"tokens":{"input_tokens":"bad","output_tokens":200,"thinking_tokens":50,"cached_tokens":100,"api_calls":4,"context":{"total_tokens":1234,"window_size":8000,"usage_pct":20}}}`
-	if err := os.WriteFile(filepath.Join(agentDir, ".status.json"), []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	got := ReadStatus(agentDir)
-	if got.Runtime.PID != 4242 || !got.Runtime.Running || got.Runtime.UptimeSeconds != 3.5 {
-		t.Fatalf("runtime = %+v, want safely decoded runtime fields", got.Runtime)
-	}
-	if got.Tokens.Context.TotalTokens != 1234 || got.Tokens.Context.WindowSize != 8000 || got.Tokens.Context.UsagePct != 20 {
-		t.Fatalf("context = %+v, want safely decoded context fields", got.Tokens.Context)
-	}
-	if got.Tokens.InputTokens != 0 || got.Tokens.OutputTokens != 0 || got.Tokens.ThinkingTokens != 0 || got.Tokens.CachedTokens != 0 || got.Tokens.APICalls != 0 {
-		t.Fatalf("economy = %+v, want the whole tuple omitted after one invalid field", got.Tokens)
-	}
-}
-
 func TestReadStatusSyntaxErrorZerosWholeSnapshot(t *testing.T) {
 	agentDir := t.TempDir()
 	body := `{"runtime":{"pid":4242},"tokens":{"input_tokens":1,"context":{"total_tokens":1234,"window_size":8000}`

--- a/tui/internal/fs/agent_test.go
+++ b/tui/internal/fs/agent_test.go
@@ -784,12 +784,13 @@ func TestReadStatusSyntaxErrorZerosWholeSnapshot(t *testing.T) {
 }
 
 func TestReadStatusInvalidEconomyValuesOmitWholeTuple(t *testing.T) {
-	base := `{"runtime":{"pid":4242,"running":true},"tokens":{"input_tokens":11,"output_tokens":22,"thinking_tokens":33,"cached_tokens":44,"api_calls":55,"context":{"total_tokens":1234,"window_size":8000,"usage_pct":20}}}`
+	base := `{"runtime":{"pid":4242,"running":true,"uptime_seconds":3.5},"tokens":{"input_tokens":11,"output_tokens":22,"thinking_tokens":33,"cached_tokens":44,"api_calls":55,"context":{"total_tokens":1234,"window_size":8000,"usage_pct":20}}}`
 	for _, tc := range []struct {
 		name  string
 		field string
 		valid int64
 		value string
+		body  string
 	}{
 		{name: "negative", field: "input_tokens", valid: 11, value: "-1"},
 		{name: "fractional", field: "output_tokens", valid: 22, value: "1.5"},
@@ -797,12 +798,16 @@ func TestReadStatusInvalidEconomyValuesOmitWholeTuple(t *testing.T) {
 		{name: "signed-int64 overflow", field: "cached_tokens", valid: 44, value: "9223372036854775808"},
 		{name: "quoted numeric string", field: "api_calls", valid: 55, value: `"55"`},
 		{name: "ordinary bad string", field: "input_tokens", valid: 11, value: `"not-a-number"`},
+		{name: "bad string with distinct safe fields", body: `{"runtime":{"pid":4242,"running":true,"uptime_seconds":3.5},"tokens":{"input_tokens":"bad","output_tokens":200,"thinking_tokens":50,"cached_tokens":100,"api_calls":4,"context":{"total_tokens":1234,"window_size":8000,"usage_pct":20}}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			needle := fmt.Sprintf(`"%s":%d`, tc.field, tc.valid)
-			body := strings.Replace(base, needle, fmt.Sprintf(`"%s":%s`, tc.field, tc.value), 1)
-			if body == base {
-				t.Fatalf("failed to replace valid %s counter", tc.field)
+			body := tc.body
+			if body == "" {
+				needle := fmt.Sprintf(`"%s":%d`, tc.field, tc.valid)
+				body = strings.Replace(base, needle, fmt.Sprintf(`"%s":%s`, tc.field, tc.value), 1)
+				if body == base {
+					t.Fatalf("failed to replace valid %s counter", tc.field)
+				}
 			}
 			agentDir := t.TempDir()
 			if err := os.WriteFile(filepath.Join(agentDir, ".status.json"), []byte(body), 0o644); err != nil {
@@ -812,8 +817,11 @@ func TestReadStatusInvalidEconomyValuesOmitWholeTuple(t *testing.T) {
 			if got.Tokens.InputTokens != 0 || got.Tokens.OutputTokens != 0 || got.Tokens.ThinkingTokens != 0 || got.Tokens.CachedTokens != 0 || got.Tokens.APICalls != 0 {
 				t.Fatalf("economy = %+v, want whole tuple omitted for %s", got.Tokens, tc.name)
 			}
-			if got.Tokens.Context.TotalTokens != 1234 || got.Runtime.PID != 4242 || !got.Runtime.Running {
-				t.Fatalf("safe fields = context=%+v runtime=%+v, want preserved", got.Tokens.Context, got.Runtime)
+			if got.Runtime.PID != 4242 || !got.Runtime.Running || got.Runtime.UptimeSeconds != 3.5 {
+				t.Fatalf("runtime = %+v, want safely decoded runtime fields", got.Runtime)
+			}
+			if got.Tokens.Context.TotalTokens != 1234 || got.Tokens.Context.WindowSize != 8000 || got.Tokens.Context.UsagePct != 20 {
+				t.Fatalf("context = %+v, want safely decoded context fields", got.Tokens.Context)
 			}
 		})
 	}

--- a/tui/internal/fs/daemon_ledger_test.go
+++ b/tui/internal/fs/daemon_ledger_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -25,6 +26,47 @@ func writeDaemonLedger(t *testing.T, agentDir, runID string, lines []string) {
 }
 
 // --- Backward-compat tests (wrappers still work) ---
+
+func TestDaemonLedgerSummaryEmptyStates(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		createDaemonsDir bool
+	}{
+		// No daemons/ directory at all must be empty, not an error.
+		{name: "missing_daemons_directory"},
+		{name: "empty_daemons_directory", createDaemonsDir: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agentDir := t.TempDir()
+			if tc.createDaemonsDir {
+				if err := os.MkdirAll(filepath.Join(agentDir, "daemons"), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+			}
+
+			// Preserve the summary callers' recentN=0 input and assert both return values.
+			totalsZero, recentZero := DaemonLedgerSummary(agentDir, 0)
+			if len(totalsZero) != 0 {
+				t.Fatalf("recentN=0: expected empty totals, got %d entries", len(totalsZero))
+			}
+			if len(recentZero) != 0 {
+				t.Fatalf("recentN=0: expected empty recent rows, got %d entries", len(recentZero))
+			}
+
+			// Preserve the wrapper callers' recentN=100 input while asserting both halves.
+			totals, recent := DaemonLedgerSummary(agentDir, 100)
+			if len(totals) != 0 {
+				t.Fatalf("recentN=100: expected empty totals, got %d entries", len(totals))
+			}
+			if len(recent) != 0 {
+				t.Fatalf("recentN=100: expected empty recent rows, got %d entries", len(recent))
+			}
+			if wrapped := DaemonRecentLedger(agentDir, 100); !reflect.DeepEqual(wrapped, recent) {
+				t.Fatalf("DaemonRecentLedger = %+v, want summary recent rows %+v", wrapped, recent)
+			}
+		})
+	}
+}
 
 func TestDaemonRecentLedgerMissing(t *testing.T) {
 	agentDir := t.TempDir()

--- a/tui/internal/fs/daemon_ledger_test.go
+++ b/tui/internal/fs/daemon_ledger_test.go
@@ -68,26 +68,6 @@ func TestDaemonLedgerSummaryEmptyStates(t *testing.T) {
 	}
 }
 
-func TestDaemonRecentLedgerMissing(t *testing.T) {
-	agentDir := t.TempDir()
-	// No daemons/ directory at all → empty, not an error.
-	entries := DaemonRecentLedger(agentDir, 100)
-	if len(entries) != 0 {
-		t.Fatalf("expected empty, got %d entries", len(entries))
-	}
-}
-
-func TestDaemonRecentLedgerEmptyDaemonsDir(t *testing.T) {
-	agentDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(agentDir, "daemons"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	entries := DaemonRecentLedger(agentDir, 100)
-	if len(entries) != 0 {
-		t.Fatalf("expected empty, got %d entries", len(entries))
-	}
-}
-
 func TestDaemonRecentLedgerTagsIdentity(t *testing.T) {
 	agentDir := t.TempDir()
 	// Daemon run with a daemon.json identity card and one ledger entry.
@@ -295,25 +275,6 @@ func TestDaemonRecentLedgerMissingDaemonJSON(t *testing.T) {
 }
 
 // --- Existing aggregated-totals tests (through unified API) ---
-
-func TestDaemonLedgerSummaryNoDaemonsDir(t *testing.T) {
-	agentDir := t.TempDir()
-	got, _ := DaemonLedgerSummary(agentDir, 0)
-	if len(got) != 0 {
-		t.Fatalf("expected empty map, got %d entries", len(got))
-	}
-}
-
-func TestDaemonLedgerSummaryEmptyDaemonsDir(t *testing.T) {
-	agentDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(agentDir, "daemons"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	got, _ := DaemonLedgerSummary(agentDir, 0)
-	if len(got) != 0 {
-		t.Fatalf("expected empty map, got %d entries", len(got))
-	}
-}
 
 func TestDaemonLedgerSummaryGroupsByProvider(t *testing.T) {
 	agentDir := t.TempDir()

--- a/tui/internal/fs/rebuild_marker_test.go
+++ b/tui/internal/fs/rebuild_marker_test.go
@@ -7,7 +7,24 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+type recentEventTimesCase struct {
+	name           string
+	eventType      string
+	recentTimes    func(string, int) []time.Time
+	tailOnlyUnix   int64
+	hugePrefixUnix int64
+}
+
+// Exercise each event-type-independent tail mechanic through both public entry
+// points. The timestamp literals preserve the formerly separate rebuild and
+// refresh-complete fixtures while sharing their filesystem setup.
+var recentEventTimesCases = []recentEventTimesCase{
+	{name: "rebuild", eventType: "psyche_molt", recentTimes: RecentRebuildTimes, tailOnlyUnix: 99999, hugePrefixUnix: 88888},
+	{name: "refresh_complete", eventType: "refresh_complete", recentTimes: RecentRefreshCompleteTimes, tailOnlyUnix: 77777, hugePrefixUnix: 66666},
+}
 
 func TestRecentRebuildTimesJSONLFallback(t *testing.T) {
 	agentDir := t.TempDir()
@@ -37,29 +54,33 @@ func TestRecentRebuildTimesJSONLFallback(t *testing.T) {
 }
 
 func TestRecentRebuildTimesJSONLTailOnly(t *testing.T) {
-	agentDir := t.TempDir()
-	logsDir := filepath.Join(agentDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// A molt event far above the tail window must NOT be seen; only the
-	// recent tail is inspected, per the no-full-scan constraint.
-	var b strings.Builder
-	b.WriteString(`{"type":"psyche_molt","ts":1.0}` + "\n") // line 1 — outside the tail
-	for i := 0; i < tailScanLines+50; i++ {
-		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
-	}
-	b.WriteString(`{"type":"psyche_molt","ts":99999.0}` + "\n") // near end — inside the tail
-	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range recentEventTimesCases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentDir := t.TempDir()
+			logsDir := filepath.Join(agentDir, "logs")
+			if err := os.MkdirAll(logsDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			// An event far above the tail window must NOT be seen; only the
+			// recent tail is inspected, per the no-full-scan constraint.
+			var b strings.Builder
+			fmt.Fprintf(&b, `{"type":%q,"ts":1.0}`+"\n", tc.eventType) // line 1 — outside the tail
+			for i := 0; i < tailScanLines+50; i++ {
+				fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
+			}
+			fmt.Fprintf(&b, `{"type":%q,"ts":%d.0}`+"\n", tc.eventType, tc.tailOnlyUnix) // near end — inside the tail
+			if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	times := RecentRebuildTimes(agentDir, 10)
-	if len(times) != 1 {
-		t.Fatalf("expected only the in-tail molt, got %d", len(times))
-	}
-	if times[0].Unix() != 99999 {
-		t.Fatalf("expected the recent molt (99999), got %d", times[0].Unix())
+			times := tc.recentTimes(agentDir, 10)
+			if len(times) != 1 {
+				t.Fatalf("expected only the in-tail %s, got %d", tc.eventType, len(times))
+			}
+			if times[0].Unix() != tc.tailOnlyUnix {
+				t.Fatalf("expected the recent %s (%d), got %d", tc.eventType, tc.tailOnlyUnix, times[0].Unix())
+			}
+		})
 	}
 }
 
@@ -91,38 +112,46 @@ func TestRecentRebuildTimesJSONLTailIncludesOldestLineInWindow(t *testing.T) {
 }
 
 func TestRecentRebuildTimesHugePrefixLineDoesNotBlockTail(t *testing.T) {
-	agentDir := t.TempDir()
-	logsDir := filepath.Join(agentDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// A >1MiB prefix line, far outside the last-1000-line window. A naive
-	// bufio.Scanner with a 1MiB token cap chokes on this line and stops,
-	// hiding the recent molt. The true tail reader must seek past it.
-	var b strings.Builder
-	huge := strings.Repeat("x", 2*1024*1024)
-	fmt.Fprintf(&b, `{"type":"text_input","ts":1.0,"junk":"%s"}`+"\n", huge)
-	for i := 0; i < tailScanLines+50; i++ {
-		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
-	}
-	b.WriteString(`{"type":"psyche_molt","ts":88888.0}` + "\n") // in the tail
-	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range recentEventTimesCases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentDir := t.TempDir()
+			logsDir := filepath.Join(agentDir, "logs")
+			if err := os.MkdirAll(logsDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			// A >1MiB prefix line, far outside the last-1000-line window. A naive
+			// bufio.Scanner with a 1MiB token cap chokes on this line and stops,
+			// hiding the recent event. The true tail reader must seek past it.
+			var b strings.Builder
+			huge := strings.Repeat("x", 2*1024*1024)
+			fmt.Fprintf(&b, `{"type":"text_input","ts":1.0,"junk":"%s"}`+"\n", huge)
+			for i := 0; i < tailScanLines+50; i++ {
+				fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
+			}
+			fmt.Fprintf(&b, `{"type":%q,"ts":%d.0}`+"\n", tc.eventType, tc.hugePrefixUnix) // in the tail
+			if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	times := RecentRebuildTimes(agentDir, 10)
-	if len(times) != 1 {
-		t.Fatalf("expected the in-tail molt despite huge prefix line, got %d", len(times))
-	}
-	if times[0].Unix() != 88888 {
-		t.Fatalf("expected the recent molt (88888), got %d", times[0].Unix())
+			times := tc.recentTimes(agentDir, 10)
+			if len(times) != 1 {
+				t.Fatalf("expected the in-tail %s despite huge prefix line, got %d", tc.eventType, len(times))
+			}
+			if times[0].Unix() != tc.hugePrefixUnix {
+				t.Fatalf("expected the recent %s (%d), got %d", tc.eventType, tc.hugePrefixUnix, times[0].Unix())
+			}
+		})
 	}
 }
 
 func TestRecentRebuildTimesMissingLogsIsEmpty(t *testing.T) {
-	times := RecentRebuildTimes(t.TempDir(), 10)
-	if len(times) != 0 {
-		t.Fatalf("expected no markers for missing logs, got %d", len(times))
+	for _, tc := range recentEventTimesCases {
+		t.Run(tc.name, func(t *testing.T) {
+			times := tc.recentTimes(t.TempDir(), 10)
+			if len(times) != 0 {
+				t.Fatalf("expected no %s markers for missing logs, got %d", tc.eventType, len(times))
+			}
+		})
 	}
 }
 

--- a/tui/internal/fs/refresh_marker_test.go
+++ b/tui/internal/fs/refresh_marker_test.go
@@ -1,7 +1,6 @@
 package fs
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,65 +33,6 @@ func TestRecentRefreshCompleteTimesJSONLFallback(t *testing.T) {
 	}
 	if times[0].Unix() != 1300 || times[1].Unix() != 1100 {
 		t.Fatalf("expected newest-first (1300,1100), got %d,%d", times[0].Unix(), times[1].Unix())
-	}
-}
-
-func TestRecentRefreshCompleteTimesJSONLTailOnly(t *testing.T) {
-	agentDir := t.TempDir()
-	logsDir := filepath.Join(agentDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// A refresh_complete far above the tail window must NOT be seen; only the
-	// recent tail is inspected, per the no-full-scan constraint.
-	var b strings.Builder
-	b.WriteString(`{"type":"refresh_complete","ts":1.0}` + "\n") // line 1 — outside the tail
-	for i := 0; i < tailScanLines+50; i++ {
-		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
-	}
-	b.WriteString(`{"type":"refresh_complete","ts":77777.0}` + "\n") // near end — inside the tail
-	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	times := RecentRefreshCompleteTimes(agentDir, 10)
-	if len(times) != 1 {
-		t.Fatalf("expected only the in-tail refresh_complete, got %d", len(times))
-	}
-	if times[0].Unix() != 77777 {
-		t.Fatalf("expected the recent refresh_complete (77777), got %d", times[0].Unix())
-	}
-}
-
-func TestRecentRefreshCompleteTimesHugePrefixLineDoesNotBlockTail(t *testing.T) {
-	agentDir := t.TempDir()
-	logsDir := filepath.Join(agentDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	var b strings.Builder
-	huge := strings.Repeat("x", 2*1024*1024)
-	fmt.Fprintf(&b, `{"type":"text_input","ts":1.0,"junk":"%s"}`+"\n", huge)
-	for i := 0; i < tailScanLines+50; i++ {
-		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
-	}
-	b.WriteString(`{"type":"refresh_complete","ts":66666.0}` + "\n")
-	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	times := RecentRefreshCompleteTimes(agentDir, 10)
-	if len(times) != 1 {
-		t.Fatalf("expected the in-tail refresh_complete despite huge prefix line, got %d", len(times))
-	}
-	if times[0].Unix() != 66666 {
-		t.Fatalf("expected the recent refresh_complete (66666), got %d", times[0].Unix())
-	}
-}
-
-func TestRecentRefreshCompleteTimesMissingLogsIsEmpty(t *testing.T) {
-	if times := RecentRefreshCompleteTimes(t.TempDir(), 10); len(times) != 0 {
-		t.Fatalf("expected no markers for missing logs, got %d", len(times))
 	}
 }
 

--- a/tui/internal/fs/session_window_test.go
+++ b/tui/internal/fs/session_window_test.go
@@ -204,12 +204,24 @@ func TestWindowedExactEqualWindowIsComplete(t *testing.T) {
 		t.Fatal("an exact authoritative window reaching offset zero must be complete")
 	}
 
-	// A larger request remains complete and stable.
-	scNext := NewSessionCache(humanDir, root, MainAggregateWriter)
-	scNext.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 8)
-	assertSessionBodiesExactly(t, scNext.Entries(), "e0", "e1", "e2", "e3")
-	if !scNext.Complete() {
-		t.Fatal("the request after an exact-equal window must resolve to complete — no endless partial")
+	// Larger requests remain complete and stable. Keep both the immediate
+	// post-boundary input and a window much larger than the whole history; the
+	// latter may be persisted like an ordinary full rebuild because it is complete.
+	for _, tc := range []struct {
+		name   string
+		window int
+	}{
+		{name: "next_after_exact_equal", window: 8},
+		{name: "much_larger_than_history", window: 2000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scNext := NewSessionCache(humanDir, root, MainAggregateWriter)
+			scNext.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", tc.window)
+			assertSessionBodiesExactly(t, scNext.Entries(), "e0", "e1", "e2", "e3")
+			if !scNext.Complete() {
+				t.Fatalf("window %d >= history must resolve to complete — no endless partial", tc.window)
+			}
+		})
 	}
 }
 

--- a/tui/internal/fs/session_window_test.go
+++ b/tui/internal/fs/session_window_test.go
@@ -545,24 +545,6 @@ func TestSessionMetadataCanonicalDepthLimit(t *testing.T) {
 	}
 }
 
-// TestWindowedRebuildLargerThanHistoryIsComplete proves that when the window is
-// at least as large as the whole event history, the cache is Complete() and may
-// be persisted like an ordinary full rebuild.
-func TestWindowedRebuildLargerThanHistoryIsComplete(t *testing.T) {
-	sqliteBin := requireSessionSQLite(t)
-	root, humanDir, orchDir := newSessionTestDirs(t)
-	buildWindowSQLiteEvents(t, sqliteBin, orchDir, 4)
-
-	sc := NewSessionCache(humanDir, root, MainAggregateWriter)
-	cache := NewMailCache(humanDir).Refresh()
-	sc.RebuildFromSourcesWindowedInMemory(cache, "human", orchDir, "orch", 2000)
-
-	assertSessionBodiesExactly(t, sc.Entries(), "e0", "e1", "e2", "e3")
-	if !sc.Complete() {
-		t.Fatal("window >= history must report Complete()==true")
-	}
-}
-
 // TestPersistRefusesPartialWindowedCache proves persistence safety: a partial
 // (windowed) cache must NOT rewrite human/logs/session.jsonl as if complete.
 func TestPersistRefusesPartialWindowedCache(t *testing.T) {

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -445,20 +445,6 @@ func TestResolveRefs_PerAccountCodexAuth(t *testing.T) {
 	}
 }
 
-// TestResolveRefs_CodexFallsBackToGlobalBoolWithoutDir verifies that when
-// CodexAuthDir is empty, codex validity falls back to the legacy global bool
-// (backward compatibility for callers that don't set the dir).
-func TestResolveRefs_CodexFallsBackToGlobalBoolWithoutDir(t *testing.T) {
-	dir := t.TempDir()
-	codexRef := writeCodexPresetWithAuthPath(t, dir, "codex", "")
-	if got := ResolveRefsWithAuth([]string{codexRef}, nil, AuthState{CodexOAuthConfigured: true}); !got[0].HasKey {
-		t.Error("with CodexOAuthConfigured=true and no dir, codex should be valid")
-	}
-	if got := ResolveRefsWithAuth([]string{codexRef}, nil, AuthState{CodexOAuthConfigured: false}); got[0].HasKey {
-		t.Error("with CodexOAuthConfigured=false and no dir, codex should be invalid")
-	}
-}
-
 func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 	withTempPresets(t, func() {
 		p := DefaultPreset()

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -286,6 +286,8 @@ func writePresetFile(t *testing.T, dir, name, provider, apiKeyEnv string) string
 func TestResolveRefs_ValidityGuard(t *testing.T) {
 	dir := t.TempDir()
 	codexRef := writePresetFile(t, dir, "codex", "codex", "")
+	legacyCodexDir := t.TempDir()
+	legacyCodexRef := writeCodexPresetWithAuthPath(t, legacyCodexDir, "codex", "")
 	claudeRef := writePresetFile(t, dir, "claude", "claude-code", "")
 	claudeUnderscoreRef := writePresetFile(t, dir, "claude_agent_sdk", "claude_agent_sdk", "")
 	customRef := writePresetFile(t, dir, "custom", "custom", "")
@@ -303,8 +305,14 @@ func TestResolveRefs_ValidityGuard(t *testing.T) {
 		wantExists bool
 		wantHasKey bool
 	}{
+		// When CodexAuthDir is empty, codex validity falls back to the legacy
+		// global bool for backward compatibility with callers that do not set the dir.
 		{"codex no OAuth", codexRef, keysEmpty, AuthState{}, true, false},
 		{"codex with OAuth", codexRef, keysEmpty, AuthState{CodexOAuthConfigured: true}, true, true},
+		// Keep the original no-dir fixture and nil key-map inputs in both bool
+		// directions as explicit legacy-compat rows.
+		{"codex legacy global bool false without dir", legacyCodexRef, nil, AuthState{CodexOAuthConfigured: false}, true, false},
+		{"codex legacy global bool true without dir", legacyCodexRef, nil, AuthState{CodexOAuthConfigured: true}, true, true},
 		{"claude-code no CLI auth", claudeRef, keysEmpty, AuthState{}, true, false},
 		{"claude-code with CLI auth", claudeRef, keysEmpty, AuthState{ClaudeCodeAuthConfigured: true}, true, true},
 		{"claude_agent_sdk alias with CLI auth", claudeUnderscoreRef, keysEmpty, AuthState{ClaudeCodeAuthConfigured: true}, true, true},


### PR DESCRIPTION
## Summary

- consolidate repeated runtime-mechanics test cases into parameterized semantic owners
- retain every RSS, quick-entry, eigen refresh, language-helper, and CLI-build behavior while removing 12 duplicate/subset functions
- keep the change test-only: 7 existing Go test files, 177 insertions and 234 deletions; no production code and no new files

## Tests-first evidence

- surviving owners were strengthened before duplicate removal
- 15 targeted behavior mutations were run against the final surviving owners; all 15 went RED and were restored
- targeted package tests, `go vet`, compile-only coverage, and the TUI build pass

## Independent review

Literal Claude Opus 5 reviewed the exact final commit in read-only mode: PASS, 0 P0 and 0 P1. Three P2 observations were nonblocking.

## Scope

This PR only consolidates test ownership. It does not change runtime behavior, merge anything, or act on maintainer-decision findings from the audit.
