### PR TITLE
test: remove subsumed and vacuous LingTai tests

### DIFF
--- a/portal/internal/fs/network_test.go
+++ b/portal/internal/fs/network_test.go
@@ -42,19 +42,6 @@ func writeHeartbeat(t *testing.T, dir string) {
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(content), 0o644)
 }
 
-func TestBuildNetwork_Portal(t *testing.T) {
-	base := setupPortalTestNetwork(t)
-
-	net, err := BuildNetwork(base)
-	if err != nil {
-		t.Fatalf("build network: %v", err)
-	}
-
-	if len(net.Nodes) != 3 {
-		t.Errorf("nodes = %d, want 3", len(net.Nodes))
-	}
-}
-
 func TestBuildNetworkWithOptionsSkipsMailEdges(t *testing.T) {
 	base := setupPortalTestNetwork(t)
 	writeMailMessage(t, filepath.Join(base, "alice"), "inbox", "msg-1", MailMessage{

--- a/tui/i18n/i18n_test.go
+++ b/tui/i18n/i18n_test.go
@@ -206,13 +206,6 @@ func TestT_ReturnsEnglishString(t *testing.T) {
 	}
 }
 
-func TestT_UnknownKeyReturnsKey(t *testing.T) {
-	got := T("nonexistent.key")
-	if got != "nonexistent.key" {
-		t.Errorf("T(\"nonexistent.key\") = %q, want %q", got, "nonexistent.key")
-	}
-}
-
 func TestT_FallsBackToEnglishWhenActiveLocaleMissesKey(t *testing.T) {
 	t.Cleanup(func() { SetLang("en") })
 

--- a/tui/internal/config/devmode_test.go
+++ b/tui/internal/config/devmode_test.go
@@ -36,14 +36,6 @@ func TestFindDevCheckoutsRequiresExplicitEnv(t *testing.T) {
 	}
 }
 
-func TestFindDevCheckoutsReturnsFalseWhenAbsent(t *testing.T) {
-	home := t.TempDir()
-	lookupEnv := func(string) (string, bool) { return "", false }
-	if _, ok := findDevCheckouts(home, lookupEnv); ok {
-		t.Fatalf("expected no dev checkouts in an empty home")
-	}
-}
-
 func TestFindDevCheckoutsRequiresKernelPyproject(t *testing.T) {
 	home := t.TempDir()
 	// Kernel dir + sibling TUI repo exist, but no pyproject.toml in the kernel.

--- a/tui/internal/config/tui_updater_test.go
+++ b/tui/internal/config/tui_updater_test.go
@@ -489,25 +489,6 @@ func TestSourceTUIUpdaterRequiresKnownRelease(t *testing.T) {
 	}
 }
 
-func TestUnknownTUIUpdaterDoesNotRunBrew(t *testing.T) {
-	runner := &fakeRunner{}
-	result := RunTUIUpdate(TUIInstallInfo{Method: TUIInstallMethodUnknown}, TUIUpdateOptions{
-		LatestVersion: "v0.8.1",
-		Runner:        runner,
-		LookPath:      func(string) (string, error) { return "/opt/homebrew/bin/brew", nil },
-	})
-
-	if !result.Healthy {
-		t.Fatalf("unknown updater guidance should not fail doctor-style update: %+v", result.Lines)
-	}
-	if !containsLine(result.Lines, "TUI install method is unknown") {
-		t.Fatalf("expected unknown updater guidance, got %+v", result.Lines)
-	}
-	if containsCall(runner.calls, "brew") {
-		t.Fatalf("unknown updater must not run brew, got %#v", runner.calls)
-	}
-}
-
 func TestTUIUpdaterSourceMetadataFailureDoesNotRunBrew(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/tui/internal/preset/preset_addons_default_test.go
+++ b/tui/internal/preset/preset_addons_default_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -290,15 +289,5 @@ func TestGenerateInitJSONDropsInvalidLegacyDictKey(t *testing.T) {
 	}
 	if names["imap;rm"] {
 		t.Errorf("invalid legacy key must not be preserved, got %v", addons)
-	}
-}
-
-// Cosmetic: confirm runtime.GOOS-aware venv python path resolution
-// produces a sensible string. Not a behavior test; just makes sure the
-// fragment matching in TestGenerateInitJSONWritesNewShapeWithLocalVenv
-// uses the right separator on Windows.
-func TestVenvPythonPathFragment(t *testing.T) {
-	if runtime.GOOS == "windows" && filepath.Separator != '\\' {
-		t.Errorf("unexpected separator on windows: %q", filepath.Separator)
 	}
 }

--- a/tui/internal/preset/skills/lingtai-recipe/scripts/test_validate_recipe.py
+++ b/tui/internal/preset/skills/lingtai-recipe/scripts/test_validate_recipe.py
@@ -315,16 +315,6 @@ def test_unknown_lang_subdir_under_layer_warns(tmp_path: Path) -> None:
     assert "fr" in result.stdout and "unknown lang" in result.stdout
 
 
-def test_unknown_greet_locale_warns(tmp_path: Path) -> None:
-    _make_valid_bundle(tmp_path)
-    fr_greet = tmp_path / ".recipe" / "greet" / "fr"
-    fr_greet.mkdir()
-    (fr_greet / "greet.md").write_text("bonjour", encoding="utf-8")
-    result = _run(tmp_path)
-    assert result.returncode == 0
-    assert "unknown lang" in result.stdout
-
-
 def test_stray_file_at_recipe_root_warns(tmp_path: Path) -> None:
     _make_valid_bundle(tmp_path)
     (tmp_path / ".recipe" / "README.md").write_text("stray", encoding="utf-8")

--- a/tui/internal/process/check_test.go
+++ b/tui/internal/process/check_test.go
@@ -29,15 +29,6 @@ func TestParsePSOutputPrefixMismatch(t *testing.T) {
 	}
 }
 
-func TestParsePSOutputEOL(t *testing.T) {
-	abs := "/work/foo"
-	out := "  1234 python -m lingtai run /work/foo\n"
-	got := parsePSOutput(out, abs)
-	if len(got) != 1 || got[0].PID != 1234 {
-		t.Fatalf("EOL match failed: %+v", got)
-	}
-}
-
 func TestParsePSOutputIgnoresUnrelated(t *testing.T) {
 	abs := "/work/foo"
 	out := `  100 sshd

--- a/tui/internal/tui/daemons_test.go
+++ b/tui/internal/tui/daemons_test.go
@@ -163,60 +163,6 @@ func TestLoadDaemonSummariesDefersHeavyDetailReads(t *testing.T) {
 	}
 }
 
-func TestLoadDaemonDetailReadsHeavyFiles(t *testing.T) {
-	agentDir := t.TempDir()
-	daemonDir := filepath.Join(agentDir, "daemons", "em-7-20260609-010203-abcdef")
-	if err := os.MkdirAll(filepath.Join(daemonDir, "logs"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(daemonDir, "history"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	write := func(path, body string) {
-		t.Helper()
-		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	write(filepath.Join(daemonDir, "daemon.json"), `{"task":"t","state":"done","backend":"lingtai"}`)
-	write(filepath.Join(daemonDir, "logs", "events.jsonl"), strings.Join([]string{
-		`{"ts":"2026-06-09T01:02:04Z","event":"daemon_start"}`,
-		`{"ts":"2026-06-09T01:02:05Z","event":"tool_call","name":"read"}`,
-		`{"ts":"2026-06-09T01:02:06Z","event":"tool_result","name":"read","status":"ok"}`,
-	}, "\n"))
-	write(filepath.Join(daemonDir, "history", "chat_history.jsonl"), `{"role":"assistant","text":"task done","ts":"2026-06-09T01:02:07Z"}`)
-	write(filepath.Join(daemonDir, "logs", "token_ledger.jsonl"), strings.Join([]string{
-		`{"input":10,"output":4,"thinking":2,"cached":7}`,
-		`{"input":3,"output":1,"thinking":0,"cached":2}`,
-	}, "\n"))
-	write(filepath.Join(daemonDir, "result.txt"), "full result")
-
-	items, err := loadDaemonSummaries(agentDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := loadDaemonDetail(items[0])
-	if !got.DetailLoaded {
-		t.Fatalf("loadDaemonDetail did not mark DetailLoaded")
-	}
-	if got.EventCount != 3 || got.ToolCount != 2 || len(got.Events) != 3 || got.LastEventAt != "2026-06-09T01:02:06Z" {
-		t.Fatalf("events not loaded: count=%d tools=%d events=%d last=%q", got.EventCount, got.ToolCount, len(got.Events), got.LastEventAt)
-	}
-	if got.Tokens.Calls != 2 || got.Tokens.Input != 13 || got.Tokens.Output != 5 {
-		t.Fatalf("tokens not loaded: %#v", got.Tokens)
-	}
-	if len(got.Chats) != 1 || got.Chats[0].Text != "task done" {
-		t.Fatalf("chats not loaded: %#v", got.Chats)
-	}
-	if got.Result != "full result" {
-		t.Fatalf("result not loaded: %q", got.Result)
-	}
-	// Light metadata from the list path is preserved through detail load.
-	if got.Task != "t" || got.State != "done" {
-		t.Fatalf("list metadata lost in detail load: %#v", got)
-	}
-}
-
 func TestDaemonsSelectionLoadsDetailLazily(t *testing.T) {
 	agentDir := t.TempDir()
 	mk := func(name, task string) {

--- a/tui/internal/tui/home_telemetry_height_test.go
+++ b/tui/internal/tui/home_telemetry_height_test.go
@@ -37,19 +37,3 @@ func TestMailFooterHeightBaseline(t *testing.T) {
 		}
 	}
 }
-
-// Reserving the telemetry row shrinks the viewport by exactly one line, which is
-// what keeps the status bar on-screen. This pins the viewport arithmetic that
-// syncViewportHeight performs so a future refactor can't silently re-clip the
-// bottom bar.
-func TestViewportHeightLeavesRoomForTelemetryRow(t *testing.T) {
-	const termHeight, header, banners = 30, 2, 0
-	palette, input := 0, 1
-
-	vpWithout := termHeight - header - banners - mailFooterHeight(palette, input, false)
-	vpWith := termHeight - header - banners - mailFooterHeight(palette, input, true)
-
-	if vpWith != vpWithout-1 {
-		t.Fatalf("telemetry row must cost exactly one viewport line: without=%d with=%d", vpWithout, vpWith)
-	}
-}

--- a/tui/internal/tui/login_test.go
+++ b/tui/internal/tui/login_test.go
@@ -427,36 +427,6 @@ func TestLoginModel_CodexRowShownWithExistingEntry(t *testing.T) {
 	}
 }
 
-// TestLoginModel_ReauthExistingAccountTargetsItsFile verifies that r on an
-// existing Codex account entry sets the login target to THAT account's token
-// file, so re-auth overwrites the right account rather than creating a new one.
-// (Enter now sets the account active; re-auth moved to r.)
-func TestLoginModel_ReauthExistingAccountTargetsItsFile(t *testing.T) {
-	_, globalDir := withTempCodexHome(t)
-	seedLoginCodexAuth(t, globalDir)
-
-	m := NewLoginModel("", globalDir)
-	if len(m.entries) != 1 || m.entries[0].Provider != "codex" {
-		t.Fatalf("precondition: expected single codex entry; got %#v", m.entries)
-	}
-	wantPath := m.entries[0].CodexPath
-	if wantPath == "" {
-		t.Fatal("codex entry should carry its token file path")
-	}
-	// cursor starts at 0 (the codex entry). r re-auths this account.
-	r := tea.KeyPressMsg{Text: "r", Code: 'r'}
-	m, cmd := m.Update(r)
-	if cmd != nil {
-		t.Fatal("r on a codex entry must not start a network command")
-	}
-	if !m.codexChoosingMethod {
-		t.Fatal("r on a codex entry should open the method chooser")
-	}
-	if m.codexLoginTargetPath != wantPath {
-		t.Fatalf("re-auth should target the account's own file %q; got %q", wantPath, m.codexLoginTargetPath)
-	}
-}
-
 // TestLoginModel_AddAccountWritesNewFileNotLegacy verifies that completing an
 // "add another account" login (empty target) when a legacy account already
 // exists writes a NEW per-account file under codex-auth/ rather than

--- a/tui/internal/tui/notification_test.go
+++ b/tui/internal/tui/notification_test.go
@@ -103,11 +103,6 @@ func TestNotificationModelNoSnapshots(t *testing.T) {
 	}
 }
 
-// TestNotificationModelNoBlocks is a backward-compat alias for TestNotificationModelNoSnapshots.
-func TestNotificationModelNoBlocks(t *testing.T) {
-	TestNotificationModelNoSnapshots(t)
-}
-
 // TestNotificationModelWithSnapshots exercises snapshot loading and renders actual block content.
 func TestNotificationModelWithSnapshots(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -156,12 +151,6 @@ func TestNotificationModelWithSnapshots(t *testing.T) {
 			t.Fatalf("all blocks entry should contain %q: %s", want, content)
 		}
 	}
-}
-
-// TestNotificationModelWithBlocks delegates to TestNotificationModelWithSnapshots
-// for backward compatibility with test names.
-func TestNotificationModelWithBlocks(t *testing.T) {
-	TestNotificationModelWithSnapshots(t)
 }
 
 // TestNotificationModelNavigation checks left/right key navigation among snapshots.
@@ -512,42 +501,6 @@ func makeNotificationSnapshotDB(t *testing.T, bin string, fieldsJSONs []string) 
 	}
 	if out, err := exec.Command(bin, db, sql).CombinedOutput(); err != nil {
 		t.Fatalf("makeNotificationSnapshotDB: %v\n%s", err, out)
-	}
-	return agentDir
-}
-
-// makeNotificationDB is a legacy helper retained for existing tests that
-// insert notification_pair_injected rows to test the query layer directly.
-func makeNotificationDB(t *testing.T, bin string, fieldsJSONs []string) string {
-	t.Helper()
-	agentDir := t.TempDir()
-	logsDir := filepath.Join(agentDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	db := filepath.Join(logsDir, "log.sqlite")
-	sql := `CREATE TABLE events (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		ts REAL NOT NULL,
-		type TEXT NOT NULL,
-		agent_address TEXT,
-		fields_json TEXT NOT NULL DEFAULT '{}',
-		source_file TEXT,
-		source_offset INTEGER,
-		source_line INTEGER,
-		source_kind TEXT,
-		scope TEXT,
-		run_id TEXT,
-		inserted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-	);`
-	for i, fj := range fieldsJSONs {
-		sql += fmt.Sprintf(
-			"\nINSERT INTO events(ts,type,fields_json) VALUES(%d.0,'notification_pair_injected','%s');",
-			1000+i, fj,
-		)
-	}
-	if out, err := exec.Command(bin, db, sql).CombinedOutput(); err != nil {
-		t.Fatalf("makeNotificationDB: %v\n%s", err, out)
 	}
 	return agentDir
 }

--- a/tui/internal/tui/project_create_test.go
+++ b/tui/internal/tui/project_create_test.go
@@ -802,19 +802,6 @@ func TestRunProjectCreate_SuccessPublishesResolvableSavedRefAndCredentialsBefore
 	}
 }
 
-// TestRunProjectCreate_NilDraft proves a nil draft fails closed rather than
-// panicking or creating anything.
-func TestRunProjectCreate_NilDraft(t *testing.T) {
-	opts := testCreateOptions(t, t.TempDir())
-	res := RunProjectCreate(nil, opts)
-	if res.Committed {
-		t.Fatal("expected Committed=false for nil draft")
-	}
-	if res.Err == nil {
-		t.Fatal("expected an error for nil draft")
-	}
-}
-
 // --- Invariant 5: unfinished staging detection/discard ---------------------
 
 // TestDetectUnfinishedStaging_ReadOnlyAndMarkerGated proves
@@ -1085,9 +1072,8 @@ func TestRunProjectCreate_ProjectRootMustMatchApprovedDestination(t *testing.T) 
 	assertSnapshotsEqual(t, "approved root after destination mismatch", approvedBefore, dirSnapshot(t, approvedRoot))
 }
 
-// TestRunProjectCreate_NilDraftNeverWrites is the pre-existing nil-draft
-// guard (TestRunProjectCreate_NilDraft above), extended to additionally
-// prove no write occurs — nil is the most trivially "invalid" draft of all,
+// TestRunProjectCreate_NilDraftNeverWrites proves the nil-draft guard fails
+// closed without touching disk — nil is the most trivially "invalid" draft of all,
 // and it's worth confirming the same "byte-for-byte parent" standard the
 // other invalid-draft cases are held to.
 func TestRunProjectCreate_NilDraftNeverWrites(t *testing.T) {


### PR DESCRIPTION
## Summary

This branch accounts for all 14 LT-A audit units by removing test code that was an exact subset, a literal alias, unreachable, dead, or otherwise vacuous while retaining the executable owners.

- Branch: `tzzheng/remove-subsumed-lingtai-tests`
- Head: `59371da8`
- Exact scope: **12 files changed, 2 insertions, 240 deletions**

## What changed

- Removed ten feasible subset cases only after their stronger retained owners were identified and exercised.
- Removed one unsatisfiable platform assertion, two literal notification aliases, and one uncalled helper; the orphaned `runtime` import left by the unsatisfiable case was removed with it.
- No assertion was moved or strengthened. The final diff contains only the mapped test targets, target-local comments, the orphan import, and a parent-amended owner comment.

## Validation

- **RED chronology:** before implementation, ten temporary production mutations each made the cited retained owner fail at the intended assertion with exit 1. Each mutation was restored immediately. After the tenth probe, the tree was clean at base `889e6027d2556949161321c5d1db65d7ed779055` before any removal.
- The remaining four units had explicit non-mutation proofs: an unsatisfiable OS/separator conjunction, two literal call-through aliases, and a helper with no caller.
- Parent-recorded focused gates passed for portal fs, TUI i18n/config/preset/process, the retained TUI-owner cluster, and the full recipe validator (**28 passed**). Portal and TUI vet/build gates also passed.
- No focused gate used deselections. The broader TUI module run passed every touched package but remained nonzero only at the root architecture-governance test; the same seven-path drift was reproduced at the exact base. The portal module required a temporary untracked embed placeholder because the base checkout lacks `portal/web/dist`; it was removed afterward.

## Review

Parent inspected the complete diff, found one surviving comment that would otherwise refer to a removed predecessor, and amended only that comment; the final head is clean and the amendment is behavior-neutral.

Literal Opus 5 review (`claude-opus-5`, high, plan): **PASS**, with **P0=0, P1=0, P2=1**. The reviewer verified exact base→head scope, all 14 mapped removals, retained-owner semantics, clean state, and the focused Go/Python gates. The sole nonblocking P2 is an empty gitignored `portal/web/dist` directory left after the temporary embed placeholder was removed; it is not part of the commit and does not create a false green.

## Boundaries

- **No production changes.** All production edits existed only as temporary RED probes and were restored before implementation.
- No OWNER/KEEP work, unrelated published unit, or architecture-governance debt was changed.
- This is a test-ownership cleanup, not a claim that product semantics were deleted or that the full repository suite is green.

Related: full-corpus test audit
