### PR TITLE
fix(release): pin installer to kernel v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,9 +248,12 @@ jobs:
             exit 1
           fi
           curl -fsSL "$manifest_url" -o /tmp/kernel-release-manifest.json
-          python3 - "$kernel_tag" "${TAG#v}" << 'PY'
+          # The kernel release is independently versioned from the TUI release;
+          # validate the manifest against the pinned kernel tag, not TAG.
+          python3 - "$kernel_tag" << 'PY'
           import json, re, sys
-          kernel_tag, kernel_version_expected = sys.argv[1], sys.argv[1].lstrip("v")
+          kernel_tag = sys.argv[1]
+          kernel_version_expected = kernel_tag.lstrip("v")
           data = json.load(open("/tmp/kernel-release-manifest.json"))
           if data.get("schema") != "lingtai.kernel.release/v1":
               sys.exit(f"kernel manifest has unexpected schema {data.get('schema')!r}")

--- a/kernel-release.json
+++ b/kernel-release.json
@@ -1,5 +1,5 @@
 {
   "schema": "lingtai.tui.kernel-pin/v1",
-  "kernel_tag": "v0.19.0",
+  "kernel_tag": "v1.0.0",
   "comment": "Repo-owned pin: the kernel release tag a TUI release binds into its bundle manifest. Bump this deliberately in the same PR/commit that intends to ship a new kernel version with the next TUI release; the release workflow never resolves 'latest kernel' on its own. See RELEASING.md."
 }

--- a/scripts/test-release-workflow-publish-gating.py
+++ b/scripts/test-release-workflow-publish-gating.py
@@ -94,6 +94,10 @@ def main() -> int:
           "windows-release must read the repo-owned kernel-release.json pin")
     check("kernel_tag" in windows_text and 'gh release view "$kernel_tag"' in windows_text,
           "windows-release must fail closed unless the pinned kernel release exists")
+    check('python3 - "$kernel_tag" << \'PY\'' in windows_text and
+          'kernel_version_expected = kernel_tag.lstrip("v")' in windows_text and
+          'python3 - "$kernel_tag" "${TAG#v}"' not in windows_text,
+          "kernel manifest validation must use the independently pinned kernel tag, not the TUI tag")
     check("win_amd64" in windows_text,
           "windows-release must require a win_amd64 kernel wheel before building")
     check("GOOS=windows GOARCH=amd64" in windows_text,


### PR DESCRIPTION
## Summary

The TUI installer release metadata still pinned the kernel to `v0.19.0` even though TUI release `v1.0.0` was intended to consume the published `Lingtai-AI/lingtai-kernel` `v1.0.0` release. The release workflow also incorrectly validated a pinned kernel manifest's version against the TUI tag, preventing independently versioned releases from being validated safely.

This change pins `kernel-release.json` to `v1.0.0` and makes the workflow derive the expected kernel version from `kernel_tag`, while retaining the separate `Lingtai-AI/lingtai-kernel` repository gate. A regression assertion prevents reintroducing TUI/kernel version coupling.

## Tests run

- `python3 scripts/test-release-workflow-publish-gating.py`
- `bash -n install.sh scripts/test-install-sh-hardening.sh scripts/test-install-sh-gitee-bundle.sh`
- `./scripts/test-install-sh-hardening.sh`
- `./scripts/test-install-sh-gitee-bundle.sh`
- `cd tui && go test ./internal/config`
- `cd tui && go build ./...`
- `git diff --check`

## Files changed

- `kernel-release.json`
- `.github/workflows/release.yml`
- `scripts/test-release-workflow-publish-gating.py`

Fixes #833

## Standing lines

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
