### PR TITLE
fix(tui): accept per-account Codex auth for presets

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -852,10 +852,12 @@ type ResolvedRef struct {
 	// is true.
 	HasKey bool
 	// CodexAuthRef is the codex preset's manifest.llm.codex_auth_path value
-	// (verbatim, possibly ""). Empty means the preset accepts any usable
-	// stored Codex account (legacy file or any per-account file). Only set
-	// for codex presets; "" for all others. Lets a UI surface which account
-	// a codex preset is bound to without re-reading the preset file.
+	// (verbatim, possibly ""). Empty with the field omitted or literal "" means
+	// the preset accepts any usable stored Codex account (legacy file or any
+	// per-account file); empty from a present wrong-type/whitespace value means
+	// the preset fails closed (see ResolvePresetWithAuth). Only set for codex
+	// presets; "" for all others. Lets a UI surface which account a codex
+	// preset is bound to without re-reading the preset file.
 	CodexAuthRef string
 }
 
@@ -1007,18 +1009,41 @@ func ResolvePresetWithAuth(p Preset, existingKeys map[string]string, auth AuthSt
 	r.Family = ClassifyCredentialFamily(r.Provider)
 	model, _ := llm["model"].(string)
 	apiKeyEnv, _ := llm["api_key_env"].(string)
-	r.CodexAuthRef, _ = llm["codex_auth_path"].(string)
+	codexAuthRaw, codexAuthPresent := llm["codex_auth_path"]
+	r.CodexAuthRef, _ = codexAuthRaw.(string) // "" for absent or wrong-type values
 	setAuth := func(ok bool) { r.HasKey = ok }
 	switch r.Family {
 	case CredentialFamilyCodexSingle:
-		if auth.CodexAuthDir != "" {
-			if strings.TrimSpace(r.CodexAuthRef) == "" {
+		codexAuthStr, codexAuthIsString := codexAuthRaw.(string)
+		switch {
+		case codexAuthPresent && !codexAuthIsString:
+			// Present but wrong-type explicit binding: fail closed.
+			setAuth(false)
+		case codexAuthPresent && codexAuthIsString && strings.TrimSpace(codexAuthStr) == "" && codexAuthStr != "":
+			// Whitespace-only explicit value: fail closed (canonical empty is
+			// an omitted field or literal "").
+			setAuth(false)
+		case codexAuthPresent && codexAuthIsString && strings.TrimSpace(codexAuthStr) != "":
+			// Explicit nonempty binding: never the aggregate bool. With a known
+			// dir, resolve exactly; without one, only absolute/"~" refs are
+			// checkable, and any other relative ref fails closed.
+			ref := strings.TrimSpace(codexAuthStr)
+			if auth.CodexAuthDir != "" {
+				setAuth(codexTokenFileValid(resolveCodexAuthRef(auth.CodexAuthDir, ref)))
+			} else if filepath.IsAbs(ref) || strings.HasPrefix(ref, "~/") || ref == "~" {
+				setAuth(codexTokenFileValid(resolveCodexAuthRef("", ref)))
+			} else {
+				setAuth(false)
+			}
+		default:
+			// Unbound (field omitted or canonical empty): accept any usable
+			// stored account when a dir is known, else the caller-provided
+			// aggregate signal.
+			if auth.CodexAuthDir != "" {
 				setAuth(anyCodexTokenFileValid(auth.CodexAuthDir))
 			} else {
-				setAuth(codexTokenFileValid(resolveCodexAuthRef(auth.CodexAuthDir, r.CodexAuthRef)))
+				setAuth(auth.CodexOAuthConfigured)
 			}
-		} else {
-			setAuth(auth.CodexOAuthConfigured)
 		}
 	case CredentialFamilyCodexPool:
 		if auth.CodexPoolEligibleModels != nil {

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -863,20 +863,19 @@ type ResolvedRef struct {
 // cannot derive from a preset file alone. Ordinary Codex OAuth, pool
 // membership, and fallback readiness remain separate facts.
 type AuthState struct {
-	// CodexOAuthConfigured is true when the legacy single-account token
-	// file ~/.lingtai-tui/codex-auth.json parses and carries a non-empty
-	// refresh_token. It is the fallback signal for a codex preset that
-	// declares no manifest.llm.codex_auth_path. The preset package must not
-	// import the tui package (import cycle), so this is computed by the
-	// caller and passed in.
+	// CodexOAuthConfigured is the caller-provided fallback signal for a codex
+	// preset that declares no manifest.llm.codex_auth_path when CodexAuthDir is
+	// empty. Callers that know the token store directory should set CodexAuthDir
+	// so the preset package can inspect legacy and per-account token files.
 	CodexOAuthConfigured bool
 
 	// CodexAuthDir is the directory (typically ~/.lingtai-tui) that
 	// per-account codex_auth_path values resolve against when they are
-	// relative or "~/"-prefixed. When set, resolveOneRef validates a codex
-	// preset's OWN bound token file at manifest.llm.codex_auth_path instead
-	// of the global CodexOAuthConfigured bool, so multiple Codex accounts
-	// are judged independently. Empty falls back to CodexOAuthConfigured.
+	// relative or "~/"-prefixed. When set, explicit manifest.llm.codex_auth_path
+	// values validate exactly that bound token file, so multiple Codex accounts
+	// are judged independently. An empty codex_auth_path means "default Codex
+	// credentials" and is valid when either the legacy token or any per-account
+	// token under codex-auth/ is usable. Empty falls back to CodexOAuthConfigured.
 	CodexAuthDir string
 
 	// CodexPoolEligible says that a flat pool has a usable positively weighted
@@ -913,6 +912,25 @@ func codexTokenFileValid(path string) bool {
 		RefreshToken string `json:"refresh_token"`
 	}
 	return json.Unmarshal(data, &tok) == nil && tok.RefreshToken != ""
+}
+
+func anyCodexTokenFileValid(authDir string) bool {
+	if codexTokenFileValid(filepath.Join(authDir, "codex-auth.json")) {
+		return true
+	}
+	entries, err := os.ReadDir(filepath.Join(authDir, "codex-auth"))
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		if codexTokenFileValid(filepath.Join(authDir, "codex-auth", e.Name())) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveCodexAuthRef expands a preset's manifest.llm.codex_auth_path against
@@ -994,7 +1012,11 @@ func ResolvePresetWithAuth(p Preset, existingKeys map[string]string, auth AuthSt
 	switch r.Family {
 	case CredentialFamilyCodexSingle:
 		if auth.CodexAuthDir != "" {
-			setAuth(codexTokenFileValid(resolveCodexAuthRef(auth.CodexAuthDir, r.CodexAuthRef)))
+			if strings.TrimSpace(r.CodexAuthRef) == "" {
+				setAuth(anyCodexTokenFileValid(auth.CodexAuthDir))
+			} else {
+				setAuth(codexTokenFileValid(resolveCodexAuthRef(auth.CodexAuthDir, r.CodexAuthRef)))
+			}
 		} else {
 			setAuth(auth.CodexOAuthConfigured)
 		}

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -852,10 +852,10 @@ type ResolvedRef struct {
 	// is true.
 	HasKey bool
 	// CodexAuthRef is the codex preset's manifest.llm.codex_auth_path value
-	// (verbatim, possibly ""). Empty means the preset uses the legacy
-	// single-account fallback file. Only set for codex presets; "" for all
-	// others. Lets a UI surface which account a codex preset is bound to
-	// without re-reading the preset file.
+	// (verbatim, possibly ""). Empty means the preset accepts any usable
+	// stored Codex account (legacy file or any per-account file). Only set
+	// for codex presets; "" for all others. Lets a UI surface which account
+	// a codex preset is bound to without re-reading the preset file.
 	CodexAuthRef string
 }
 
@@ -911,7 +911,7 @@ func codexTokenFileValid(path string) bool {
 	var tok struct {
 		RefreshToken string `json:"refresh_token"`
 	}
-	return json.Unmarshal(data, &tok) == nil && tok.RefreshToken != ""
+	return json.Unmarshal(data, &tok) == nil && strings.TrimSpace(tok.RefreshToken) != ""
 }
 
 func anyCodexTokenFileValid(authDir string) bool {

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -396,6 +396,19 @@ func writeStubTokenFile(t *testing.T, path string) {
 	}
 }
 
+// writeMalformedTokenFile writes a token file whose refresh_token is
+// whitespace-only, which the canonical account store rejects and the unbound
+// preset fallback must therefore ignore.
+func writeMalformedTokenFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"refresh_token":"   "}`), 0o600); err != nil {
+		t.Fatalf("write malformed token: %v", err)
+	}
+}
+
 // TestResolveRefs_PerAccountCodexAuth verifies that, when AuthState.CodexAuthDir
 // is set, each codex preset's validity is judged by ITS OWN bound token file
 // (manifest.llm.codex_auth_path), with an empty path falling back to the legacy
@@ -477,6 +490,29 @@ func TestResolveRefs_CodexDefaultAuthAcceptsAnyStoredAccount(t *testing.T) {
 		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
 		if len(got) != 1 || got[0].HasKey {
 			t.Fatalf("default codex preset with no auth = %#v, want HasKey=false", got)
+		}
+	})
+
+	t.Run("whitespace-only per-account token ignored with valid one present", func(t *testing.T) {
+		authDir := t.TempDir()
+		writeStubTokenFile(t, filepath.Join(authDir, "codex-auth", "work.json"))
+		writeMalformedTokenFile(t, filepath.Join(authDir, "codex-auth", "bad.json"))
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-bad-plus-good-default", "")
+
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
+		if len(got) != 1 || !got[0].HasKey {
+			t.Fatalf("default codex preset with bad+valid per-account auth = %#v, want HasKey=true", got)
+		}
+	})
+
+	t.Run("whitespace-only per-account token alone is not valid", func(t *testing.T) {
+		authDir := t.TempDir()
+		writeMalformedTokenFile(t, filepath.Join(authDir, "codex-auth", "bad.json"))
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-bad-only-default", "")
+
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
+		if len(got) != 1 || got[0].HasKey {
+			t.Fatalf("default codex preset with only whitespace token = %#v, want HasKey=false", got)
 		}
 	})
 

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -386,6 +386,29 @@ func writeCodexPresetWithAuthPath(t *testing.T, dir, name, authRef string) strin
 	return path
 }
 
+// writeCodexPresetWithRawAuthPath writes a codex preset whose llm.codex_auth_path
+// is set to an arbitrary JSON value (number/object/null/whitespace string),
+// returning its absolute path.
+func writeCodexPresetWithRawAuthPath(t *testing.T, dir, name string, raw interface{}) string {
+	t.Helper()
+	llm := map[string]interface{}{
+		"provider":    "codex",
+		"model":       "gpt-5.6-sol",
+		"api_key_env": "",
+	}
+	llm["codex_auth_path"] = raw
+	doc := map[string]interface{}{
+		"description": map[string]interface{}{"summary": "codex preset"},
+		"manifest":    map[string]interface{}{"llm": llm},
+	}
+	data, _ := json.MarshalIndent(doc, "", "  ")
+	path := filepath.Join(dir, name+".json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write preset: %v", err)
+	}
+	return path
+}
+
 func writeStubTokenFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -527,6 +550,73 @@ func TestResolveRefs_CodexDefaultAuthAcceptsAnyStoredAccount(t *testing.T) {
 		}
 		if got[0].CodexAuthRef != "codex-auth/missing.json" {
 			t.Fatalf("CodexAuthRef = %q, want explicit ref", got[0].CodexAuthRef)
+		}
+	})
+}
+
+// TestResolveRefs_CodexMalformedExplicitAuthFailsClosed verifies that a present
+// but malformed manifest.llm.codex_auth_path (wrong JSON type or whitespace-only
+// string) never fails open to the unbound fallback: the preset must resolve
+// HasKey=false even when a valid stored account exists.
+func TestResolveRefs_CodexMalformedExplicitAuthFailsClosed(t *testing.T) {
+	presetDir := t.TempDir()
+	authDir := t.TempDir()
+	writeStubTokenFile(t, filepath.Join(authDir, "codex-auth.json"))
+	auth := AuthState{CodexAuthDir: authDir}
+
+	cases := []struct {
+		name string
+		raw  interface{}
+	}{
+		{"number", 42},
+		{"object", map[string]interface{}{"k": "v"}},
+		{"null", nil},
+		{"whitespace-only", "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := writeCodexPresetWithRawAuthPath(t, presetDir, "codex-malformed-"+tc.name, tc.raw)
+			got := ResolveRefsWithAuth([]string{ref}, nil, auth)
+			if len(got) != 1 || got[0].HasKey {
+				t.Fatalf("malformed explicit codex_auth_path %#v = %#v, want HasKey=false", tc.raw, got)
+			}
+		})
+	}
+}
+
+// TestResolveRefs_CodexExplicitAuthNeverUsesAggregateBool verifies that a preset
+// with an explicit non-empty codex_auth_path is never validated by the aggregate
+// CodexOAuthConfigured bool, even when CodexAuthDir is empty. Absolute and
+// ~/-prefixed refs remain exactly checkable without a dir; relative refs fail
+// closed because they cannot be resolved.
+func TestResolveRefs_CodexExplicitAuthNeverUsesAggregateBool(t *testing.T) {
+	presetDir := t.TempDir()
+
+	t.Run("relative missing ref fails closed with aggregate true", func(t *testing.T) {
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-rel-missing", "codex-auth/missing.json")
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexOAuthConfigured: true})
+		if len(got) != 1 || got[0].HasKey {
+			t.Fatalf("explicit relative missing ref + aggregate true = %#v, want HasKey=false", got)
+		}
+	})
+
+	t.Run("absolute valid ref resolves without dir", func(t *testing.T) {
+		authDir := t.TempDir()
+		absPath := filepath.Join(authDir, "codex-auth", "abs.json")
+		writeStubTokenFile(t, absPath)
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-abs-valid", absPath)
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexOAuthConfigured: true})
+		if len(got) != 1 || !got[0].HasKey {
+			t.Fatalf("explicit absolute valid ref without dir = %#v, want HasKey=true", got)
+		}
+	})
+
+	t.Run("absolute missing ref fails closed without dir", func(t *testing.T) {
+		absPath := filepath.Join(t.TempDir(), "codex-auth", "missing.json")
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-abs-missing", absPath)
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexOAuthConfigured: true})
+		if len(got) != 1 || got[0].HasKey {
+			t.Fatalf("explicit absolute missing ref without dir = %#v, want HasKey=false", got)
 		}
 	})
 }

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -445,6 +445,56 @@ func TestResolveRefs_PerAccountCodexAuth(t *testing.T) {
 	}
 }
 
+func TestResolveRefs_CodexDefaultAuthAcceptsAnyStoredAccount(t *testing.T) {
+	presetDir := t.TempDir()
+
+	t.Run("legacy file valid", func(t *testing.T) {
+		authDir := t.TempDir()
+		writeStubTokenFile(t, filepath.Join(authDir, "codex-auth.json"))
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-legacy-default", "")
+
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
+		if len(got) != 1 || !got[0].HasKey {
+			t.Fatalf("default codex preset with legacy auth = %#v, want HasKey=true", got)
+		}
+	})
+
+	t.Run("per-account file valid", func(t *testing.T) {
+		authDir := t.TempDir()
+		writeStubTokenFile(t, filepath.Join(authDir, "codex-auth", "work.json"))
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-per-account-default", "")
+
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
+		if len(got) != 1 || !got[0].HasKey {
+			t.Fatalf("default codex preset with per-account auth = %#v, want HasKey=true", got)
+		}
+	})
+
+	t.Run("no credentials", func(t *testing.T) {
+		authDir := t.TempDir()
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-no-auth-default", "")
+
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
+		if len(got) != 1 || got[0].HasKey {
+			t.Fatalf("default codex preset with no auth = %#v, want HasKey=false", got)
+		}
+	})
+
+	t.Run("explicit auth path remains exact", func(t *testing.T) {
+		authDir := t.TempDir()
+		writeStubTokenFile(t, filepath.Join(authDir, "codex-auth", "work.json"))
+		ref := writeCodexPresetWithAuthPath(t, presetDir, "codex-explicit-missing", "codex-auth/missing.json")
+
+		got := ResolveRefsWithAuth([]string{ref}, nil, AuthState{CodexAuthDir: authDir})
+		if len(got) != 1 || got[0].HasKey {
+			t.Fatalf("explicit codex preset with different account auth = %#v, want HasKey=false", got)
+		}
+		if got[0].CodexAuthRef != "codex-auth/missing.json" {
+			t.Fatalf("CodexAuthRef = %q, want explicit ref", got[0].CodexAuthRef)
+		}
+	})
+}
+
 func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 	withTempPresets(t, func() {
 		p := DefaultPreset()

--- a/tui/internal/tui/app_test.go
+++ b/tui/internal/tui/app_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"path/filepath"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -151,5 +152,36 @@ func TestSetupCommandOpensFirstRunSetupMode(t *testing.T) {
 	}
 	if got.firstRun.setupOrchName != "manager" {
 		t.Fatalf("/setup orch name = %q, want manager", got.firstRun.setupOrchName)
+	}
+}
+
+func TestSetupCredentialsReturnRebuildsSetupWithCodexAuth(t *testing.T) {
+	projectDir := t.TempDir()
+	globalDir := t.TempDir()
+	orchDir := t.TempDir()
+	writeStubCodexToken(t, filepath.Join(globalDir, codexAuthSubdir, "work.json"), "work@example.com")
+	a := App{
+		currentView: appViewLogin,
+		globalDir:   globalDir,
+		projectDir:  projectDir,
+		orchDir:     orchDir,
+		orchName:    "manager",
+		login:       NewSetupCredentialsModel(orchDir, globalDir),
+	}
+
+	model, _ := a.Update(ViewChangeMsg{View: "setup"})
+	got := model.(App)
+
+	if got.currentView != appViewFirstRun {
+		t.Fatalf("return from credentials currentView = %v, want appViewFirstRun", got.currentView)
+	}
+	if !got.firstRun.setupMode {
+		t.Fatal("return from credentials should rebuild setup-mode first-run model")
+	}
+	if !got.firstRun.codexAuth.valid {
+		t.Fatal("return from credentials should refresh Codex auth from per-account files")
+	}
+	if got.firstRun.codexAuth.email != "work@example.com" {
+		t.Fatalf("refreshed Codex email = %q, want work@example.com", got.firstRun.codexAuth.email)
 	}
 }

--- a/tui/internal/tui/codex_auth_store.go
+++ b/tui/internal/tui/codex_auth_store.go
@@ -18,7 +18,8 @@ import (
 // ChatGPT accounts, additional accounts live as separate token files under
 // ~/.lingtai-tui/codex-auth/<slug>.json. A Codex preset binds to a specific
 // account through its non-secret manifest.llm.codex_auth_path field; a preset
-// with no such field falls back to the legacy file.
+// with no such field accepts any usable stored account (legacy file or any
+// per-account file).
 //
 // Everything here treats the token JSON as a secret: contents are parsed only
 // to read non-secret display metadata (label/email) and to confirm a non-empty

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -1352,9 +1352,8 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 			//   pickCodexAuthIdx = visibleCount       — Codex 凭据 row
 			//   Back = visibleCount + 1
 			//   Next = visibleCount + 2
-			// Codex template is hidden from the preset list (its row is
-			// replaced by the Codex 凭据 section row); saved codex
-			// presets render normally in 已存预设.
+			// All templates, including Codex, render in 新建预设; the Codex
+			// 凭据 row below is only the OAuth/account management surface.
 			visibleCount := m.visiblePresetCount()
 			pickCodexAuthIdx := visibleCount
 			pickBackIdx := visibleCount + 1


### PR DESCRIPTION
## Summary
- Fixed the Codex preset credential gate split-brain: the setup credentials row already treats legacy `codex-auth.json` and per-account files under `codex-auth/` as valid Codex OAuth, but unbound single-Codex presets only checked the legacy file.
- Preserved exact binding semantics for presets with explicit `manifest.llm.codex_auth_path`; only unbound/default single-Codex presets now accept any usable stored Codex account.
- Covered the setup navigation inconsistency by locking the existing `login -> setup` return path at the app level, including a fresh per-account Codex auth refresh after returning from Setup -> Credentials.
- Updated the stale first-run comment that said the Codex template was hidden; it now reflects that the Codex template renders in `新建预设` and the credential row is OAuth/account management only.

## Tests
- `cd tui && go test ./internal/preset/... ./internal/tui/...`

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
