### PR TITLE
feat(tui): import Codex CLI credentials + persist draft-mode codex login

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -284,6 +284,8 @@
   "codex.oauth_login_hint": "[c] login",
   "codex.oauth_logout_hint": "[r] logout",
   "codex.oauth_logout_confirm": "Log out of Codex? [y/N]",
+  "codex.import_cli_hint": "import from Codex CLI (press i)",
+  "codex.import_cli_done": "Imported Codex CLI credential (%s)",
   "firstrun.preset_pick.codex_locked": "(login required)",
   "firstrun.preset_pick.codex_locked_hint": "Press [c] above to log in to Codex first.",
   "firstrun.preset_pick.codex_needs_oauth": "(press Enter to login)",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -280,6 +280,8 @@
   "codex.oauth_login_hint": "[c] 登",
   "codex.oauth_logout_hint": "[r] 注销",
   "codex.oauth_logout_confirm": "注销 Codex 否？[y/N]",
+  "codex.import_cli_hint": "由 Codex CLI 引入（按 i）",
+  "codex.import_cli_done": "已引入 Codex CLI 凭（%s）",
   "firstrun.preset_pick.codex_locked": "（须先登）",
   "firstrun.preset_pick.codex_locked_hint": "请按 [c] 先登入 Codex。",
   "firstrun.preset_pick.codex_needs_oauth": "（按回车登）",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -280,6 +280,8 @@
   "codex.oauth_login_hint": "[c] 登录",
   "codex.oauth_logout_hint": "[r] 注销",
   "codex.oauth_logout_confirm": "注销 Codex？[y/N]",
+  "codex.import_cli_hint": "从 Codex CLI 导入（按 i）",
+  "codex.import_cli_done": "已导入 Codex CLI 凭据（%s）",
   "firstrun.preset_pick.codex_locked": "（须先登）",
   "firstrun.preset_pick.codex_locked_hint": "请按 [c] 先登入 Codex。",
   "firstrun.preset_pick.codex_needs_oauth": "（按 Enter 登录）",

--- a/tui/internal/tui/codex_auth_store.go
+++ b/tui/internal/tui/codex_auth_store.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -312,6 +313,151 @@ func hasAnyCodexAccount(globalDir string) bool {
 		}
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI credential import.
+//
+// The Codex CLI (`codex login`) writes its own credential to
+// ~/.codex/auth.json (or $CODEX_HOME/auth.json) in a NESTED format the TUI
+// never reads: {"auth_mode": "chatgpt", "tokens": {"id_token": ...,
+// "access_token": ..., "refresh_token": ..., "account_id": ...}, ...}. The
+// one-click import below converts that file into the TUI's own per-account
+// store (~/.lingtai-tui/codex-auth/<slug>.json) so a `codex login` user can
+// bind a codex preset without re-authenticating. The CLI file is read-only
+// input: it is never modified, and no token material is ever logged.
+// ---------------------------------------------------------------------------
+
+// codexCLIAuthPath returns the path of the Codex CLI's own credential file:
+// $CODEX_HOME/auth.json when CODEX_HOME is set non-empty, otherwise
+// ~/.codex/auth.json.
+func codexCLIAuthPath() string {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return filepath.Join(home, "auth.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".codex", "auth.json")
+	}
+	return filepath.Join(".codex", "auth.json") // best effort
+}
+
+// readCodexCLIAuthFile parses a Codex CLI credential file and converts it to
+// the TUI's flat CodexTokens. ok=false unless the file parses, auth_mode is
+// "chatgpt", and a non-empty refresh_token is present. Email is recovered
+// from the id_token (falling back to the access_token) JWT claims; the CLI
+// file carries no expiry, so ExpiresAt stays 0. Token material is never
+// printed.
+func readCodexCLIAuthFile(path string) (CodexTokens, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return CodexTokens{}, false
+	}
+	var raw struct {
+		AuthMode string `json:"auth_mode"`
+		Tokens   *struct {
+			IDToken      string `json:"id_token"`
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"tokens"`
+	}
+	if json.Unmarshal(data, &raw) != nil {
+		return CodexTokens{}, false
+	}
+	if raw.AuthMode != "chatgpt" || raw.Tokens == nil {
+		return CodexTokens{}, false
+	}
+	if strings.TrimSpace(raw.Tokens.RefreshToken) == "" {
+		return CodexTokens{}, false
+	}
+	email := extractEmailFromJWT(raw.Tokens.IDToken)
+	if email == "" {
+		email = extractEmailFromJWT(raw.Tokens.AccessToken)
+	}
+	return CodexTokens{
+		AccessToken:  raw.Tokens.AccessToken,
+		RefreshToken: raw.Tokens.RefreshToken,
+		Email:        email,
+	}, true
+}
+
+// codexCLISlug derives the per-account filename slug for an imported Codex
+// CLI credential: the first 8 characters of the account_id embedded in the
+// access token, or the email's local part when no account_id is present.
+// Sanitized through codexAccountSlug like every other account filename.
+func codexCLISlug(accountID, email string) string {
+	if s := strings.TrimSpace(accountID); s != "" {
+		if len(s) > 8 {
+			s = s[:8]
+		}
+		return codexAccountSlug(s, "codex-cli")
+	}
+	return codexAccountSlug(email, "codex-cli")
+}
+
+// importCodexCLIAuth copies the Codex CLI's own credential into the TUI's
+// per-account store and returns the ref to bind a preset to it plus a
+// non-secret display label (email, or the slug when the CLI file carries no
+// email). It never writes to the CLI's file and never overwrites an existing
+// TUI token file. Fails with an "already imported" error when the TUI already
+// holds the same account: a valid legacy file, or a per-account file whose
+// access-token account_id matches the CLI's. The returned ref is the
+// codexAuthSubdir-relative "codex-auth/<slug>.json" form so
+// resolveCodexAuthPath round-trips it onto the written file.
+func importCodexCLIAuth(globalDir string) (ref string, label string, err error) {
+	cliPath := codexCLIAuthPath()
+	cliTokens, ok := readCodexCLIAuthFile(cliPath)
+	if !ok {
+		return "", "", fmt.Errorf("no valid Codex CLI credential at %s (run `codex login` first)", cliPath)
+	}
+	cliAccountID := extractAccountIDFromJWT(cliTokens.AccessToken)
+
+	// Already imported? A valid legacy file means the TUI already has a
+	// working credential; a per-account file whose access-token account_id
+	// matches the CLI's is the same account imported earlier.
+	if codexAuthPathValid(legacyCodexAuthPath(globalDir)) {
+		return "", "", errors.New("codex CLI credential already imported (a legacy account exists)")
+	}
+	if cliAccountID != "" {
+		for _, a := range listCodexAccounts(globalDir) {
+			if a.Legacy || !a.Valid {
+				continue
+			}
+			tok, ok := readCodexTokenFile(a.Path)
+			if !ok {
+				continue
+			}
+			if extractAccountIDFromJWT(tok.AccessToken) == cliAccountID {
+				return "", "", errors.New("codex CLI credential already imported (same account)")
+			}
+		}
+	}
+
+	slug := codexCLISlug(cliAccountID, cliTokens.Email)
+	dir := codexAuthDir(globalDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", "", err
+	}
+	target := filepath.Join(dir, slug+".json")
+	if _, err := os.Stat(target); err == nil {
+		return "", "", fmt.Errorf("codex-auth/%s.json already exists — refusing to overwrite", slug)
+	} else if !os.IsNotExist(err) {
+		return "", "", err
+	}
+
+	// Token material is secret: written 0600, never logged.
+	data, err := json.MarshalIndent(cliTokens, "", "  ")
+	if err != nil {
+		return "", "", err
+	}
+	if err := os.WriteFile(target, data, 0o600); err != nil {
+		return "", "", err
+	}
+
+	label = cliTokens.Email
+	if label == "" {
+		label = slug
+	}
+	return filepath.ToSlash(filepath.Join(codexAuthSubdir, slug+".json")), label, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/tui/internal/tui/codex_cli_import_test.go
+++ b/tui/internal/tui/codex_cli_import_test.go
@@ -1,0 +1,268 @@
+package tui
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeCodexTestJWT builds an unsigned synthetic JWT (base64url, no padding,
+// trailing ".sig") whose payload carries the given claims. No code path under
+// test verifies the signature; the shape only needs to match what
+// extractEmailFromJWT / extractAccountIDFromJWT decode.
+func makeCodexTestJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal jwt claims: %v", err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+// codexCLIProfileClaims returns OpenAI-style JWT claims carrying both an email
+// (https://api.openai.com/profile) and an account_id
+// (https://api.openai.com/auth), matching what real Codex CLI tokens embed.
+func codexCLIProfileClaims(email, accountID string) map[string]interface{} {
+	return map[string]interface{}{
+		"sub": "u-1",
+		"https://api.openai.com/profile": map[string]string{"email": email},
+		"https://api.openai.com/auth":    map[string]string{"account_id": accountID},
+	}
+}
+
+// writeCodexCLIAuthFile writes a Codex CLI-shaped auth.json under dir and
+// returns its path. An empty authMode defaults to "chatgpt".
+func writeCodexCLIAuthFile(t *testing.T, dir, authMode, idToken, accessToken, refreshToken string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir cli dir: %v", err)
+	}
+	if authMode == "" {
+		authMode = "chatgpt"
+	}
+	raw := map[string]interface{}{
+		"auth_mode":      authMode,
+		"OPENAI_API_KEY": nil,
+		"tokens": map[string]interface{}{
+			"id_token":      idToken,
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"account_id":    "ignored-field",
+		},
+		"last_refresh": "2026-01-01T00:00:00Z",
+	}
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal cli auth: %v", err)
+	}
+	path := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write cli auth: %v", err)
+	}
+	return path
+}
+
+// TestReadCodexCLIAuthFile_Valid verifies the nested CLI format converts to
+// the flat CodexTokens: tokens copied, email derived from the id_token,
+// ExpiresAt zero (the CLI file carries no expiry).
+func TestReadCodexCLIAuthFile_Valid(t *testing.T) {
+	email := "sam@example.com"
+	accountID := "org-12345678"
+	idToken := makeCodexTestJWT(t, codexCLIProfileClaims(email, accountID))
+	accessToken := makeCodexTestJWT(t, codexCLIProfileClaims(email, accountID))
+	path := writeCodexCLIAuthFile(t, t.TempDir(), "chatgpt", idToken, accessToken, "rt-abc")
+
+	tok, ok := readCodexCLIAuthFile(path)
+	if !ok {
+		t.Fatal("a valid CLI auth file should parse")
+	}
+	if tok.AccessToken != accessToken || tok.RefreshToken != "rt-abc" {
+		t.Fatalf("token material mismatch: access=%q refresh=%q", tok.AccessToken, tok.RefreshToken)
+	}
+	if tok.Email != email {
+		t.Fatalf("email should be derived from the id_token; got %q", tok.Email)
+	}
+	if tok.ExpiresAt != 0 {
+		t.Fatalf("CLI file carries no expiry; ExpiresAt should be 0, got %d", tok.ExpiresAt)
+	}
+}
+
+// TestReadCodexCLIAuthFile_MissingRefreshToken verifies ok=false when the CLI
+// file has no refresh token.
+func TestReadCodexCLIAuthFile_MissingRefreshToken(t *testing.T) {
+	claims := codexCLIProfileClaims("sam@example.com", "org-12345678")
+	path := writeCodexCLIAuthFile(t, t.TempDir(), "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "")
+	if _, ok := readCodexCLIAuthFile(path); ok {
+		t.Fatal("CLI auth without a refresh_token must not parse as valid")
+	}
+}
+
+// TestReadCodexCLIAuthFile_WrongAuthMode verifies ok=false unless auth_mode is
+// "chatgpt" (e.g. an enterprise "sso" auth file is not importable).
+func TestReadCodexCLIAuthFile_WrongAuthMode(t *testing.T) {
+	claims := codexCLIProfileClaims("sam@example.com", "org-12345678")
+	path := writeCodexCLIAuthFile(t, t.TempDir(), "sso", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-abc")
+	if _, ok := readCodexCLIAuthFile(path); ok {
+		t.Fatal("non-chatgpt auth_mode must not parse as valid")
+	}
+}
+
+// TestCodexCLIAuthPath_HonorsCODEXHOME verifies the CODEX_HOME override and
+// the ~/.codex fallback.
+func TestCodexCLIAuthPath_HonorsCODEXHOME(t *testing.T) {
+	t.Setenv("CODEX_HOME", "/tmp/codex-home")
+	if got := codexCLIAuthPath(); got != filepath.Join("/tmp/codex-home", "auth.json") {
+		t.Fatalf("CODEX_HOME should point at $CODEX_HOME/auth.json; got %q", got)
+	}
+	t.Setenv("CODEX_HOME", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	if got := codexCLIAuthPath(); got != filepath.Join(home, ".codex", "auth.json") {
+		t.Fatalf("unset CODEX_HOME should fall back to ~/.codex/auth.json; got %q", got)
+	}
+}
+
+// TestImportCodexCLIAuth_WritesPerAccountFile verifies the end-to-end import:
+// slug from the first 8 account_id chars, ref resolvable onto the written
+// file, 0600 perms, and the CLI file left byte-identical.
+func TestImportCodexCLIAuth_WritesPerAccountFile(t *testing.T) {
+	email := "sam@example.com"
+	accountID := "org-12345678"
+	claims := codexCLIProfileClaims(email, accountID)
+	cliDir := t.TempDir()
+	t.Setenv("CODEX_HOME", cliDir)
+	writeCodexCLIAuthFile(t, cliDir, "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-abc")
+	cliPath := filepath.Join(cliDir, "auth.json")
+	before, err := os.ReadFile(cliPath)
+	if err != nil {
+		t.Fatalf("read cli auth: %v", err)
+	}
+
+	globalDir := t.TempDir()
+	ref, label, err := importCodexCLIAuth(globalDir)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if ref != "codex-auth/org-1234.json" {
+		t.Fatalf("slug should come from the first 8 account_id chars; got ref %q", ref)
+	}
+	if label != email {
+		t.Fatalf("label should be the account email; got %q", label)
+	}
+
+	target := resolveCodexAuthPath(globalDir, ref)
+	if target != filepath.Join(globalDir, "codex-auth", "org-1234.json") {
+		t.Fatalf("ref should resolve onto the written file; got %q", target)
+	}
+	tok, ok := readCodexTokenFile(target)
+	if !ok || tok.RefreshToken != "rt-abc" || tok.Email != email {
+		t.Fatalf("imported file should parse with the CLI credential: ok=%v tok=%+v", ok, tok)
+	}
+	if fi, err := os.Stat(target); err != nil || fi.Mode().Perm() != 0o600 {
+		t.Fatalf("imported token file should be 0600; mode=%v err=%v", fi.Mode(), err)
+	}
+
+	after, err := os.ReadFile(cliPath)
+	if err != nil {
+		t.Fatalf("re-read cli auth: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("import must not modify the Codex CLI auth file")
+	}
+}
+
+// TestImportCodexCLIAuth_SlugFallsBackToEmail verifies the email-local-part
+// slug when the access token carries no account_id.
+func TestImportCodexCLIAuth_SlugFallsBackToEmail(t *testing.T) {
+	email := "sam.smith@example.com"
+	claims := map[string]interface{}{
+		"sub": "u-1",
+		"https://api.openai.com/profile": map[string]string{"email": email},
+	}
+	cliDir := t.TempDir()
+	t.Setenv("CODEX_HOME", cliDir)
+	writeCodexCLIAuthFile(t, cliDir, "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-abc")
+
+	ref, label, err := importCodexCLIAuth(t.TempDir())
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if ref != "codex-auth/sam-smith.json" {
+		t.Fatalf("slug should derive from the email local part; got %q", ref)
+	}
+	if label != email {
+		t.Fatalf("label should be the email; got %q", label)
+	}
+}
+
+// TestImportCodexCLIAuth_AlreadyImportedSameAccount verifies a second import
+// of the same account (same access-token account_id) fails with "already
+// imported" and leaves the stored credential untouched.
+func TestImportCodexCLIAuth_AlreadyImportedSameAccount(t *testing.T) {
+	email := "sam@example.com"
+	accountID := "org-12345678"
+	claims := codexCLIProfileClaims(email, accountID)
+	cliDir := t.TempDir()
+	t.Setenv("CODEX_HOME", cliDir)
+	writeCodexCLIAuthFile(t, cliDir, "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-abc")
+	globalDir := t.TempDir()
+
+	if _, _, err := importCodexCLIAuth(globalDir); err != nil {
+		t.Fatalf("first import should succeed: %v", err)
+	}
+	// Same account, new refresh token: re-import must refuse, not clobber.
+	writeCodexCLIAuthFile(t, cliDir, "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-different")
+	if _, _, err := importCodexCLIAuth(globalDir); err == nil || !strings.Contains(err.Error(), "already imported") {
+		t.Fatalf("re-import of the same account should fail with 'already imported'; got %v", err)
+	}
+	tok, _ := readCodexTokenFile(filepath.Join(globalDir, "codex-auth", "org-1234.json"))
+	if tok.RefreshToken != "rt-abc" {
+		t.Fatalf("existing credential must not be overwritten; got %q", tok.RefreshToken)
+	}
+}
+
+// TestImportCodexCLIAuth_AlreadyImportedLegacy verifies a valid legacy
+// single-account file blocks the import entirely.
+func TestImportCodexCLIAuth_AlreadyImportedLegacy(t *testing.T) {
+	claims := codexCLIProfileClaims("sam@example.com", "org-12345678")
+	cliDir := t.TempDir()
+	t.Setenv("CODEX_HOME", cliDir)
+	writeCodexCLIAuthFile(t, cliDir, "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-abc")
+	globalDir := t.TempDir()
+	writeStubCodexToken(t, filepath.Join(globalDir, "codex-auth.json"), "other@example.com")
+
+	if _, _, err := importCodexCLIAuth(globalDir); err == nil || !strings.Contains(err.Error(), "already imported") {
+		t.Fatalf("a valid legacy credential should block import; got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(globalDir, "codex-auth", "org-1234.json")); !os.IsNotExist(err) {
+		t.Fatal("import must not write a per-account file when already imported")
+	}
+}
+
+// TestImportCodexCLIAuth_NeverOverwritesExistingFile verifies the no-clobber
+// guarantee: a pre-existing per-account file with a different account_id but
+// the same slug blocks the import and stays byte-identical.
+func TestImportCodexCLIAuth_NeverOverwritesExistingFile(t *testing.T) {
+	claims := codexCLIProfileClaims("sam@example.com", "org-12345678")
+	cliDir := t.TempDir()
+	t.Setenv("CODEX_HOME", cliDir)
+	writeCodexCLIAuthFile(t, cliDir, "chatgpt", makeCodexTestJWT(t, claims), makeCodexTestJWT(t, claims), "rt-abc")
+	globalDir := t.TempDir()
+
+	target := filepath.Join(globalDir, "codex-auth", "org-1234.json")
+	writeStubCodexToken(t, target, "other@example.com")
+
+	if _, _, err := importCodexCLIAuth(globalDir); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("import must refuse to overwrite an existing file; got %v", err)
+	}
+	tok, ok := readCodexTokenFile(target)
+	if !ok || tok.Email != "other@example.com" {
+		t.Fatalf("existing file should be untouched: ok=%v tok=%+v", ok, tok)
+	}
+}

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -1111,24 +1111,29 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 			m.message = fmt.Sprintf("Failed to encode tokens: %v", err)
 			return m, nil
 		}
+		authPath := legacyCodexAuthPath(m.globalDir)
+		if err := os.MkdirAll(filepath.Dir(authPath), 0o755); err != nil {
+			m.message = fmt.Sprintf("Failed to save tokens: %v", err)
+			return m, nil
+		}
+		if err := os.WriteFile(authPath, data, 0o600); err != nil {
+			m.message = fmt.Sprintf("Failed to save tokens: %v", err)
+			return m, nil
+		}
 		if m.draftMode {
-			// Draft only: hold the completed OAuth bundle in memory as
-			// secretBytes. The real codex-auth.json write happens during
-			// the finalizer's pre-publish dependency phase (project_create.go),
-			// never here. m.codexAuth is still updated in-memory (below, via
-			// refreshCodexAuth) purely so the wizard's UI reflects "logged
-			// in" without touching disk.
+			// Draft mode: persist the completed OAuth bundle to disk NOW
+			// (legacy codex-auth.json) so a successful codex login survives
+			// even when the user abandons the wizard — the preset-first flow
+			// (create preset, then project) may never reach the finalizer's
+			// pre-publish dependency phase. Keep the draft copy as well so
+			// project_create.go's finalizer verify step still passes; it
+			// rewrites the identical bundle idempotently.
 			if m.draft != nil {
 				m.draft.DraftCodexTokens = secretBytes(data)
 			}
 			m.codexAuth.valid = true
 			m.codexAuth.email = msg.Tokens.Email
 			m.codexAuth.label = codexAccountName(codexAccount{Email: msg.Tokens.Email, Legacy: true})
-			return m, nil
-		}
-		authPath := legacyCodexAuthPath(m.globalDir)
-		if err := os.WriteFile(authPath, data, 0o600); err != nil {
-			m.message = fmt.Sprintf("Failed to save tokens: %v", err)
 			return m, nil
 		}
 		m.refreshCodexAuth()
@@ -1563,13 +1568,16 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 							// draft session) — the arm above already
 							// blocked the pre-existing-disk-auth case
 							// before m.codexLogoutArmed could ever become
-							// true. Clearing the in-memory bundle here is
-							// accurate: nothing was ever written to
-							// codex-auth.json, so there is nothing to
-							// remove from disk.
+							// true. Since CodexOAuthDoneMsg's draftMode
+							// branch now persists the bundle to disk
+							// immediately (the same legacy
+							// codex-auth.json the non-draft path writes),
+							// logging out here must remove that file too,
+							// then clear the in-memory draft.
 							if m.draft != nil {
 								m.draft.DraftCodexTokens = nil
 							}
+							_ = os.Remove(legacyCodexAuthPath(m.globalDir))
 							m.codexAuth.valid = false
 							m.codexAuth.email = ""
 							m.codexAuth.label = ""

--- a/tui/internal/tui/launcher_test.go
+++ b/tui/internal/tui/launcher_test.go
@@ -756,15 +756,19 @@ func TestDraftFirstRun_CodexDeleteBlockedForPreExistingAuth(t *testing.T) {
 // of blocker 5's fix: when the Codex login happened DURING this draft
 // session (draft.DraftCodexTokens non-empty, exactly what
 // CodexOAuthDoneMsg's draftMode branch sets — see firstrun.go), clearing it
-// via Delete remains fully functional and honest, since nothing was ever
-// written to disk in the first place. This proves the blocking guard in
-// blocker 5's fix is scoped correctly — it must not also break the
-// legitimate, already-tested "undo a same-session login" path.
+// via Delete remains fully functional and honest. Since the draftMode login
+// now persists immediately to the legacy codex-auth.json (so a preset-first
+// flow keeps the credential even if the wizard is abandoned), the same-session
+// logout must remove that persisted file as well as the in-memory draft. This
+// proves the blocking guard in blocker 5's fix is scoped correctly — it must
+// not also break the legitimate, already-tested "undo a same-session login"
+// path.
 func TestDraftFirstRun_CodexDeleteAllowedForSessionLogin(t *testing.T) {
 	m, home, _ := buildDraftModel(t)
 	m.step = stepPickPreset
 	m.presets = nil
 	m.cursor = 0
+	globalDir := filepath.Join(home, ".lingtai-tui")
 
 	// Simulate a completed same-session OAuth login via the real message
 	// path (CodexOAuthDoneMsg), not a synthetic direct field assignment.
@@ -778,6 +782,15 @@ func TestDraftFirstRun_CodexDeleteAllowedForSessionLogin(t *testing.T) {
 		t.Fatal("expected codexAuth.valid=true after the same-session login")
 	}
 
+	// The draftMode login persists immediately: the legacy codex-auth.json
+	// must exist on disk after the OAuth completion.
+	authPath := legacyCodexAuthPath(globalDir)
+	if raw, err := os.ReadFile(authPath); err != nil {
+		t.Fatalf("expected codex-auth.json persisted by draftMode login: %v", err)
+	} else if !strings.Contains(string(raw), "session-token") {
+		t.Fatalf("expected persisted codex-auth.json to contain the session token, got %q", raw)
+	}
+
 	before := dirSnapshot(t, home)
 
 	// Two-press Del: arm, then confirm.
@@ -787,7 +800,16 @@ func TestDraftFirstRun_CodexDeleteAllowedForSessionLogin(t *testing.T) {
 	}
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
 
-	assertSnapshotsEqual(t, "draft Codex delete for same-session login", before, dirSnapshot(t, home))
+	// The only expected filesystem change from this logout is the
+	// persisted codex-auth.json being removed; everything else must be
+	// untouched.
+	after := dirSnapshot(t, home)
+	if len(after) != len(before)-1 {
+		t.Fatalf("expected exactly one file removed by same-session logout: before=%v after=%v", before, after)
+	}
+	if _, ok := after[filepath.Join(".lingtai-tui", "codex-auth.json")]; ok {
+		t.Fatalf("expected codex-auth.json absent after logout, got %v", after)
+	}
 
 	if !m.draft.DraftCodexTokens.Empty() {
 		t.Fatal("expected DraftCodexTokens cleared after confirming the in-memory logout")
@@ -797,6 +819,10 @@ func TestDraftFirstRun_CodexDeleteAllowedForSessionLogin(t *testing.T) {
 	}
 	if m.message != i18n.T("firstrun.preset_pick.codex_logged_out") {
 		t.Fatalf("expected the normal logged-out message for a same-session login, got %q", m.message)
+	}
+	// The persisted file must be removed too.
+	if _, err := os.Stat(authPath); !os.IsNotExist(err) {
+		t.Fatalf("expected codex-auth.json removed after same-session logout, stat err=%v", err)
 	}
 }
 

--- a/tui/internal/tui/oauth.go
+++ b/tui/internal/tui/oauth.go
@@ -653,6 +653,46 @@ func extractEmailFromJWT(jwt string) string {
 	return profile.Email
 }
 
+// extractAccountIDFromJWT extracts the OpenAI account id from an access
+// token's "https://api.openai.com/auth" claim. Returns empty string on any
+// error. Used to detect whether a stored TUI credential already matches a
+// Codex CLI credential before importing it.
+func extractAccountIDFromJWT(jwt string) string {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+
+	// Base64url decode the payload (index 1). Add padding if needed.
+	payload := parts[1]
+	if m := len(payload) % 4; m != 0 {
+		payload += strings.Repeat("=", 4-m)
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		return ""
+	}
+
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return ""
+	}
+
+	authRaw, ok := claims["https://api.openai.com/auth"]
+	if !ok {
+		return ""
+	}
+
+	var auth struct {
+		AccountID string `json:"account_id"`
+	}
+	if err := json.Unmarshal(authRaw, &auth); err != nil {
+		return ""
+	}
+	return auth.AccountID
+}
+
 // oauthBrowserOpener is the indirection startOAuthFlow uses to launch the
 // system browser at the authorize URL. It defaults to openBrowser (defined in
 // app.go) in production; tests override it so that running `go test ./...`

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -325,6 +326,11 @@ type PresetEditorModel struct {
 
 	// Status
 	saveErr string
+
+	// statusMsg is a transient, non-error footer message (e.g. "Imported
+	// Codex CLI credential"). It replaces the browse hint until the next
+	// keypress; renderFooter prefers it over saveErr-free hints.
+	statusMsg string
 }
 
 // NewPresetEditorModel builds an editor against a working copy of `p`.
@@ -459,6 +465,9 @@ func (m PresetEditorModel) Update(msg tea.Msg) (PresetEditorModel, tea.Cmd) {
 // ───────────────────────────────────────────────────────────────────────────
 
 func (m PresetEditorModel) updateBrowse(msg tea.KeyMsg) (PresetEditorModel, tea.Cmd) {
+	// Transient footer message: visible for the frame that set it, cleared by
+	// the next keypress (the import handler below re-sets it after this line).
+	m.statusMsg = ""
 	switch msg.String() {
 	case "esc":
 		// Clean editor (no edits made) → close immediately. Confirming
@@ -523,6 +532,27 @@ func (m PresetEditorModel) updateBrowse(msg tea.KeyMsg) (PresetEditorModel, tea.
 		// who want to see the on-disk shape; hidden by default to keep
 		// the form uncluttered.
 		m.showJSON = !m.showJSON
+		return m, nil
+	case "i":
+		// One-click import of the Codex CLI's own credential (`codex
+		// login` writes ~/.codex/auth.json) into the TUI store, bound to
+		// this preset's API-key row. Only meaningful on the codex
+		// API-key row while the bound account is invalid (the footer
+		// hint codex.import_cli_hint advertises it only when a valid CLI
+		// file exists). Errors — no CLI credential, already imported,
+		// target exists — surface in the footer via saveErr.
+		f := editorFieldOrder[m.cursor]
+		if f == feAPIKey && preset.ClassifyCredentialFamily(asString(m.llmMap()["provider"])) == preset.CredentialFamilyCodexSingle && m.globalDir != "" {
+			if _, valid := m.codexBoundAccountLabel(); !valid {
+				ref, label, err := importCodexCLIAuth(m.globalDir)
+				if err != nil {
+					m.saveErr = err.Error()
+				} else {
+					m.setCodexAuthRef(ref)
+					m.statusMsg = fmt.Sprintf(i18n.T("codex.import_cli_done"), label)
+				}
+			}
+		}
 		return m, nil
 	}
 	return m, nil
@@ -804,6 +834,25 @@ func (m PresetEditorModel) codexBoundAccountLabel() (string, bool) {
 	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)), valid
 }
 
+// codexCLIImportAvailable reports whether the codex API-key row can offer the
+// one-click CLI import: the preset uses a codex single credential, globalDir
+// is set, the currently-bound account is invalid, and a valid Codex CLI
+// credential file (~/.codex/auth.json or $CODEX_HOME/auth.json) exists to
+// import. Drives the footer hint; the 'i' handler additionally requires the
+// row to be focused.
+func (m PresetEditorModel) codexCLIImportAvailable() bool {
+	if m.globalDir == "" {
+		return false
+	}
+	if preset.ClassifyCredentialFamily(asString(m.llmMap()["provider"])) != preset.CredentialFamilyCodexSingle {
+		return false
+	}
+	if _, valid := m.codexBoundAccountLabel(); valid {
+		return false
+	}
+	_, ok := readCodexCLIAuthFile(codexCLIAuthPath())
+	return ok
+}
 func (m PresetEditorModel) codexServiceTier() string {
 	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
 	if asString(llm["service_tier"]) == "fast" {
@@ -2047,7 +2096,18 @@ func (m PresetEditorModel) renderFooter() string {
 	case emExitPrompt:
 		return hintStyle.Render("  " + i18n.T("preset_editor.hint_exit"))
 	}
-	return hintStyle.Render("  " + i18n.T("preset_editor.hint_browse"))
+	hint := i18n.T("preset_editor.hint_browse")
+	if m.statusMsg != "" {
+		// Transient feedback (e.g. a completed CLI credential import)
+		// replaces the generic browse hint until the next keypress.
+		hint = m.statusMsg
+	} else if m.codexCLIImportAvailable() {
+		// A `codex login` credential exists while this preset's bound
+		// account is invalid: advertise the one-click import on the
+		// codex API-key row.
+		hint += "  " + i18n.T("codex.import_cli_hint")
+	}
+	return hintStyle.Render("  " + hint)
 }
 
 func (m PresetEditorModel) renderCloneOverlay(_ string) string {


### PR DESCRIPTION
## Why

Since the 5/3 credential redesign, the TUI manages its **own** Codex OAuth store (`~/.lingtai-tui/codex-auth.json` + `codex-auth/<slug>.json`) and never reads the Codex CLI's `~/.codex/auth.json`. A user who runs `codex login` (the standard CLI flow) then tries to create a codex preset in the TUI sees "login required" — the TUI cannot see the CLI credential. This breaks the common workflow: CLI-auth first, TUI preset second.

## What

1. **Import from Codex CLI** — In the preset editor, a codex API-key row whose bound account is invalid and where a CLI credential exists now shows `import from Codex CLI (press i)`. Pressing `i` converts `~/.codex/auth.json` (nested chatgpt format) into the TUI's per-account store (`codex-auth/<slug>.json`, 0600), pool-aware, never overwrites an existing account, never touches the CLI file. Backed by new `importCodexCLIAuth` in `codex_auth_store.go` + `codex_cli_import_test.go`.

2. **Persist draft-mode codex login immediately** — The first-run (new-user) wizard previously held a completed Codex OAuth bundle only in memory (`DraftCodexTokens`) and wrote `codex-auth.json` only when project creation finished. In the preset-first flow (create preset, then project), the login was silently lost if the wizard was abandoned. Now `CodexOAuthDoneMsg`'s draft-mode branch writes the legacy `codex-auth.json` **immediately** (0600, with `MkdirAll`), keeps the draft copy for the finalizer verify, and the draft-mode logout removes the persisted file for consistency.

## Tested

- `go build ./...` ✓
- `go test ./internal/tui/ -run 'DraftFirstRun_Codex|CodexCLIImport|Import'` ✓
- Broader `-run 'Draft|FirstRun|Launcher|Codex'` ✓
- macOS ad-hoc codesign at final path (taskgated would SIGKILL an unsigned rebuild)
