### PR TITLE
feat(tui): cap thinking block preview at 150 chars in first Ctrl+O layer

### DIFF
--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -1881,6 +1881,11 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 					b.WriteString(renderApiCallGroupSeparator(m.width) + "\n")
 				}
 				evStyle = thinkingStyle
+				// Ctrl+O level 1 shows only the first 150 chars of thinking
+				// blocks as a compact preview; level 2 shows the full body.
+				if msg.Type == "thinking" && m.verbose == verboseThinking {
+					body = truncateToolBody(body, thinkingPreviewLimit)
+				}
 			default:
 				if apiCallGroupSeparatorBefore(prevVisibleApiGroup, msg) {
 					b.WriteString(renderApiCallGroupSeparator(m.width) + "\n")

--- a/tui/internal/tui/thinking_preview_test.go
+++ b/tui/internal/tui/thinking_preview_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// First Ctrl+O layer (verboseThinking): a thinking block longer than 150 runes
+// is rendered as a 150-char preview with a clear ellipsis indicator, not in
+// full. The deeper layer (verboseExtended) keeps the full thinking body.
+func TestRenderMessages_ThinkingBlockPreviewedInFirstLayer(t *testing.T) {
+	long := strings.Repeat("A", 200) + "TAIL_MARKER"
+	msgs := []ChatMessage{
+		{Type: "thinking", ApiCallID: "api_1", Timestamp: "2026-06-08T07:08:27Z", Body: long},
+	}
+
+	// First layer: preview only (first 150 chars, ellipsis, no tail).
+	mFirst := MailModel{width: 100, verbose: verboseThinking}
+	first := mFirst.renderMessages(msgs)
+	if strings.Contains(first, "TAIL_MARKER") {
+		t.Fatalf("first Ctrl+O layer must not render the full thinking tail:\n%s", first)
+	}
+	if !strings.Contains(first, "…") {
+		t.Fatalf("first-layer preview of a >150-char thinking block must show an ellipsis indicator:\n%s", first)
+	}
+
+	// Deeper layer: full text.
+	mDeep := MailModel{width: 100, verbose: verboseExtended}
+	deep := mDeep.renderMessages(msgs)
+	if !strings.Contains(deep, "TAIL_MARKER") {
+		t.Fatalf("deeper Ctrl+O layer must render the full thinking body:\n%s", deep)
+	}
+}
+
+// A thinking block at or under 150 runes is never truncated and gets no
+// misleading ellipsis in the first layer.
+func TestRenderMessages_ShortThinkingNotTruncatedInFirstLayer(t *testing.T) {
+	short := "Should we use the cheaper preset for this batch?"
+	mFirst := MailModel{width: 100, verbose: verboseThinking}
+	out := mFirst.renderMessages([]ChatMessage{
+		{Type: "thinking", ApiCallID: "api_1", Timestamp: "2026-06-08T07:08:27Z", Body: short},
+	})
+	if !strings.Contains(out, short) {
+		t.Fatalf("short thinking must render in full in the first layer:\n%s", out)
+	}
+	if strings.Contains(out, "…") {
+		t.Fatalf("short thinking must not show a misleading ellipsis in the first layer:\n%s", out)
+	}
+}
+
+// Diary and text blocks are intentionally NOT preview-truncated at level 1:
+// only thinking blocks carry the 150-char preview.
+func TestRenderMessages_DiaryAndTextNotPreviewTruncatedInFirstLayer(t *testing.T) {
+	long := strings.Repeat("B", 200) + "DIARY_TAIL_MARKER"
+	for _, typ := range []string{"diary", "text_input", "text_output"} {
+		mFirst := MailModel{width: 100, verbose: verboseThinking}
+		out := mFirst.renderMessages([]ChatMessage{
+			{Type: typ, ApiCallID: "api_1", Timestamp: "2026-06-08T07:08:27Z", Body: long},
+		})
+		if !strings.Contains(out, "DIARY_TAIL_MARKER") {
+			t.Fatalf("%s must render in full at first layer (not preview-truncated):\n%s", typ, out)
+		}
+	}
+}

--- a/tui/internal/tui/toolcall_display.go
+++ b/tui/internal/tui/toolcall_display.go
@@ -63,6 +63,11 @@ const toolCallSummaryPreviewLimit = 400
 // summary. Counted in runes, never split mid-codepoint.
 const aprioriSummaryPreviewLimit = 200
 
+// thinkingPreviewLimit caps the thinking block text shown in the FIRST Ctrl+O
+// layer (verboseThinking). Full thinking blocks are too noisy for the compact
+// layer; the deeper Ctrl+O level still renders the full thinking body.
+const thinkingPreviewLimit = 150
+
 // previewSummaryText returns the first aprioriSummaryPreviewLimit runes of the
 // generated summary text with a trailing ellipsis when (and only when) the text
 // is longer than the limit. A text at or under the limit is returned verbatim,


### PR DESCRIPTION
## What\n\nThe first Ctrl+O layer (verboseThinking) renders full thinking blocks, which are too noisy when a model emits a long chain-of-thought. This PR caps the thinking-block body at the first 150 chars with the existing ellipsis indicator in the first layer; the second Ctrl+O layer (verboseExtended) still renders the full thinking body.\n\n## Why\n\nJason requested: "show only first 150 char of thinking block in TUI first ctrl+o layer, other too noisy". Mirrors the existing apriori-summary preview pattern (200 chars) and tool_call compact-summary pattern (400 chars) for consistency.\n\n## Changes\n- `tui/internal/tui/toolcall_display.go`: add `thinkingPreviewLimit = 150` constant.\n- `tui/internal/tui/mail.go`: in `renderMessages`, when `msg.Type == "thinking" && m.verbose == verboseThinking`, truncate body via `truncateToolBody(body, thinkingPreviewLimit)`.\n- `tui/internal/tui/thinking_preview_test.go`: 3 tests (long thinking previewed in layer 1, short thinking not truncated, diary/text not preview-truncated).\n\n## Tests\n- `go test ./internal/tui/` passes (full package).\n\nTelegram: @lingtaidev1bot | Nickname: 知微\nPowered by LingTai AI: https://github.com/Lingtai-AI/lingtai