### PR TITLE
docs: require explicit capability-to-code mapping and repair orphan related_files in ANATOMY

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -93,8 +93,12 @@ maintenance: |
   when their boundary changes. Code is the structural source of truth: repair
   stale navigation in the same change that moves files, symbols, connections,
   composition, or state. Preserve the child template and its maintenance rule;
-  validate the distributed graph before merge. See dev-guide-skill/SKILL.md for
-  the workflow.
+  validate the distributed graph before merge. Capability mentions in any
+  document require explicit navigation mapping to the implementing code: a
+  related_files entry in the owning ANATOMY.md (or a markdown link to that node
+  when the document lives in the anatomy graph itself), bidirectional between
+  document and owner. A capability with no mapping is drift; fix the mapping in
+  the same change. See dev-guide-skill/SKILL.md for the workflow.
 ---
 
 # lingtai
@@ -348,6 +352,13 @@ Maintenance is part of reading:
   `TestArchitectureDocumentsCoverEveryTrackedFile` fails with the exact paths to
   add. Deleting a file means deleting its entry; a new package directory means a
   new `ANATOMY.md` linked from its parent.
+- **Capability mentions require explicit bidirectional mapping to implementing
+  code.** Any document (README, docs, skill, issue/PR body, proposal) that names
+  a user-visible or agent-visible capability must resolve to the code that
+  implements it: either the owning ANATOMY.md lists that document in its
+  `related_files` and the implementing files, or the document links to the
+  owning anatomy node. A capability with no mapping is navigation drift and
+  must be repaired in the same change, not deferred.
 - Keep parent/child and Anatomy/Contract pair links reciprocal, and keep the
   two-binary facts compatible across `tui/ANATOMY.md` and `portal/ANATOMY.md`.
   When this system's convention itself changes, update this root, its smoke test

--- a/portal/ANATOMY.md
+++ b/portal/ANATOMY.md
@@ -43,6 +43,7 @@ related_files:
   - portal/web/tsconfig.json
   - portal/web/tsconfig.node.json
   - portal/web/vite.config.ts
+  - portal/main_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/portal/internal/fs/ANATOMY.md
+++ b/portal/internal/fs/ANATOMY.md
@@ -19,6 +19,8 @@ related_files:
   - portal/internal/fs/resolve.go
   - portal/internal/fs/resolve_test.go
   - portal/internal/fs/signal.go
+  - portal/internal/fs/discovery_test.go
+  - portal/internal/fs/heartbeat_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/tui/internal/config/ANATOMY.md
+++ b/tui/internal/config/ANATOMY.md
@@ -24,6 +24,8 @@ related_files:
   - tui/internal/config/global_atomic_test.go
   - tui/internal/config/tui_updater.go
   - tui/internal/config/tui_updater_test.go
+  - tui/internal/config/addon_key.go
+  - tui/internal/config/addon_key_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -53,6 +53,7 @@ related_files:
   - tui/internal/fs/refresh_marker_test.go
   - tui/internal/fs/session_race_test.go
   - tui/internal/fs/tool_call_render_test.go
+  - tui/internal/fs/discovery_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -198,6 +198,7 @@ related_files:
   - tui/internal/preset/templates/wechat.jsonc
   - tui/internal/preset/tui_help_mcp_guidance_test.go
   - tui/internal/preset/tui_help_populate_test.go
+  - tui/internal/preset/preset_name_containment_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/tui/internal/tui/ANATOMY.md
+++ b/tui/internal/tui/ANATOMY.md
@@ -182,6 +182,8 @@ related_files:
   - tui/internal/tui/update_tui_test.go
   - tui/internal/tui/visible_rail_v2_test.go
   - tui/internal/tui/wizard_footer.go
+  - tui/internal/tui/codex_cli_import_test.go
+  - tui/internal/tui/thinking_preview_test.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;


### PR DESCRIPTION
Align the lingtai (Go) monorepo with the same capability-to-code mapping rule just merged in lingtai-kernel #1393 (b8f59e87), and repair the 9 orphan tracked files that fail `TestArchitectureDocumentsCoverEveryTrackedFile` on current main.

- Root ANATOMY.md: maintenance + ## Maintenance now require explicit bidirectional navigation mapping from any capability mention to its implementing code.
- Repaired 9 orphan files by adding them to the owning ANATOMY related_files:
  - portal/internal/fs/discovery_test.go, heartbeat_test.go
  - portal/main_test.go
  - tui/internal/config/addon_key.go, addon_key_test.go
  - tui/internal/fs/discovery_test.go
  - tui/internal/preset/preset_name_containment_test.go
  - tui/internal/tui/codex_cli_import_test.go, thinking_preview_test.go
- Validation: `go test -run TestArchitectureDocuments .` now PASSES (was FAIL on current main with the exact 9-file orphan list); `git diff --check` clean.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai