### PR TITLE
feat(tui): add home async-work stats row from daemon job ledger

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -841,5 +841,11 @@
   "firstrun.self_heal_done": "Self-healed config.json from %d key(s) in .env. Continue to propagate to your agents.",
   "firstrun.self_heal_failed": "Self-heal failed: %v",
   "degraded.banner": "⚠ config.json keys missing — derived from .env; /setup to restore",
-  "doctor.d4_no_agent_cli": "→ No agent selected — D4 (addon secrets) skipped on the CLI; run /doctor in the TUI for per-agent checks."
+  "doctor.d4_no_agent_cli": "→ No agent selected — D4 (addon secrets) skipped on the CLI; run /doctor in the TUI for per-agent checks.",
+  "mail.async_label": "Async:",
+  "mail.async_running": "running",
+  "mail.async_queued": "queued",
+  "mail.async_done": "done",
+  "mail.async_failed": "failed",
+  "mail.async_daemons_hint": "/daemons for details"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -841,5 +841,11 @@
   "firstrun.self_heal_done": "已自 .env %d 枚鑰自癒 config.json。續行以佈達諸靈使。",
   "firstrun.self_heal_failed": "自癒不成：%v",
   "degraded.banner": "⚠ config.json key 缺失 — 已自 .env 推衍; /setup 復原",
-  "doctor.d4_no_agent_cli": "→ 未择 agent — CLI 略 D4 (addon 钥) 检；请在 TUI 行 /doctor 察每 agent。"
+  "doctor.d4_no_agent_cli": "→ 未择 agent — CLI 略 D4 (addon 钥) 检；请在 TUI 行 /doctor 察每 agent。",
+  "mail.async_label": "異步:",
+  "mail.async_running": "運行",
+  "mail.async_queued": "排隊",
+  "mail.async_done": "完成",
+  "mail.async_failed": "失敗",
+  "mail.async_daemons_hint": "/daemons 查看詳情"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -841,5 +841,11 @@
   "firstrun.self_heal_done": "已从 .env 的 %d 个 key 自愈 config.json。继续即可同步给 agent。",
   "firstrun.self_heal_failed": "自愈失败：%v",
   "degraded.banner": "⚠ config.json key 缺失 — 已从 .env 推导; /setup 恢复",
-  "doctor.d4_no_agent_cli": "→ 未选择 agent — CLI 跳过 D4 (addon 密钥) 检查；请在 TUI 中运行 /doctor 查看每 agent 检查。"
+  "doctor.d4_no_agent_cli": "→ 未选择 agent — CLI 跳过 D4 (addon 密钥) 检查；请在 TUI 中运行 /doctor 查看每 agent 检查。",
+  "mail.async_label": "异步:",
+  "mail.async_running": "运行",
+  "mail.async_queued": "排队",
+  "mail.async_done": "完成",
+  "mail.async_failed": "失败",
+  "mail.async_daemons_hint": "/daemons 查看详情"
 }

--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -35,6 +35,9 @@ type NetworkActivity struct {
 // DaemonCounts summarizes daemon run files under a single agent directory.
 type DaemonCounts struct {
 	Running int `json:"running"`
+	Queued  int `json:"queued"`
+	Done    int `json:"done"`
+	Failed  int `json:"failed"`
 	Total   int `json:"total"`
 }
 
@@ -300,11 +303,40 @@ func CountDaemons(agentDir string) DaemonCounts {
 			continue
 		}
 		counts.Total++
-		if isRunningDaemonState(state) {
-			counts.Running++
+		switch stateBucket(state.State) {
+		case "running":
+			if isRunningDaemonState(state) {
+				counts.Running++
+			}
+		case "queued":
+			counts.Queued++
+		case "done":
+			counts.Done++
+		case "failed":
+			counts.Failed++
 		}
 	}
 	return counts
+}
+
+// stateBucket maps a daemon.json state string to the home async-stats bucket.
+// Terminal failure states (failed/cancelled/timeout) share the "failed" bucket;
+// "running" and "active" are the live bucket; everything else (queued, pending,
+// etc.) falls through to "queued" when not finished, and is ignored otherwise.
+func stateBucket(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "running", "active":
+		return "running"
+	case "done":
+		return "done"
+	case "failed", "cancelled", "timeout", "canceled":
+		return "failed"
+	default:
+		if state == "" {
+			return ""
+		}
+		return "queued"
+	}
 }
 
 func readDaemonStateFile(path string) (daemonStateFile, bool) {

--- a/tui/internal/fs/activity_test.go
+++ b/tui/internal/fs/activity_test.go
@@ -110,6 +110,15 @@ func TestCountDaemons(t *testing.T) {
 	writeDaemonState(t, agentDir, "terminal", map[string]interface{}{
 		"state": "done",
 	})
+	writeDaemonState(t, agentDir, "queued", map[string]interface{}{
+		"state": "queued",
+	})
+	writeDaemonState(t, agentDir, "failed", map[string]interface{}{
+		"state": "failed",
+	})
+	writeDaemonState(t, agentDir, "timedout", map[string]interface{}{
+		"state": "timeout",
+	})
 	writeDaemonState(t, agentDir, "finished", map[string]interface{}{
 		"state":       "running",
 		"finished_at": "2026-05-24T12:00:00Z",
@@ -120,8 +129,17 @@ func TestCountDaemons(t *testing.T) {
 	if counts.Running != 2 {
 		t.Fatalf("running daemons = %d, want 2", counts.Running)
 	}
-	if counts.Total != 4 {
-		t.Fatalf("total daemons = %d, want 4", counts.Total)
+	if counts.Queued != 1 {
+		t.Fatalf("queued daemons = %d, want 1", counts.Queued)
+	}
+	if counts.Done != 1 {
+		t.Fatalf("done daemons = %d, want 1", counts.Done)
+	}
+	if counts.Failed != 2 {
+		t.Fatalf("failed daemons = %d, want 2 (failed+timeout)", counts.Failed)
+	}
+	if counts.Total != 7 {
+		t.Fatalf("total daemons = %d, want 7", counts.Total)
 	}
 }
 

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -401,7 +401,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, cmd
 
-	case mailRefreshMsg, mailPersistMsg, mailHistoryCountMsg, mailOlderPageMsg, homeTelemetryMsg:
+	case mailRefreshMsg, mailPersistMsg, mailHistoryCountMsg, mailOlderPageMsg, homeTelemetryMsg, homeAsyncStatsMsg:
 		// Mail content/count rebuilds, older pages, post-frame persistence, and
 		// telemetry can outlive the view that launched them. Route all at the root so Projects/Help
 		// cannot drop Mail's state machine; MailModel owns generation acceptance.
@@ -1877,6 +1877,7 @@ func (a App) returnFromVisit() (App, tea.Cmd) {
 func (a *App) resumeMailModel(restored MailModel) tea.Cmd {
 	a.installMailModel(restored)
 	a.mail.homeTelemetryInFlight = false
+	a.mail.homeAsyncStatsInFlight = false
 	var refreshCmd tea.Cmd
 	if a.mail.initialLoading {
 		refreshCmd = a.issueMailInitialRebuild()

--- a/tui/internal/tui/home_async_stats.go
+++ b/tui/internal/tui/home_async_stats.go
@@ -1,0 +1,149 @@
+package tui
+
+// Home async-work stats row.
+//
+// One muted line BELOW the input box and ABOVE the bottom path/shortcut status
+// bar that shows the orchestrator agent's async job ledger at a glance, mirroring
+// the Telegram Task Card's daemon counts ("N running · M queued · K done · J
+// failed"). It is a sibling of the home telemetry row (home_telemetry.go) and
+// follows the same contract: background tea.Cmd I/O, snapshot cached on the
+// model, never touched on View/Update hot paths, and the row's height is reserved
+// through the same mailFooterHeight budget so the status bar can never be
+// clipped by the additive line.
+//
+// Data source: <agentDir>/daemons/<run-id>/daemon.json state files — the async
+// job ledger. fs.CountDaemons() reads those state files cheaply (one JSON per
+// run directory, no ledger/event/chat/result I/O), which is the same source the
+// /daemons view and props.go detail counts use.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/anthropics/lingtai-tui/i18n"
+	"github.com/anthropics/lingtai-tui/internal/fs"
+)
+
+// homeAsyncStatsTTL is how long a fetched async-stats snapshot is considered
+// fresh, matching the home telemetry TTL so the two additive rows refresh on the
+// same cadence without doubling disk reads.
+const homeAsyncStatsTTL = 1 * time.Second
+
+// homeAsyncStats is the resolved, cached snapshot of the orchestrator agent's
+// async job ledger counts. A zero value means "no data yet / nothing to show".
+type homeAsyncStats struct {
+	running int
+	queued  int
+	done    int
+	failed  int
+}
+
+// hasData reports whether any count is present. With nothing to show the caller
+// omits the whole row.
+func (s homeAsyncStats) hasData() bool {
+	return s.running > 0 || s.queued > 0 || s.done > 0 || s.failed > 0
+}
+
+// hasHomeAsyncStats reports whether View() will render the additive async row.
+// It is the single predicate shared by the height budget (syncViewportHeight)
+// and the renderer (View), mirroring hasHomeTelemetry so they can never disagree
+// about whether the row occupies a line.
+func (m MailModel) hasHomeAsyncStats() bool {
+	return m.homeAsyncStatsLoaded && m.homeAsyncStats.hasData()
+}
+
+// fetchHomeAsyncStats returns the background command that reads the async job
+// ledger snapshot. It runs off the render/input path: os.ReadDir over the
+// daemons directory can stall on a slow volume, so like fetchHomeTelemetry it is
+// never invoked synchronously from View()/Update().
+func (m MailModel) fetchHomeAsyncStats() tea.Cmd {
+	return func() tea.Msg {
+		counts := fs.CountDaemons(m.orchestrator)
+		return homeAsyncStatsMsg{
+			generation: m.generation,
+			t: homeAsyncStats{
+				running: counts.Running,
+				queued:  counts.Queued,
+				done:    counts.Done,
+				failed:  counts.Failed,
+			},
+		}
+	}
+}
+
+// maybeScheduleHomeAsyncStats gates a background fetch by in-flight + TTL so the
+// poll loop does not spawn a new read every tick. The first fetch is always
+// allowed; subsequent fetches wait homeAsyncStatsTTL since the last completion.
+// Returns nil when no fetch should start.
+func (m MailModel) maybeScheduleHomeAsyncStats(now time.Time) tea.Cmd {
+	if m.homeAsyncStatsInFlight {
+		return nil
+	}
+	if !m.homeAsyncStatsLastFetch.IsZero() && now.Sub(m.homeAsyncStatsLastFetch) < homeAsyncStatsTTL {
+		return nil
+	}
+	return m.fetchHomeAsyncStats()
+}
+
+// applyHomeAsyncStats stores a completed snapshot and returns whether the row's
+// visibility flipped (data ⇄ no-data), so the viewport height is re-synced only
+// when the layout actually changes.
+func (m *MailModel) applyHomeAsyncStats(t homeAsyncStats, now time.Time) bool {
+	wasVisible := m.homeAsyncStatsLoaded && m.homeAsyncStats.hasData()
+	m.homeAsyncStats = t
+	m.homeAsyncStatsLoaded = true
+	m.homeAsyncStatsLastFetch = now
+	return m.homeAsyncStats.hasData() != wasVisible
+}
+
+// formatHomeAsyncStats renders the async-work row for the given terminal width,
+// or "" when there is nothing to show. The returned string is styled and
+// left-padded to align with the status-bar path label ("  " indent), matching
+// the home telemetry row.
+func formatHomeAsyncStats(s homeAsyncStats, width int) string {
+	if !s.hasData() {
+		return ""
+	}
+
+	var segs []string
+	if s.running > 0 {
+		segs = append(segs, fmt.Sprintf("%s %d", i18n.T("mail.async_running"), s.running))
+	}
+	if s.queued > 0 {
+		segs = append(segs, fmt.Sprintf("%s %d", i18n.T("mail.async_queued"), s.queued))
+	}
+	if s.done > 0 {
+		segs = append(segs, fmt.Sprintf("%s %d", i18n.T("mail.async_done"), s.done))
+	}
+	if s.failed > 0 {
+		segs = append(segs, fmt.Sprintf("%s %d", i18n.T("mail.async_failed"), s.failed))
+	}
+	if len(segs) == 0 {
+		return ""
+	}
+
+	// Lead with a localized scope label (mirroring "Session:") so the user reads
+	// "these are the orchestrator agent's async jobs". The whole row is muted.
+	segs = append([]string{i18n.T("mail.async_label")}, segs...)
+	left := "  " + StyleFaint.Render(strings.Join(segs, "  "))
+
+	// Right-side affordance pointing at the full run browser (/daemons), dropped
+	// on terminals too narrow to right-align it without colliding.
+	return appendAsyncDaemonsHint(left, width)
+}
+
+// appendAsyncDaemonsHint right-aligns a "/daemons for details" affordance
+// against the terminal width, mirroring appendKanbanHint. It returns left
+// unchanged when there isn't room for at least two spaces of gap.
+func appendAsyncDaemonsHint(left string, width int) string {
+	hint := StyleFaint.Render(i18n.T("mail.async_daemons_hint"))
+	pad := width - lipgloss.Width(left) - lipgloss.Width(hint) - 1
+	if pad < 2 {
+		return left
+	}
+	return left + strings.Repeat(" ", pad) + hint
+}

--- a/tui/internal/tui/home_async_stats_test.go
+++ b/tui/internal/tui/home_async_stats_test.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatHomeAsyncStats(t *testing.T) {
+	t.Run("no-data renders empty", func(t *testing.T) {
+		if got := formatHomeAsyncStats(homeAsyncStats{}, 80); got != "" {
+			t.Fatalf("empty stats should render nothing, got %q", got)
+		}
+	})
+
+	t.Run("counts render in order with label", func(t *testing.T) {
+		got := formatHomeAsyncStats(homeAsyncStats{running: 3, queued: 2, done: 12, failed: 1}, 120)
+		if got == "" {
+			t.Fatal("expected a row")
+		}
+		for _, want := range []string{"running 3", "queued 2", "done 12", "failed 1"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("row missing %q: %q", want, got)
+			}
+		}
+		if !strings.HasPrefix(got, "  ") {
+			t.Errorf("row should be left-padded, got %q", got)
+		}
+	})
+
+	t.Run("zero buckets are omitted", func(t *testing.T) {
+		got := formatHomeAsyncStats(homeAsyncStats{running: 1}, 80)
+		if strings.Contains(got, "queued") || strings.Contains(got, "done") || strings.Contains(got, "failed") {
+			t.Errorf("zero buckets should be omitted: %q", got)
+		}
+	})
+
+	t.Run("narrow terminal keeps hint", func(t *testing.T) {
+		got := formatHomeAsyncStats(homeAsyncStats{running: 1}, 30)
+		if got == "" {
+			t.Fatal("expected a row on narrow terminal")
+		}
+	})
+}

--- a/tui/internal/tui/home_telemetry.go
+++ b/tui/internal/tui/home_telemetry.go
@@ -94,6 +94,11 @@ type homeTelemetryMsg struct {
 	t          homeTelemetry
 }
 
+type homeAsyncStatsMsg struct {
+	generation uint64
+	t          homeAsyncStats
+}
+
 // fetchHomeTelemetry is the background worker: it performs status/context-fallback
 // I/O off the UI thread and returns a homeTelemetryMsg.
 // It is a value-receiver tea.Cmd, so it captures a snapshot of the model (orchestrator
@@ -262,12 +267,9 @@ func (m MailModel) hasHomeTelemetry() bool {
 // footer height shared by syncViewportHeight (the viewport budget) and View()
 // (the actual render), so the additive telemetry row is reserved consistently
 // and never overflows the frame.
-func mailFooterHeight(paletteLines, inputLines int, telemetryVisible bool) int {
+func mailFooterHeight(paletteLines, inputLines, telemetryRows int) int {
 	h := 1 + paletteLines + inputLines + 1 + 1 // sep + palette + input + border + status
-	if telemetryVisible {
-		h++
-	}
-	return h
+	return h + telemetryRows
 }
 
 // formatHomeTelemetry renders the telemetry row for the given terminal width, or

--- a/tui/internal/tui/home_telemetry_height_test.go
+++ b/tui/internal/tui/home_telemetry_height_test.go
@@ -13,11 +13,15 @@ import "testing"
 func TestMailFooterHeightAccountsForTelemetryRow(t *testing.T) {
 	const palette, input = 0, 1
 
-	without := mailFooterHeight(palette, input, false)
-	with := mailFooterHeight(palette, input, true)
+	without := mailFooterHeight(palette, input, 0)
+	with := mailFooterHeight(palette, input, 1)
+	both := mailFooterHeight(palette, input, 2)
 
 	if with != without+1 {
 		t.Fatalf("telemetry row must add exactly one footer line: without=%d with=%d", without, with)
+	}
+	if both != without+2 {
+		t.Fatalf("telemetry + async rows must add exactly two footer lines: without=%d both=%d", without, both)
 	}
 }
 
@@ -32,8 +36,8 @@ func TestMailFooterHeightBaseline(t *testing.T) {
 		{2, 1, 6}, // palette open
 	}
 	for _, c := range cases {
-		if got := mailFooterHeight(c.palette, c.input, false); got != c.want {
-			t.Errorf("mailFooterHeight(%d,%d,false)=%d, want %d", c.palette, c.input, got, c.want)
+		if got := mailFooterHeight(c.palette, c.input, 0); got != c.want {
+			t.Errorf("mailFooterHeight(%d,%d,0)=%d, want %d", c.palette, c.input, got, c.want)
 		}
 	}
 }

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -79,7 +79,7 @@ type mailRefreshMsg struct {
 	acceptedSnapshot     acceptedMailSnapshot
 	selectorRows         []agentSelectorRow
 	directPublication    *fs.DirectMailPublication
-	directStates         map[string]string // stable direct-thread key -> target lifecycle state
+	directStates         map[string]string    // stable direct-thread key -> target lifecycle state
 	lastProgressAt       time.Time            // orchestrator .status.json runtime.last_progress_at (zero when absent)
 	directLastProgress   map[string]time.Time // stable direct-thread key -> target last_progress_at
 	alive                bool
@@ -213,7 +213,7 @@ type MailModel struct {
 	lastInputLines       int
 	lastPaletteLines     int
 	lastBannerLines      int
-	lastTelemetryRow     bool                   // whether the home telemetry row was reserved last sync
+	lastTelemetryRows    int                    // how many additive home rows were reserved last sync
 	pendingMessage       string                 // full text from editor, sent on Enter
 	globalDir            string                 // ~/.lingtai-tui/
 	wasActive            bool                   // true if previous refresh was ACTIVE
@@ -281,6 +281,13 @@ type MailModel struct {
 	homeTelemetryLoaded    bool          // true once a background fetch has completed at least once
 	homeTelemetryInFlight  bool          // true while a fetchHomeTelemetry command is running (debounce)
 	homeTelemetryLastFetch time.Time     // completion time of the last fetch, for the TTL floor
+
+	// Home async-work stats resolve exactly like home telemetry: a background
+	// fs.CountDaemons() read, cached snapshot, in-flight debounce, TTL floor.
+	homeAsyncStats          homeAsyncStats // last-known snapshot; zero value renders no row
+	homeAsyncStatsLoaded    bool           // true once a background fetch has completed at least once
+	homeAsyncStatsInFlight  bool           // true while a fetchHomeAsyncStats command is running (debounce)
+	homeAsyncStatsLastFetch time.Time      // completion time of the last fetch, for the TTL floor
 }
 
 func NewMailModel(humanDir, humanAddr, baseDir, orchDir, orchName string, pageSize int, globalDir, lang string, insights bool, toolCallTruncate int) MailModel {
@@ -456,33 +463,38 @@ func (m *MailModel) syncViewportHeight() bool {
 	// viewport must reclaim exactly those rows while leaving Main state intact.
 	_, direct := m.currentDirectTarget()
 	bannerLines := 0
-	telemetryRow := false
+	telemetryRows := 0
 	if !direct {
 		bannerLines = m.bannerLineCount()
-		telemetryRow = m.hasHomeTelemetry()
+		if m.hasHomeTelemetry() {
+			telemetryRows++
+		}
+		if m.hasHomeAsyncStats() {
+			telemetryRows++
+		}
 	}
 	// Size the palette before consuming LineCount. Mail owns the child rectangle
 	// and reserves its fixed chrome plus one mandatory transcript row; Palette
 	// owns which cursor-following command rows fit in the remaining allowance.
-	paletteMaxHeight := m.height - 2 - bannerLines - 1 - mailFooterHeight(0, inputLines, telemetryRow)
+	paletteMaxHeight := m.height - 2 - bannerLines - 1 - mailFooterHeight(0, inputLines, telemetryRows)
 	m.palette.SetSize(m.width, paletteMaxHeight)
 	paletteLines := 0
 	if m.input.IsPaletteActive() {
 		paletteLines = m.palette.LineCount()
 	}
-	if inputLines == m.lastInputLines && paletteLines == m.lastPaletteLines && bannerLines == m.lastBannerLines && telemetryRow == m.lastTelemetryRow {
+	if inputLines == m.lastInputLines && paletteLines == m.lastPaletteLines && bannerLines == m.lastBannerLines && telemetryRows == m.lastTelemetryRows {
 		return false
 	}
 	m.lastInputLines = inputLines
 	m.lastPaletteLines = paletteLines
 	m.lastBannerLines = bannerLines
-	m.lastTelemetryRow = telemetryRow
+	m.lastTelemetryRows = telemetryRows
 	// Layout: header(2) + topBanner(0-1) + viewport + bottomBanner(0-1) + footer.
 	// The footer block (sep + palette + input + optional telemetry + status) is
 	// sized by mailFooterHeight so View() and this height budget stay in lockstep
 	// — the telemetry row added by PR #441 must be reserved here or it pushes the
 	// bottom status bar (the "ctrl+o to expand" hint) off-screen.
-	footerHeight := mailFooterHeight(paletteLines, inputLines, telemetryRow)
+	footerHeight := mailFooterHeight(paletteLines, inputLines, telemetryRows)
 	vpHeight := m.height - 2 - bannerLines - footerHeight
 	if vpHeight < 1 {
 		vpHeight = 1
@@ -1397,6 +1409,9 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		if cmd := m.maybeScheduleHomeTelemetry(time.Now()); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		if cmd := m.maybeScheduleHomeAsyncStats(time.Now()); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		return m, tea.Batch(cmds...)
 
 	case homeTelemetryMsg:
@@ -1420,6 +1435,25 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case homeAsyncStatsMsg:
+		if msg.generation != m.generation {
+			return m, nil
+		}
+		// A background async-stats fetch completed. Land the snapshot; re-sync the
+		// viewport height only when the row visibility flipped, mirroring telemetry.
+		if m.applyHomeAsyncStats(msg.t, time.Now()) && m.ready {
+			if _, direct := m.currentDirectTarget(); direct {
+				m.directChat.mainViewportDirty = true
+			} else {
+				atBottom := m.viewport.AtBottom()
+				m.syncViewportHeight()
+				m.viewport.SetContent(m.renderMessages(m.visibleMessages()))
+				if atBottom {
+					m.viewport.GotoBottom()
+				}
+			}
+			cmds = append(cmds, m.maybeScheduleHomeAsyncStats(time.Now()))
+		}
 	case SendMsg:
 		var text string
 		fromPending := false
@@ -2544,6 +2578,11 @@ func (m MailModel) view(showAgentRailExpandControl bool) string {
 	if !direct && m.hasHomeTelemetry() {
 		if telemetry := formatHomeTelemetry(m.homeTelemetry, m.width); telemetry != "" {
 			footer += telemetry + "\n"
+		}
+	}
+	if !direct && m.hasHomeAsyncStats() {
+		if async := formatHomeAsyncStats(m.homeAsyncStats, m.width); async != "" {
+			footer += async + "\n"
 		}
 	}
 	footer += statusBar


### PR DESCRIPTION
## What

Adds one muted line to the TUI home/mail footer, below the existing session telemetry row and above the bottom path/shortcut status bar, showing the orchestrator agent's async job ledger at a glance — mirroring the daemon counts the Telegram Task Card shows ("N running · M queued · K done · J failed").

## Why

Jason asked for a TUI bottom line showing async work stats like the Telegram Task Card (Telegram 10230/10236/10240), driven by the async job ledger.

## How

- New `tui/internal/tui/home_async_stats.go`: `Async: running N · queued N · done N · failed N` row (+ "/daemons for details" right affordance), following the home telemetry row contract (home_telemetry.go): background tea.Cmd read, cached snapshot, 1s TTL, never on View/Update hot paths, height reserved through the shared `mailFooterHeight` budget so the status bar is never clipped.
- Data source is the async job ledger: `<agentDir>/daemons/<run-id>/daemon.json` state files. Extended `fs.CountDaemons` (tui/internal/fs/activity.go) from {Running,Total} to {Running,Queued,Done,Failed,Total} via a new `stateBucket` (running/active → running; queued → queued; done → done; failed/cancelled/timeout/canceled → failed).
- Wired poll-loop scheduling, Update case, viewport height budget (`telemetryRows` count), app.go routing/resume reset, and i18n keys (en/zh/wen).

## Tests

- Extended `TestCountDaemons` with queued/failed/timeout buckets.
- Updated `TestMailFooterHeight*` for the int row-count signature and pinned the 2-row (telemetry+async) budget.
- New `TestFormatHomeAsyncStats` (empty, ordering, zero-bucket omission, narrow width).
- `go build ./...` clean; `go test ./internal/tui/... ./internal/fs/... ./i18n/...` all pass (tui 42.8s / fs 13.0s / i18n 0.2s).

## Validation

Base: origin/main e50e6dc6. Author Huang Zesen <hzsbazinga@outlook.com>. 11 files changed, +331/−25.

---
Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai