### PR TITLE
fix(tui): sort mail by parsed timestamp

### DIFF
--- a/tui/internal/fs/mail.go
+++ b/tui/internal/fs/mail.go
@@ -220,9 +220,10 @@ func (c MailCache) Refresh() MailCache {
 	out.scanFolder(out.inboxDir, true)
 	out.scanFolder(out.sentDir, true)
 
-	// Sort by ReceivedAt (RFC3339 strings sort lexicographically).
+	// Sort by the parsed instant; RFC3339Nano's variable-width fractional
+	// seconds do not sort chronologically as strings.
 	sort.Slice(out.Messages, func(i, j int) bool {
-		return out.Messages[i].ReceivedAt < out.Messages[j].ReceivedAt
+		return mailMessageBefore(out.Messages[i], out.Messages[j])
 	})
 	// Rebuild the mailbox-id→index map after the sort. Keyed by MailboxID, which is
 	// the mailbox directory basename (what scanFolder looks up) — not msg.ID,
@@ -233,6 +234,22 @@ func (c MailCache) Refresh() MailCache {
 		out.seen[m.MailboxID] = i
 	}
 	return out
+}
+
+func mailMessageBefore(a, b MailMessage) bool {
+	at, aErr := time.Parse(time.RFC3339Nano, a.ReceivedAt)
+	bt, bErr := time.Parse(time.RFC3339Nano, b.ReceivedAt)
+	if aErr == nil && bErr == nil {
+		if !at.Equal(bt) {
+			return at.Before(bt)
+		}
+	} else if a.ReceivedAt != b.ReceivedAt {
+		return a.ReceivedAt < b.ReceivedAt
+	}
+	if a.MailboxID != b.MailboxID {
+		return a.MailboxID < b.MailboxID
+	}
+	return a.ID < b.ID
 }
 
 // scanFolder reads mailbox-id directories in folder. For mailbox ids not yet in seen,

--- a/tui/internal/fs/mail_test.go
+++ b/tui/internal/fs/mail_test.go
@@ -345,6 +345,41 @@ func TestMailCache_InboxAndSentDeliveredTrue(t *testing.T) {
 	}
 }
 
+func TestMailCacheSortsRFC3339NanoTimestampsByInstant(t *testing.T) {
+	humanDir := t.TempDir()
+	cases := []MailMessage{
+		{ID: "later-fraction", MailboxID: "later-fraction", From: "alice", To: []string{"human"}, Message: "later fraction", ReceivedAt: "2026-08-14T10:00:00.5Z"},
+		{ID: "earlier-whole", MailboxID: "earlier-whole", From: "alice", To: []string{"human"}, Message: "earlier whole", ReceivedAt: "2026-08-14T10:00:00Z"},
+		{ID: "later-prefix", MailboxID: "later-prefix", From: "alice", To: []string{"human"}, Message: "later prefix", ReceivedAt: "2026-08-14T10:00:01.11Z"},
+		{ID: "earlier-prefix", MailboxID: "earlier-prefix", From: "alice", To: []string{"human"}, Message: "earlier prefix", ReceivedAt: "2026-08-14T10:00:01.1Z"},
+		{ID: "normal-four", MailboxID: "normal-four", From: "alice", To: []string{"human"}, Message: "normal four", ReceivedAt: "2026-08-14T10:00:02.4Z"},
+		{ID: "normal-five", MailboxID: "normal-five", From: "alice", To: []string{"human"}, Message: "normal five", ReceivedAt: "2026-08-14T10:00:02.5Z"},
+	}
+	for _, msg := range cases {
+		msgDir := filepath.Join(humanDir, "mailbox", "inbox", msg.MailboxID)
+		if err := os.MkdirAll(msgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.Marshal(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(msgDir, "message.json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cache := NewMailCache(humanDir).Refresh()
+	got := make([]string, 0, len(cache.Messages))
+	for _, msg := range cache.Messages {
+		got = append(got, msg.Message)
+	}
+	want := []string{"earlier whole", "later fraction", "earlier prefix", "later prefix", "normal four", "normal five"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("message order = %#v, want %#v", got, want)
+	}
+}
+
 func TestMailCacheCloneDetachesMutableGraphAndPreservesShapes(t *testing.T) {
 	original := MailCache{
 		seen:      map[string]int{"one": 0, "two": 1},

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -840,7 +840,7 @@ func (m *MailModel) buildMessages() {
 		m.auxiliaryMessages++
 	}
 	sort.SliceStable(chatMsgs, func(i, j int) bool {
-		return chatMsgs[i].Timestamp < chatMsgs[j].Timestamp
+		return chatMessageBefore(chatMsgs[i], chatMsgs[j])
 	})
 
 	// Restore dismissed state for insights.
@@ -850,6 +850,28 @@ func (m *MailModel) buildMessages() {
 		}
 	}
 	m.messages = chatMsgs
+}
+
+func chatMessageBefore(a, b ChatMessage) bool {
+	at, aErr := time.Parse(time.RFC3339Nano, a.Timestamp)
+	bt, bErr := time.Parse(time.RFC3339Nano, b.Timestamp)
+	if aErr == nil && bErr == nil {
+		if !at.Equal(bt) {
+			return at.Before(bt)
+		}
+	} else if a.Timestamp != b.Timestamp {
+		return a.Timestamp < b.Timestamp
+	}
+	if a.Type != b.Type {
+		return a.Type < b.Type
+	}
+	if a.From != b.From {
+		return a.From < b.From
+	}
+	if a.Body != b.Body {
+		return a.Body < b.Body
+	}
+	return a.Subject < b.Subject
 }
 
 // shouldShow returns whether a session entry should be displayed given the

--- a/tui/internal/tui/mail_mailbox_source_test.go
+++ b/tui/internal/tui/mail_mailbox_source_test.go
@@ -158,3 +158,31 @@ func TestMailModelOnlyUsesAcceptedMailboxSnapshotForRenderAndOlderPage(t *testin
 		t.Errorf("older-page reconstruction used live producer state: bodies=%v", olderBodies)
 	}
 }
+
+func TestMailModelBuildMessagesSortsRFC3339NanoTimestampsByInstant(t *testing.T) {
+	humanDir := t.TempDir()
+	orchDir := t.TempDir()
+	cache := fs.MailCache{Messages: []fs.MailMessage{
+		{ID: "later-fraction", MailboxID: "later-fraction", From: orchDir, To: "human", Message: "later fraction", ReceivedAt: "2026-08-14T10:00:00.5Z"},
+		{ID: "earlier-whole", MailboxID: "earlier-whole", From: orchDir, To: "human", Message: "earlier whole", ReceivedAt: "2026-08-14T10:00:00Z"},
+		{ID: "later-prefix", MailboxID: "later-prefix", From: orchDir, To: "human", Message: "later prefix", ReceivedAt: "2026-08-14T10:00:01.11Z"},
+		{ID: "earlier-prefix", MailboxID: "earlier-prefix", From: orchDir, To: "human", Message: "earlier prefix", ReceivedAt: "2026-08-14T10:00:01.1Z"},
+		{ID: "normal-four", MailboxID: "normal-four", From: orchDir, To: "human", Message: "normal four", ReceivedAt: "2026-08-14T10:00:02.4Z"},
+		{ID: "normal-five", MailboxID: "normal-five", From: orchDir, To: "human", Message: "normal five", ReceivedAt: "2026-08-14T10:00:02.5Z"},
+	}}
+	m := NewMailModel(humanDir, "human", t.TempDir(), orchDir, "agent", 200, "", "en", false, 0)
+	m.acceptedSnapshot = newAcceptedMailSnapshot(cache)
+
+	m.buildMessages()
+
+	got := make([]string, 0, len(m.messages))
+	for _, msg := range m.messages {
+		if msg.Type == "mail" {
+			got = append(got, msg.Body)
+		}
+	}
+	want := []string{"earlier whole", "later fraction", "earlier prefix", "later prefix", "normal four", "normal five"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("mail order = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #883. Sorts TUI mail/cache transcript entries by parsed RFC3339Nano instants with deterministic fallbacks instead of raw timestamp strings, and adds regressions for whole-second/fractional and fractional-prefix cases.