### PR TITLE
fix(tui): probe Windows agent lock

### DIFF
--- a/tui/internal/tui/lock_windows.go
+++ b/tui/internal/tui/lock_windows.go
@@ -2,7 +2,32 @@
 
 package tui
 
-// tryLock on Windows always returns true (no flock support).
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLock attempts a non-blocking exclusive lock on the lock file. Returns
+// true if the lock was acquired, and releases it immediately.
 func tryLock(path string) bool {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return true // can't open -> assume not locked
+	}
+	defer f.Close()
+	var overlapped windows.Overlapped
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		^uint32(0),
+		^uint32(0),
+		&overlapped,
+	)
+	if err != nil {
+		return false
+	}
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped)
 	return true
 }

--- a/tui/internal/tui/lock_windows_test.go
+++ b/tui/internal/tui/lock_windows_test.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestTryLockWindowsReportsHeldAndReleasedLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".agent.lock")
+	holder, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(
+		windows.Handle(holder.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		^uint32(0),
+		^uint32(0),
+		&overlapped,
+	); err != nil {
+		t.Fatalf("lock held file: %v", err)
+	}
+
+	if tryLock(path) {
+		t.Fatalf("tryLock(%q) = true while another handle holds the lock", path)
+	}
+
+	if err := windows.UnlockFileEx(windows.Handle(holder.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped); err != nil {
+		t.Fatalf("unlock held file: %v", err)
+	}
+	if !tryLock(path) {
+		t.Fatalf("tryLock(%q) = false after releasing the lock", path)
+	}
+}


### PR DESCRIPTION
Fixes #884. Implements Windows tryLock with a nonblocking exclusive LockFileEx probe, releases successful probes immediately, and adds a Windows regression for held and released lock states.