### PR TITLE
fix(tui): report Unix purge outcomes

### DIFF
--- a/tui/purge_unix.go
+++ b/tui/purge_unix.go
@@ -14,6 +14,25 @@ import (
 	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
+const (
+	purgeTermGrace      = 2 * time.Second
+	purgeVerifyDeadline = 2 * time.Second
+	purgeVerifyInterval = 100 * time.Millisecond
+)
+
+var unixSignalProcess = func(pid int, sig syscall.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(sig)
+}
+
+type purgeResult struct {
+	purged int
+	failed int
+}
+
 func purgeMain() {
 	// Optional dir filter from os.Args[2]
 	var filterDir string
@@ -57,24 +76,52 @@ func purgeMain() {
 		return
 	}
 
-	// SIGTERM first
+	result := purgeUnixProcesses(procs, purgeTermGrace)
+	if result.failed > 0 {
+		fmt.Printf("Purged %d process(es). Failed %d process(es).\n", result.purged, result.failed)
+		return
+	}
+	fmt.Printf("Purged %d process(es).\n", result.purged)
+}
+
+func purgeUnixProcesses(procs []purgeProc, termGrace time.Duration) purgeResult {
 	for _, p := range procs {
-		if proc, err := os.FindProcess(p.pid); err == nil {
-			proc.Signal(syscall.SIGTERM)
+		_ = unixSignalProcess(p.pid, syscall.SIGTERM)
+	}
+	time.Sleep(termGrace)
+
+	var result purgeResult
+	for _, p := range procs {
+		if !unixProcessAlive(p.pid) {
+			result.purged++
+			continue
+		}
+		if err := unixSignalProcess(p.pid, syscall.SIGKILL); err != nil {
+			result.failed++
+			continue
+		}
+		if waitForUnixProcessExit(p.pid, purgeVerifyDeadline, purgeVerifyInterval) {
+			result.purged++
+		} else {
+			result.failed++
 		}
 	}
-	time.Sleep(2 * time.Second)
+	return result
+}
 
-	// SIGKILL survivors
-	killed := 0
-	for _, p := range procs {
-		if proc, err := os.FindProcess(p.pid); err == nil {
-			if proc.Signal(syscall.Signal(0)) == nil {
-				proc.Signal(syscall.SIGKILL)
-			}
+func unixProcessAlive(pid int) bool {
+	return unixSignalProcess(pid, syscall.Signal(0)) == nil
+}
+
+func waitForUnixProcessExit(pid int, deadline, interval time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for {
+		if !unixProcessAlive(pid) {
+			return true
 		}
-		killed++
+		if !time.Now().Before(end) {
+			return false
+		}
+		time.Sleep(interval)
 	}
-
-	fmt.Printf("Purged %d process(es).\n", killed)
 }

--- a/tui/purge_unix_test.go
+++ b/tui/purge_unix_test.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestPurgeMainFailsLoudOnScanError(t *testing.T) {
@@ -38,5 +41,53 @@ func TestPurgeMainFailsLoudOnScanError(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "No lingtai processes found") {
 		t.Fatalf("stdout = %q, scan failure must not masquerade as an empty process list", stdout.String())
+	}
+}
+
+func TestPurgeUnixProcessesReportsObservedOutcomes(t *testing.T) {
+	origSignalProcess := unixSignalProcess
+	defer func() {
+		unixSignalProcess = origSignalProcess
+	}()
+
+	alive := map[int]bool{
+		101: true,
+		202: true,
+		303: true,
+	}
+	unixSignalProcess = func(pid int, sig syscall.Signal) error {
+		switch sig {
+		case syscall.SIGTERM:
+			if pid == 101 {
+				alive[pid] = false
+			}
+			return nil
+		case syscall.SIGKILL:
+			if pid == 303 {
+				return errors.New("permission denied")
+			}
+			alive[pid] = false
+			return nil
+		case syscall.Signal(0):
+			if alive[pid] {
+				return nil
+			}
+			return syscall.ESRCH
+		default:
+			return nil
+		}
+	}
+
+	result := purgeUnixProcesses([]purgeProc{
+		{pid: 101},
+		{pid: 202},
+		{pid: 303},
+	}, 0)
+
+	if result.purged != 2 || result.failed != 1 {
+		t.Fatalf("purge result = %+v, want purged=2 failed=1", result)
+	}
+	if waitForUnixProcessExit(303, 0, time.Millisecond) {
+		t.Fatalf("waitForUnixProcessExit reported a still-signalable process as exited")
 	}
 }


### PR DESCRIPTION
Fixes #885. Counts Unix purge results from observed signal/liveness outcomes instead of the original candidate count, reports failed processes, and adds regression coverage for SIGTERM exit, SIGKILL cleanup, and failed kill cases.