### PR TITLE
Deduplicate prompt path fields

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -3987,9 +3987,9 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 	// Pre-fill prompt paths based on language — also overridden below in setup mode.
 	langs := []string{"en", "zh", "wen"}
 	lang := langs[m.agentLangIdx]
-	m.covenantInput.SetValue(preset.CovenantPath(m.globalDir, lang))
-	m.soulFlowInput.SetValue(preset.SoulFlowPath(m.globalDir, lang))
-	m.commentInput.SetValue("")
+	setPromptPathInputValue(&m.covenantInput, preset.CovenantPath(m.globalDir, lang))
+	setPromptPathInputValue(&m.soulFlowInput, preset.SoulFlowPath(m.globalDir, lang))
+	setPromptPathInputValue(&m.commentInput, "")
 	m.covenantDirty = false
 	m.soulFlowDirty = false
 	m.karmaIdx = 0   // true
@@ -4051,17 +4051,17 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 		}
 		// Behavioral-layer paths live at the top level of init.json, not under manifest.
 		if s, ok := m.setupKeepInitJSON["covenant_file"].(string); ok && s != "" {
-			m.covenantInput.SetValue(s)
+			setPromptPathInputValue(&m.covenantInput, s)
 			m.covenantDirty = true
 		}
 		if s, ok := m.setupKeepInitJSON["soul_file"].(string); ok && s != "" {
-			m.soulFlowInput.SetValue(s)
+			setPromptPathInputValue(&m.soulFlowInput, s)
 			m.soulFlowDirty = true
 		}
 		if s, ok := m.setupKeepInitJSON["comment_file"].(string); ok && s != "" {
-			m.commentInput.SetValue(s)
+			setPromptPathInputValue(&m.commentInput, s)
 		} else if s, ok := m.setupKeepInitJSON["comment"].(string); ok {
-			m.commentInput.SetValue(s)
+			setPromptPathInputValue(&m.commentInput, s)
 		}
 	}
 
@@ -4185,11 +4185,35 @@ func (m *FirstRunModel) updatePromptPaths() {
 	langs := []string{"en", "zh", "wen"}
 	lang := langs[m.agentLangIdx]
 	if !m.covenantDirty {
-		m.covenantInput.SetValue(preset.CovenantPath(m.globalDir, lang))
+		setPromptPathInputValue(&m.covenantInput, preset.CovenantPath(m.globalDir, lang))
 	}
 	if !m.soulFlowDirty {
-		m.soulFlowInput.SetValue(preset.SoulFlowPath(m.globalDir, lang))
+		setPromptPathInputValue(&m.soulFlowInput, preset.SoulFlowPath(m.globalDir, lang))
 	}
+}
+
+func setPromptPathInputValue(input *textinput.Model, value string) {
+	input.SetValue(collapseDuplicatePromptPathLines(value))
+}
+
+func collapseDuplicatePromptPathLines(value string) string {
+	lines := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	})
+	if len(lines) <= 1 {
+		return strings.TrimSpace(value)
+	}
+	seen := make(map[string]bool, len(lines))
+	collapsed := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || seen[line] {
+			continue
+		}
+		seen[line] = true
+		collapsed = append(collapsed, line)
+	}
+	return strings.Join(collapsed, " ")
 }
 
 // getPresetProvider extracts provider name from a preset

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -826,6 +826,26 @@ func TestEnterAgentNameDirSetupModeSurfacesExistingInitLanguage(t *testing.T) {
 	}
 }
 
+func TestEnterAgentNameDirDeduplicatesRepeatedPromptPathLines(t *testing.T) {
+	repeated := "/Users/example/.lingtai-tui/covenant/en/covenant.md\n" +
+		"/Users/example/.lingtai-tui/covenant/en/covenant.md\n" +
+		"/Users/example/.lingtai-tui/covenant/en/covenant.md"
+	m := NewFirstRunModel(t.TempDir(), t.TempDir(), true)
+	m.setupMode = true
+	m.setupKeepInitJSON = map[string]interface{}{
+		"covenant_file": repeated,
+	}
+
+	m.enterAgentNameDir(preset.Preset{Name: "dedupe-test", Manifest: map[string]interface{}{}})
+
+	if got, want := m.covenantInput.Value(), "/Users/example/.lingtai-tui/covenant/en/covenant.md"; got != want {
+		t.Fatalf("covenantInput = %q, want deduplicated single path %q", got, want)
+	}
+	if strings.Count(m.View(), "covenant/en/covenant.md") != 1 {
+		t.Fatalf("view should render the repeated covenant path once:\n%s", m.View())
+	}
+}
+
 func TestPickPreset_CodexEnterShowsMethodChooser(t *testing.T) {
 	dir := t.TempDir()
 	m := FirstRunModel{


### PR DESCRIPTION
Draft for #882.

## 现状
- The screenshot shows the Step 3 prompt section rendering the same covenant path many times.
- In this repo, that page renders covenant_file, soul_file, and comment_file through single-line textinput widgets. If one of those values already contains repeated newline-separated copies, the widget view expands into repeated terminal lines.

## 方案
- Normalize prompt-path textinput values before display/save by trimming and folding repeated newline-separated entries into a single ordered, de-duplicated line.
- Keep the change scoped to prompt path fields; it does not change preset policy, recipe resolution, or project creation flow.
- Add a focused regression test for repeated covenant_file values.

## 待确认点
- Need confirmation whether the duplicate string is being written into init.json by an older runtime, by manual editing, or by a terminal paste/input path. This draft fixes the visible duplicated rendering and prevents saving the repeated lines back from this screen, but it does not yet identify every upstream producer.

## Validation
- cd tui && go test ./internal/tui