### PR TITLE
fix(tui): verify lock inode before unlink

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1269,10 +1269,9 @@ func hardRefreshDir(lingtaiCmd, dir string) error {
 	if process.IsAgentRunning(dir) {
 		_ = process.TerminateAgentProcesses(dir)
 	}
-	// Clear lingering handshake files. waitForLockClear may have force-removed
-	// .agent.lock; the others (.refresh/.refresh.taken/.suspend) get removed
-	// here so the new interpreter doesn't immediately observe a stale signal.
-	os.Remove(filepath.Join(dir, ".agent.lock"))
+	// Clear lingering handshake files. .agent.lock is removed only after taking
+	// ownership of the current lock inode; the others are one-shot markers.
+	removeAgentLockIfOwned(filepath.Join(dir, ".agent.lock"))
 	os.Remove(filepath.Join(dir, ".refresh"))
 	os.Remove(filepath.Join(dir, ".refresh.taken"))
 	os.Remove(suspendFile)
@@ -1289,20 +1288,25 @@ func hardRefreshDir(lingtaiCmd, dir string) error {
 	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
-// waitForLockClear polls for .agent.lock to free (force-removing it after
-// 60s if the holder is gone). Used by hardRefreshDir between suspend and
-// relaunch so we don't stomp a still-running agent's init.json.
+// waitForLockClear polls for .agent.lock to free. If the deadline expires, it
+// only removes a lock file whose current inode can be locked by this process.
+// Used by hardRefreshDir between suspend and relaunch so we don't stomp a
+// still-running agent's init.json.
 func waitForLockClear(dir string) {
 	lockFile := filepath.Join(dir, ".agent.lock")
-	for i := 0; i < 120; i++ { // 120 × 500ms = 60s max
+	for i := 0; i < lockWaitAttempts; i++ {
 		if tryLock(lockFile) {
 			return
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(lockWaitInterval)
 	}
-	// Process likely died without releasing lock — clean up
-	os.Remove(lockFile)
+	removeAgentLockIfOwned(lockFile)
 }
+
+var (
+	lockWaitAttempts = 120
+	lockWaitInterval = 500 * time.Millisecond
+)
 
 // resetActivePresetToDefault rewrites manifest.preset.active to match
 // manifest.preset.default in the agent's init.json. Best-effort: any error
@@ -1714,7 +1718,7 @@ func hardRefreshDirWithPreset(lingtaiCmd, dir, presetPath string) error {
 	if process.IsAgentRunning(dir) {
 		_ = process.TerminateAgentProcesses(dir)
 	}
-	os.Remove(filepath.Join(dir, ".agent.lock"))
+	removeAgentLockIfOwned(filepath.Join(dir, ".agent.lock"))
 	os.Remove(filepath.Join(dir, ".refresh"))
 	os.Remove(filepath.Join(dir, ".refresh.taken"))
 	os.Remove(suspendFile)
@@ -1730,22 +1734,22 @@ func hardRefreshDirWithPreset(lingtaiCmd, dir, presetPath string) error {
 	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
-// reviveDir waits for .agent.lock to free (force-removing it if the holder
-// is gone), then relaunches the agent. Used by /cpr (dead agent, no prior
-// suspend) and as the tail of hardRefreshDir (after writing .suspend).
+// reviveDir waits for .agent.lock to free, then relaunches the agent. Timeout
+// cleanup only removes a lock inode this process can first lock itself. Used
+// by /cpr (dead agent, no prior suspend) and as the tail of hardRefreshDir
+// (after writing .suspend).
 func reviveDir(lingtaiCmd, dir string) error {
 	lockFile := filepath.Join(dir, ".agent.lock")
 	locked := true
-	for i := 0; i < 120; i++ { // 120 × 500ms = 60s max
+	for i := 0; i < lockWaitAttempts; i++ {
 		if tryLock(lockFile) {
 			locked = false
 			break
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(lockWaitInterval)
 	}
 	if locked {
-		// Process likely died without releasing lock — clean up
-		os.Remove(lockFile)
+		removeAgentLockIfOwned(lockFile)
 	}
 	cmd, err := process.LaunchAgent(lingtaiCmd, dir)
 	if err != nil {

--- a/tui/internal/tui/lock_unix.go
+++ b/tui/internal/tui/lock_unix.go
@@ -22,3 +22,34 @@ func tryLock(path string) bool {
 	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 	return true
 }
+
+func removeAgentLockIfOwned(path string) bool {
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if os.IsNotExist(err) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return false
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+	fdInfo, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	pathInfo, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return true
+	}
+	if err != nil || !os.SameFile(fdInfo, pathInfo) {
+		return false
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/tui/internal/tui/lock_unix_test.go
+++ b/tui/internal/tui/lock_unix_test.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWaitForLockClearDoesNotUnlinkHeldLockInode(t *testing.T) {
+	dir := t.TempDir()
+	lockFile := filepath.Join(dir, ".agent.lock")
+	holder, err := os.OpenFile(lockFile, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+
+	before, err := os.Stat(lockFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origAttempts, origInterval := lockWaitAttempts, lockWaitInterval
+	lockWaitAttempts, lockWaitInterval = 1, 0
+	defer func() {
+		lockWaitAttempts, lockWaitInterval = origAttempts, origInterval
+	}()
+
+	waitForLockClear(dir)
+
+	after, err := os.Stat(lockFile)
+	if err != nil {
+		t.Fatalf("held lock path was removed after timeout: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatalf("held lock path inode changed after timeout")
+	}
+}
+
+func TestRemoveAgentLockIfOwnedRemovesUnlockedCurrentInode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".agent.lock")
+	if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !removeAgentLockIfOwned(path) {
+		t.Fatalf("removeAgentLockIfOwned(%q) = false for unlocked lock file", path)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("lock file still exists after safe removal: %v", err)
+	}
+}
+
+func TestWaitForLockClearReturnsQuicklyForUnlockedLock(t *testing.T) {
+	dir := t.TempDir()
+	origAttempts, origInterval := lockWaitAttempts, lockWaitInterval
+	lockWaitAttempts, lockWaitInterval = 2, time.Millisecond
+	defer func() {
+		lockWaitAttempts, lockWaitInterval = origAttempts, origInterval
+	}()
+
+	waitForLockClear(dir)
+}

--- a/tui/internal/tui/lock_windows.go
+++ b/tui/internal/tui/lock_windows.go
@@ -31,3 +31,13 @@ func tryLock(path string) bool {
 	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped)
 	return true
 }
+
+func removeAgentLockIfOwned(path string) bool {
+	if !tryLock(path) {
+		return false
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Fixes #886. Replaces direct .agent.lock removal with an ownership-checked cleanup path that locks the current inode and verifies pathname identity before unlinking, and adds Unix regressions for held lock timeout and unlocked cleanup.