### PR TITLE
perf(tui): only list daemons from the last 10 minutes to bound per-second kanban scan cost

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -854,5 +854,9 @@
   "mail.async_queued": "queued",
   "mail.async_done": "done",
   "mail.async_failed": "failed",
+  "mail.async_in": "in",
+  "mail.async_out": "out",
+  "mail.async_cache": "cache",
+  "mail.async_calls": "calls",
   "mail.async_daemons_hint": "/daemons for details"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -854,5 +854,9 @@
   "mail.async_queued": "排隊",
   "mail.async_done": "完成",
   "mail.async_failed": "失敗",
+  "mail.async_in": "輸入",
+  "mail.async_out": "輸出",
+  "mail.async_cache": "快取",
+  "mail.async_calls": "呼叫",
   "mail.async_daemons_hint": "/daemons 查看詳情"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -854,5 +854,9 @@
   "mail.async_queued": "排队",
   "mail.async_done": "完成",
   "mail.async_failed": "失败",
+  "mail.async_in": "输入",
+  "mail.async_out": "输出",
+  "mail.async_cache": "缓存",
+  "mail.async_calls": "调用",
   "mail.async_daemons_hint": "/daemons 查看详情"
 }

--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -280,7 +280,27 @@ type daemonStateFile struct {
 	FinishedAt json.RawMessage `json:"finished_at"`
 }
 
-// CountDaemons counts parseable daemon.json files under agentDir/daemons.
+// daemonListWindow bounds the daemon runs shown by the live kanban summary and
+// the mail async-work row to runs whose run directory was modified within the
+// last 10 minutes. Done/active/failed states are all included while recent.
+// Older historical runs remain browsable through the /daemons view; the
+// per-second dashboard never opens their state files, so a quiet week of
+// history costs no IO on the 1s tick.
+const daemonListWindow = 10 * time.Minute
+
+// withinDaemonListWindow reports whether a run's directory mtime is fresh
+// enough for the live daemon summary to scan it. The boundary is inclusive: a
+// run exactly daemonListWindow old is still shown. Future mtimes (clock skew)
+// yield a negative age and are treated as fresh.
+func withinDaemonListWindow(runModTime, now time.Time) bool {
+	return now.Sub(runModTime) <= daemonListWindow
+}
+
+// CountDaemons counts parseable daemon.json files under agentDir/daemons whose
+// run directory was modified within the last daemonListWindow. The recency gate
+// runs on directory metadata already returned by ReadDir, so stale historical
+// runs are skipped before any daemon.json read: the per-second kanban/mail
+// summary only ever opens state files for recently-active runs.
 func CountDaemons(agentDir string) DaemonCounts {
 	daemonDir := filepath.Join(agentDir, "daemons")
 	entries, err := os.ReadDir(daemonDir)
@@ -288,6 +308,7 @@ func CountDaemons(agentDir string) DaemonCounts {
 		return DaemonCounts{}
 	}
 
+	now := time.Now()
 	var counts DaemonCounts
 	for _, entry := range entries {
 		var path string
@@ -296,6 +317,13 @@ func CountDaemons(agentDir string) DaemonCounts {
 		} else if entry.Name() == "daemon.json" {
 			path = filepath.Join(daemonDir, entry.Name())
 		} else {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if !withinDaemonListWindow(info.ModTime(), now) {
 			continue
 		}
 		state, ok := readDaemonStateFile(path)

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -436,41 +436,14 @@ func ReadStatus(dir string) AgentStatus {
 	return s
 }
 
-type contextStatsCacheEntry struct {
-	size    int64
-	modTime time.Time
-	stats   ContextStats
-}
-
-var contextStatsCache = struct {
-	sync.Mutex
-	byPath map[string]contextStatsCacheEntry
-}{byPath: map[string]contextStatsCacheEntry{}}
-
 // ReadContextStats reads the agent's retained chat history and returns a
-// structural summary for diagnostics. Results are memoized by file size+mtime;
-// an unchanged detail reopen therefore does not decode the retained context
-// again, while a live append invalidates immediately.
+// structural summary for diagnostics. Missing/unreadable/malformed rows are
+// treated as empty/partial data so the kanban detail view remains best-effort.
 func ReadContextStats(dir string) ContextStats {
-	path := filepath.Join(dir, "history", "chat_history.jsonl")
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return ContextStats{}
-	}
-	contextStatsCache.Lock()
-	cached, ok := contextStatsCache.byPath[filepath.Clean(path)]
-	if ok && cached.size == info.Size() && cached.modTime.Equal(info.ModTime()) {
-		stats := cached.stats
-		stats.ToolCounts = append([]ContextToolCount(nil), stats.ToolCounts...)
-		contextStatsCache.Unlock()
-		return stats
-	}
-	contextStatsCache.Unlock()
-
 	var stats ContextStats
 	callCounts := map[string]int{}
 	resultCounts := map[string]int{}
-	_ = forEachJSONLLine(path, func(line []byte) {
+	_ = forEachJSONLLine(filepath.Join(dir, "history", "chat_history.jsonl"), func(line []byte) {
 		var entry struct {
 			Role    string          `json:"role"`
 			System  string          `json:"system"`
@@ -566,13 +539,6 @@ func ReadContextStats(dir string) ContextStats {
 			Results: resultCounts[name],
 		})
 	}
-	stored := stats
-	stored.ToolCounts = append([]ContextToolCount(nil), stats.ToolCounts...)
-	contextStatsCache.Lock()
-	contextStatsCache.byPath[filepath.Clean(path)] = contextStatsCacheEntry{
-		size: info.Size(), modTime: info.ModTime(), stats: stored,
-	}
-	contextStatsCache.Unlock()
 	return stats
 }
 
@@ -629,82 +595,31 @@ func SumTokenLedger(path string) TokenTotals {
 		return cached
 	}
 
-	scan, err := scanMainTokenLedgerFile(path, tokenLedgerCachedRecent)
+	t, err = sumTokenLedgerFile(path)
 	if err != nil {
 		return TokenTotals{}
 	}
-	storeTokenLedgerTotals(path, info, scan.totals)
-	storeTokenLedgerDetail(path, info, scan)
-	return scan.totals
+	storeTokenLedgerTotals(path, info, t)
+	return t
 }
 
-const tokenLedgerCachedRecent = 100
-
-type mainTokenLedgerScan struct {
-	totals      TokenTotals
-	byProvider  map[string]TokenTotals
-	recent      []LedgerEntry // newest first
-	recentLimit int
-	rowCount    int
-}
-
-// scanMainTokenLedgerFile builds the ordinary totals and the detail provider /
-// recent-row snapshot in the same pass. The summary path already has to decode
-// this ledger once, so retaining 100 rows and a small provider map lets Ctrl+D
-// reuse that work instead of scanning a large main ledger again.
-func scanMainTokenLedgerFile(path string, recentLimit int) (mainTokenLedgerScan, error) {
-	scan := mainTokenLedgerScan{
-		byProvider:  map[string]TokenTotals{},
-		recentLimit: recentLimit,
-	}
-	var ring []LedgerEntry
-	next := 0
+func sumTokenLedgerFile(path string) (TokenTotals, error) {
+	var t TokenTotals
 	err := forEachJSONLLine(path, func(line []byte) {
 		var entry LedgerEntry
-		if err := json.Unmarshal(line, &entry); err != nil || isDaemonLedgerEntry(entry) {
+		if err := json.Unmarshal(line, &entry); err != nil {
 			return
 		}
-		scan.rowCount++
-		scan.totals.Input += entry.Input
-		scan.totals.Output += entry.Output
-		scan.totals.Thinking += entry.Thinking
-		scan.totals.Cached += entry.Cached
-		scan.totals.APICalls++
-
-		provider := DeriveLedgerProvider(entry.Endpoint, entry.Model)
-		t := scan.byProvider[provider]
+		if isDaemonLedgerEntry(entry) {
+			return
+		}
 		t.Input += entry.Input
 		t.Output += entry.Output
 		t.Thinking += entry.Thinking
 		t.Cached += entry.Cached
 		t.APICalls++
-		scan.byProvider[provider] = t
-
-		if recentLimit <= 0 {
-			ring = append(ring, entry)
-			return
-		}
-		if len(ring) < recentLimit {
-			ring = append(ring, entry)
-			return
-		}
-		ring[next] = entry
-		next = (next + 1) % recentLimit
 	})
-	if err != nil {
-		return mainTokenLedgerScan{}, err
-	}
-	if recentLimit > 0 && len(ring) == recentLimit && next != 0 {
-		ordered := make([]LedgerEntry, 0, len(ring))
-		ordered = append(ordered, ring[next:]...)
-		ordered = append(ordered, ring[:next]...)
-		ring = ordered
-	}
-	for i, j := 0, len(ring)-1; i < j; i, j = i+1, j-1 {
-		ring[i], ring[j] = ring[j], ring[i]
-	}
-	scan.recent = ring
-	return scan, nil
+	return t, err
 }
 
 type tokenLedgerCacheEntry struct {
@@ -717,20 +632,6 @@ var tokenLedgerTotalsCache = struct {
 	sync.Mutex
 	byPath map[string]tokenLedgerCacheEntry
 }{byPath: map[string]tokenLedgerCacheEntry{}}
-
-type tokenLedgerDetailCacheEntry struct {
-	size        int64
-	modTime     time.Time
-	byProvider  map[string]TokenTotals
-	recent      []LedgerEntry
-	recentLimit int
-	rowCount    int
-}
-
-var tokenLedgerDetailCache = struct {
-	sync.Mutex
-	byPath map[string]tokenLedgerDetailCacheEntry
-}{byPath: map[string]tokenLedgerDetailCacheEntry{}}
 
 type moltSessionTokenLedgerCacheEntry struct {
 	ledgerSize    int64
@@ -768,51 +669,6 @@ func storeTokenLedgerTotals(path string, info os.FileInfo, totals TokenTotals) {
 	}
 }
 
-func cachedTokenLedgerDetail(path string, info os.FileInfo, recentN int) (map[string]TokenTotals, []LedgerEntry, bool) {
-	key := filepath.Clean(path)
-	tokenLedgerDetailCache.Lock()
-	defer tokenLedgerDetailCache.Unlock()
-	entry, ok := tokenLedgerDetailCache.byPath[key]
-	if !ok || entry.size != info.Size() || !entry.modTime.Equal(info.ModTime()) {
-		return nil, nil, false
-	}
-	if recentN <= 0 {
-		if entry.recentLimit > 0 && entry.rowCount > len(entry.recent) {
-			return nil, nil, false
-		}
-	} else if entry.recentLimit > 0 && entry.recentLimit < recentN && entry.rowCount > len(entry.recent) {
-		return nil, nil, false
-	}
-	providers := cloneTokenTotalsMap(entry.byProvider)
-	recent := entry.recent
-	if recentN > 0 && len(recent) > recentN {
-		recent = recent[:recentN]
-	}
-	return providers, append([]LedgerEntry(nil), recent...), true
-}
-
-func storeTokenLedgerDetail(path string, info os.FileInfo, scan mainTokenLedgerScan) {
-	key := filepath.Clean(path)
-	tokenLedgerDetailCache.Lock()
-	defer tokenLedgerDetailCache.Unlock()
-	tokenLedgerDetailCache.byPath[key] = tokenLedgerDetailCacheEntry{
-		size:        info.Size(),
-		modTime:     info.ModTime(),
-		byProvider:  cloneTokenTotalsMap(scan.byProvider),
-		recent:      append([]LedgerEntry(nil), scan.recent...),
-		recentLimit: scan.recentLimit,
-		rowCount:    scan.rowCount,
-	}
-}
-
-func cloneTokenTotalsMap(src map[string]TokenTotals) map[string]TokenTotals {
-	out := make(map[string]TokenTotals, len(src))
-	for key, value := range src {
-		out[key] = value
-	}
-	return out
-}
-
 // LedgerEntry is a single per-call line from logs/token_ledger.jsonl
 // surfaced to UI consumers (the kanban detail view, primarily). Older
 // entries written before kernel v0.7.x have no Model/Endpoint/Source — those
@@ -836,24 +692,48 @@ type LedgerEntry struct {
 
 // SumTokenLedgerByProvider reads a token_ledger.jsonl, groups main-agent
 // entries by derived provider name, and returns the totals plus the most-recent
-// recentN raw entries (newest first). A size+mtime snapshot populated by the
-// ordinary SumTokenLedger summary scan makes Ctrl+D a metadata-only cache hit
-// when the ledger has not changed.
-func SumTokenLedgerByProvider(path string, recentN int) (map[string]TokenTotals, []LedgerEntry) {
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return map[string]TokenTotals{}, nil
+// `recentN` raw entries (newest first). Provider attribution comes from
+// the entry's `endpoint` host when present; falls back to a `model`
+// prefix match; otherwise "unknown".
+//
+// Daemon-sourced rows are skipped here and rendered from daemon run ledgers.
+// Missing/unreadable file returns empty maps and nil entries — caller
+// renders an empty state rather than erroring.
+func SumTokenLedgerByProvider(path string, recentN int) (
+	byProvider map[string]TokenTotals, recent []LedgerEntry,
+) {
+	byProvider = map[string]TokenTotals{}
+	_ = forEachJSONLLine(path, func(line []byte) {
+		var entry LedgerEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return
+		}
+		if isDaemonLedgerEntry(entry) {
+			return
+		}
+		provider := DeriveLedgerProvider(entry.Endpoint, entry.Model)
+		t := byProvider[provider]
+		t.Input += entry.Input
+		t.Output += entry.Output
+		t.Thinking += entry.Thinking
+		t.Cached += entry.Cached
+		t.APICalls++
+		byProvider[provider] = t
+		recent = append(recent, entry)
+		if recentN > 0 && len(recent) > recentN {
+			copy(recent, recent[len(recent)-recentN:])
+			recent = recent[:recentN]
+		}
+	})
+	// Trim to the last recentN entries, newest last in file → newest at
+	// the end of `recent`. Reverse so callers can iterate "newest first".
+	if recentN > 0 && len(recent) > recentN {
+		recent = recent[len(recent)-recentN:]
 	}
-	if providers, recent, ok := cachedTokenLedgerDetail(path, info, recentN); ok {
-		return providers, recent
+	for i, j := 0, len(recent)-1; i < j; i, j = i+1, j-1 {
+		recent[i], recent[j] = recent[j], recent[i]
 	}
-	scan, err := scanMainTokenLedgerFile(path, recentN)
-	if err != nil {
-		return map[string]TokenTotals{}, nil
-	}
-	storeTokenLedgerTotals(path, info, scan.totals)
-	storeTokenLedgerDetail(path, info, scan)
-	return cloneTokenTotalsMap(scan.byProvider), append([]LedgerEntry(nil), scan.recent...)
+	return byProvider, recent
 }
 
 // SumMoltSessionTokenLedger reads an agent's logs and sums non-daemon token

--- a/tui/internal/fs/daemon_ledger.go
+++ b/tui/internal/fs/daemon_ledger.go
@@ -1,12 +1,10 @@
 package fs
 
 import (
-	"container/heap"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
-	"sync"
 )
 
 // DaemonLedgerEntry is a single per-call token_ledger.jsonl line from a
@@ -27,7 +25,7 @@ type DaemonLedgerEntry struct {
 // path needs: identity for tagging and attribution, plus the backend/preset
 // fields for fallback provider derivation when a run has no per-call ledger.
 // CLITokens and Tokens carry the typed token snapshot so a card is read only
-// once whenever its file signature changes.
+// once per run.
 type daemonCard struct {
 	Handle         string                  `json:"handle"`
 	RunID          string                  `json:"run_id"`
@@ -59,10 +57,10 @@ type daemonLegacyTokenBlock struct {
 	Cached   int64 `json:"cached"`
 }
 
-// DaemonDetailSnapshot is the bounded daemon data used by Ctrl+D. Token totals
-// and recent rows cover the newest ScannedRuns run directories, while
+// DaemonDetailSnapshot is the daemon data shown by Ctrl+D. Token totals and
+// recent rows cover the newest ScannedRuns run directories, while
 // Counts.Total is the cheap directory-entry total across all run directories.
-// Running/Queued/Done/Failed are classified only inside the recent window; the
+// Running/Queued/Done/Failed are classified only inside the scanned window; the
 // UI intentionally renders Running and Total and labels token totals with the
 // window size.
 type DaemonDetailSnapshot struct {
@@ -71,163 +69,103 @@ type DaemonDetailSnapshot struct {
 	Counts       DaemonCounts
 	ScannedRuns  int
 	TotalRuns    int
-	TerminalRuns int // total minus recent/observed-live running and queued runs
+	TerminalRuns int // total minus scanned running and queued runs
 }
-
-type daemonFileStamp struct {
-	exists  bool
-	size    int64
-	modTime int64
-}
-
-type daemonRunRef struct {
-	name    string
-	modTime int64
-}
-
-type daemonLedgerFileSummary struct {
-	byProvider map[string]TokenTotals
-	recent     []LedgerEntry // append order; bounded to the newest recentLimit rows
-	validRows  int
-}
-
-type daemonRunMemo struct {
-	cardStamp      daemonFileStamp
-	ledgerStamp    daemonFileStamp
-	heartbeatStamp daemonFileStamp
-	recentLimit    int
-	card           daemonCard
-	ledger         daemonLedgerFileSummary
-}
-
-type daemonDirectoryMemo struct {
-	dirStamp daemonFileStamp
-	runs     []daemonRunRef
-	byRun    map[string]*daemonRunMemo
-	liveRuns map[string]bool // once observed live, always rechecked until terminal
-}
-
-var daemonDetailCache = struct {
-	sync.Mutex
-	byDir map[string]*daemonDirectoryMemo
-}{byDir: map[string]*daemonDirectoryMemo{}}
 
 // ReadDaemonDetailSnapshot reads only the newest recentRunN run directories
-// (all runs when recentRunN <= 0), retains at most recentCallN globally newest
-// ledger rows, and memoizes each selected card/ledger by size+mtime.
-//
-// The daemons/ directory listing is reused while its signature is unchanged.
-// Cached run-directory mtimes are still statted so an atomically replaced file
-// or live state transition can reorder the recent window without requiring a
-// parent-directory change. For selected runs, daemon.json, token_ledger.jsonl,
-// and .heartbeat are statted on every call. A heartbeat change forces a card
-// and ledger reread, preventing a live daemon from being hidden by the memo even
-// on a filesystem with coarse content mtimes.
+// (all runs when recentRunN <= 0) and keeps at most recentCallN globally
+// newest ledger rows. It is a direct, stateless read: one ReadDir ordered by
+// run-directory mtime, then daemon.json + token_ledger.jsonl per selected run.
+// No caching or live-run retention — Ctrl+D is a point-in-time diagnostic
+// refreshed on open, explicit Ctrl+R, or agent change.
 func ReadDaemonDetailSnapshot(agentDir string, recentRunN, recentCallN int) DaemonDetailSnapshot {
 	daemonDir := filepath.Join(agentDir, "daemons")
-	key := filepath.Clean(daemonDir)
+	entries, err := os.ReadDir(daemonDir)
+	if err != nil {
+		return DaemonDetailSnapshot{ByProvider: map[string]TokenTotals{}}
+	}
 
-	daemonDetailCache.Lock()
-	defer daemonDetailCache.Unlock()
-
-	memo := daemonDetailCache.byDir[key]
-	if memo == nil {
-		memo = &daemonDirectoryMemo{
-			byRun:    map[string]*daemonRunMemo{},
-			liveRuns: map[string]bool{},
+	// Order run directories by mtime, newest first, so the scan opens only the
+	// most recently active runs.
+	type daemonRunRef struct {
+		name    string
+		modTime int64
+	}
+	runs := make([]daemonRunRef, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
 		}
-		daemonDetailCache.byDir[key] = memo
-	}
-	if !refreshDaemonRunList(daemonDir, memo) {
-		delete(daemonDetailCache.byDir, key)
-		return DaemonDetailSnapshot{}
-	}
-
-	runLimit := len(memo.runs)
-	if recentRunN > 0 && runLimit > recentRunN {
-		runLimit = recentRunN
-	}
-	runs := append([]daemonRunRef(nil), memo.runs[:runLimit]...)
-	selected := make(map[string]bool, len(runs)+len(memo.liveRuns))
-	for _, run := range runs {
-		selected[run.name] = true
-	}
-	// A run observed as live never ages out of the window. It remains on the
-	// heartbeat/card/ledger fast-refresh path until its card becomes terminal.
-	for _, run := range memo.runs[runLimit:] {
-		if memo.liveRuns[run.name] && !selected[run.name] {
-			runs = append(runs, run)
-			selected[run.name] = true
+		info, err := entry.Info()
+		if err != nil {
+			continue
 		}
+		runs = append(runs, daemonRunRef{name: entry.Name(), modTime: info.ModTime().UnixNano()})
+	}
+	sort.SliceStable(runs, func(i, j int) bool {
+		if runs[i].modTime != runs[j].modTime {
+			return runs[i].modTime > runs[j].modTime
+		}
+		return runs[i].name > runs[j].name
+	})
+	totalRuns := len(runs)
+	if recentRunN > 0 && len(runs) > recentRunN {
+		runs = runs[:recentRunN]
 	}
 
 	result := DaemonDetailSnapshot{
 		ByProvider:  map[string]TokenTotals{},
 		ScannedRuns: len(runs),
-		TotalRuns:   len(memo.runs),
+		TotalRuns:   totalRuns,
 	}
-	// The fast total counts run directories from the single cached ReadDir,
-	// rather than opening every historical daemon.json.
-	result.Counts.Total = len(memo.runs)
+	result.Counts.Total = totalRuns
 
-	var recentHeap daemonEntryHeap
-	var unbounded []DaemonLedgerEntry
+	var all []DaemonLedgerEntry
 	for _, run := range runs {
-		selected[run.name] = true
 		runDir := filepath.Join(daemonDir, run.name)
-		runMemo := refreshDaemonRunMemo(runDir, recentCallN, memo.byRun[run.name])
-		memo.byRun[run.name] = runMemo
-
-		card := runMemo.card
+		card := readDaemonCard(filepath.Join(runDir, "daemon.json"))
 		if card.RunID == "" {
 			card.RunID = run.name
 		}
 		addDaemonDetailState(&result.Counts, card)
-		state := daemonStateFile{State: card.State, FinishedAt: card.FinishedAt}
-		bucket := stateBucket(card.State)
-		if (bucket == "running" && isRunningDaemonState(state)) || bucket == "queued" {
-			memo.liveRuns[run.name] = true
-		} else {
-			delete(memo.liveRuns, run.name)
-		}
 
-		if runMemo.ledger.validRows > 0 {
-			addProviderTotals(result.ByProvider, runMemo.ledger.byProvider)
-			for _, entry := range runMemo.ledger.recent {
-				tagged := DaemonLedgerEntry{
-					LedgerEntry: entry,
+		ledgerEntries := readLedgerEntries(filepath.Join(runDir, "logs", "token_ledger.jsonl"))
+		if len(ledgerEntries) > 0 {
+			for _, e := range ledgerEntries {
+				provider := DeriveLedgerProvider(e.Endpoint, e.Model)
+				t := result.ByProvider[provider]
+				t.Input += e.Input
+				t.Output += e.Output
+				t.Thinking += e.Thinking
+				t.Cached += e.Cached
+				t.APICalls++
+				result.ByProvider[provider] = t
+
+				all = append(all, DaemonLedgerEntry{
+					LedgerEntry: e,
 					RunID:       card.RunID,
 					Handle:      card.Handle,
 					State:       card.State,
 					Backend:     card.Backend,
-				}
-				if recentCallN <= 0 {
-					unbounded = append(unbounded, tagged)
-				} else {
-					pushRecentDaemonEntry(&recentHeap, tagged, recentCallN)
-				}
+				})
 			}
 			continue
 		}
 		addDaemonFallbackTotals(result.ByProvider, card)
 	}
 
-	// Keep the process cache bounded to the currently selected run window.
-	for name := range memo.byRun {
-		if !selected[name] {
-			delete(memo.byRun, name)
-		}
+	// Global newest-first sort by ts, then keep the newest recentCallN rows.
+	sort.SliceStable(all, func(i, j int) bool {
+		return all[i].TS > all[j].TS
+	})
+	if recentCallN > 0 && len(all) > recentCallN {
+		all = all[:recentCallN]
 	}
+	result.Recent = all
 
 	result.TerminalRuns = result.TotalRuns - result.Counts.Running - result.Counts.Queued
 	if result.TerminalRuns < 0 {
 		result.TerminalRuns = 0
-	}
-	if recentCallN <= 0 {
-		sort.SliceStable(unbounded, func(i, j int) bool { return unbounded[i].TS > unbounded[j].TS })
-		result.Recent = unbounded
-	} else {
-		result.Recent = drainRecentDaemonEntries(&recentHeap)
 	}
 	return result
 }
@@ -248,96 +186,6 @@ func DaemonRecentLedger(agentDir string, recentN int) []DaemonLedgerEntry {
 	return recent
 }
 
-func daemonPathStamp(path string) daemonFileStamp {
-	info, err := os.Stat(path)
-	if err != nil {
-		return daemonFileStamp{}
-	}
-	return daemonFileStamp{exists: true, size: info.Size(), modTime: info.ModTime().UnixNano()}
-}
-
-// refreshDaemonRunList avoids ReadDir on an unchanged directory. It still
-// compares every cached run-directory mtime, which is metadata-only O(D) work
-// and is what makes recent-by-mtime ordering responsive to run transitions.
-func refreshDaemonRunList(daemonDir string, memo *daemonDirectoryMemo) bool {
-	dirStamp := daemonPathStamp(daemonDir)
-	if !dirStamp.exists {
-		return false
-	}
-
-	needReadDir := !memo.dirStamp.exists || memo.dirStamp != dirStamp
-	changed := false
-	if !needReadDir {
-		for i := range memo.runs {
-			stamp := daemonPathStamp(filepath.Join(daemonDir, memo.runs[i].name))
-			if !stamp.exists {
-				needReadDir = true
-				break
-			}
-			if memo.runs[i].modTime != stamp.modTime {
-				memo.runs[i].modTime = stamp.modTime
-				changed = true
-			}
-		}
-	}
-
-	if needReadDir {
-		entries, err := os.ReadDir(daemonDir)
-		if err != nil {
-			return false
-		}
-		runs := make([]daemonRunRef, 0, len(entries))
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			info, err := entry.Info()
-			if err != nil {
-				continue
-			}
-			runs = append(runs, daemonRunRef{name: entry.Name(), modTime: info.ModTime().UnixNano()})
-		}
-		memo.runs = runs
-		memo.dirStamp = dirStamp
-		changed = true
-	}
-
-	if changed {
-		sort.SliceStable(memo.runs, func(i, j int) bool {
-			if memo.runs[i].modTime != memo.runs[j].modTime {
-				return memo.runs[i].modTime > memo.runs[j].modTime
-			}
-			return memo.runs[i].name > memo.runs[j].name
-		})
-	}
-	return true
-}
-
-func refreshDaemonRunMemo(runDir string, recentLimit int, memo *daemonRunMemo) *daemonRunMemo {
-	if memo == nil {
-		memo = &daemonRunMemo{}
-	}
-
-	heartbeatStamp := daemonPathStamp(filepath.Join(runDir, ".heartbeat"))
-	liveChanged := memo.heartbeatStamp != heartbeatStamp
-	cardPath := filepath.Join(runDir, "daemon.json")
-	cardStamp := daemonPathStamp(cardPath)
-	if liveChanged || memo.cardStamp != cardStamp {
-		memo.card = readDaemonCard(cardPath)
-		memo.cardStamp = cardStamp
-	}
-
-	ledgerPath := filepath.Join(runDir, "logs", "token_ledger.jsonl")
-	ledgerStamp := daemonPathStamp(ledgerPath)
-	if liveChanged || memo.ledgerStamp != ledgerStamp || memo.recentLimit != recentLimit {
-		memo.ledger = readDaemonLedgerSummary(ledgerPath, recentLimit)
-		memo.ledgerStamp = ledgerStamp
-		memo.recentLimit = recentLimit
-	}
-	memo.heartbeatStamp = heartbeatStamp
-	return memo
-}
-
 // readDaemonCard reads daemon.json; missing or malformed files yield a zero card.
 func readDaemonCard(path string) daemonCard {
 	var card daemonCard
@@ -351,58 +199,34 @@ func readDaemonCard(path string) daemonCard {
 	return card
 }
 
-// readDaemonLedgerSummary streams a ledger once. It aggregates while decoding
-// and retains only a fixed-size ring of recent rows instead of materializing
-// every historical LedgerEntry and truncating after a global sort.
-func readDaemonLedgerSummary(path string, recentLimit int) daemonLedgerFileSummary {
-	out := daemonLedgerFileSummary{byProvider: map[string]TokenTotals{}}
-	var ring []LedgerEntry
-	next := 0
+// readLedgerEntries parses every well-formed object line of a token_ledger.jsonl
+// file into LedgerEntry values (file order preserved). Missing file or
+// malformed lines are skipped silently.
+func readLedgerEntries(path string) []LedgerEntry {
+	var out []LedgerEntry
 	_ = forEachJSONLLine(path, func(line []byte) {
-		var entry LedgerEntry
-		if line[0] != '{' || json.Unmarshal(line, &entry) != nil {
+		var e LedgerEntry
+		if line[0] != '{' || json.Unmarshal(line, &e) != nil {
 			return
 		}
-		out.validRows++
-		provider := DeriveLedgerProvider(entry.Endpoint, entry.Model)
-		t := out.byProvider[provider]
-		t.Input += entry.Input
-		t.Output += entry.Output
-		t.Thinking += entry.Thinking
-		t.Cached += entry.Cached
-		t.APICalls++
-		out.byProvider[provider] = t
-
-		if recentLimit <= 0 {
-			ring = append(ring, entry)
-			return
-		}
-		if len(ring) < recentLimit {
-			ring = append(ring, entry)
-			return
-		}
-		ring[next] = entry
-		next = (next + 1) % recentLimit
+		out = append(out, e)
 	})
-	if recentLimit > 0 && len(ring) == recentLimit && next != 0 {
-		ordered := make([]LedgerEntry, 0, len(ring))
-		ordered = append(ordered, ring[next:]...)
-		ordered = append(ordered, ring[:next]...)
-		ring = ordered
-	}
-	out.recent = ring
 	return out
 }
 
-func addProviderTotals(dst, src map[string]TokenTotals) {
-	for provider, value := range src {
-		t := dst[provider]
-		t.Input += value.Input
-		t.Output += value.Output
-		t.Thinking += value.Thinking
-		t.Cached += value.Cached
-		t.APICalls += value.APICalls
-		dst[provider] = t
+func addDaemonDetailState(counts *DaemonCounts, card daemonCard) {
+	state := daemonStateFile{State: card.State, FinishedAt: card.FinishedAt}
+	switch stateBucket(card.State) {
+	case "running":
+		if isRunningDaemonState(state) {
+			counts.Running++
+		}
+	case "queued":
+		counts.Queued++
+	case "done":
+		counts.Done++
+	case "failed":
+		counts.Failed++
 	}
 }
 
@@ -433,62 +257,6 @@ func addDaemonFallbackTotals(dst map[string]TokenTotals, card daemonCard) {
 	t.Cached += cached
 	t.APICalls += calls
 	dst[provider] = t
-}
-
-func addDaemonDetailState(counts *DaemonCounts, card daemonCard) {
-	state := daemonStateFile{State: card.State, FinishedAt: card.FinishedAt}
-	switch stateBucket(card.State) {
-	case "running":
-		if isRunningDaemonState(state) {
-			counts.Running++
-		}
-	case "queued":
-		counts.Queued++
-	case "done":
-		counts.Done++
-	case "failed":
-		counts.Failed++
-	}
-}
-
-type daemonEntryHeap []DaemonLedgerEntry
-
-func (h daemonEntryHeap) Len() int { return len(h) }
-func (h daemonEntryHeap) Less(i, j int) bool {
-	if h[i].TS != h[j].TS {
-		return h[i].TS < h[j].TS
-	}
-	return h[i].RunID < h[j].RunID
-}
-func (h daemonEntryHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
-func (h *daemonEntryHeap) Push(x any)   { *h = append(*h, x.(DaemonLedgerEntry)) }
-func (h *daemonEntryHeap) Pop() any {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[:n-1]
-	return x
-}
-
-func pushRecentDaemonEntry(h *daemonEntryHeap, entry DaemonLedgerEntry, limit int) {
-	if h.Len() < limit {
-		heap.Push(h, entry)
-		return
-	}
-	oldest := (*h)[0]
-	if entry.TS < oldest.TS || (entry.TS == oldest.TS && entry.RunID <= oldest.RunID) {
-		return
-	}
-	heap.Pop(h)
-	heap.Push(h, entry)
-}
-
-func drainRecentDaemonEntries(h *daemonEntryHeap) []DaemonLedgerEntry {
-	out := make([]DaemonLedgerEntry, h.Len())
-	for i := len(out) - 1; i >= 0; i-- {
-		out[i] = heap.Pop(h).(DaemonLedgerEntry)
-	}
-	return out
 }
 
 // daemonFallbackProvider derives a provider/backend label for daemon runs

--- a/tui/internal/fs/daemon_ledger.go
+++ b/tui/internal/fs/daemon_ledger.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 )
 
 // DaemonLedgerEntry is a single per-call token_ledger.jsonl line from a
@@ -184,6 +185,59 @@ func DaemonLedgerSummary(agentDir string, recentN int) (map[string]TokenTotals, 
 func DaemonRecentLedger(agentDir string, recentN int) []DaemonLedgerEntry {
 	_, recent := DaemonLedgerSummary(agentDir, recentN)
 	return recent
+}
+
+// DaemonRecentLedgerSummary aggregates token usage and API-call counts across
+// only the daemon runs whose run directory was modified within daemonListWindow
+// (10 minutes), mirroring CountDaemons' recency gate. The mail async-work row
+// and any other per-second consumer call this so token ledgers are never opened
+// for stale historical runs: one ReadDir yields the directory metadata, and only
+// in-window runs get their daemon.json / token_ledger.jsonl read. Per-run totals
+// follow ReadDaemonDetailSnapshot: the per-call ledger when present, else the
+// daemon.json cli_tokens/legacy snapshot (CLI backends write no ledger).
+func DaemonRecentLedgerSummary(agentDir string) TokenTotals {
+	daemonDir := filepath.Join(agentDir, "daemons")
+	entries, err := os.ReadDir(daemonDir)
+	if err != nil {
+		return TokenTotals{}
+	}
+
+	now := time.Now()
+	var totals TokenTotals
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if !withinDaemonListWindow(info.ModTime(), now) {
+			continue
+		}
+		runDir := filepath.Join(daemonDir, entry.Name())
+		card := readDaemonCard(filepath.Join(runDir, "daemon.json"))
+		if ledger := readLedgerEntries(filepath.Join(runDir, "logs", "token_ledger.jsonl")); len(ledger) > 0 {
+			for _, e := range ledger {
+				totals.Input += e.Input
+				totals.Output += e.Output
+				totals.Thinking += e.Thinking
+				totals.Cached += e.Cached
+				totals.APICalls++
+			}
+			continue
+		}
+		byProvider := map[string]TokenTotals{}
+		addDaemonFallbackTotals(byProvider, card)
+		for _, t := range byProvider {
+			totals.Input += t.Input
+			totals.Output += t.Output
+			totals.Thinking += t.Thinking
+			totals.Cached += t.Cached
+			totals.APICalls += t.APICalls
+		}
+	}
+	return totals
 }
 
 // readDaemonCard reads daemon.json; missing or malformed files yield a zero card.

--- a/tui/internal/fs/daemon_ledger_test.go
+++ b/tui/internal/fs/daemon_ledger_test.go
@@ -661,6 +661,140 @@ func TestDaemonDetailSnapshotInvalidatesLiveRunOnNewLedgerRow(t *testing.T) {
 	}
 }
 
+// --- 10-minute live-window tests (CountDaemons) ---
+
+// setRunDirMtime backdates a run directory's mtime to stamp. The daemon.json
+// inside keeps its own fresh mtime, so any read of the state file would be
+// observable through the counts.
+func setRunDirMtime(t *testing.T, agentDir, runID string, stamp time.Time) {
+	t.Helper()
+	runDir := filepath.Join(agentDir, "daemons", runID)
+	if err := os.Chtimes(runDir, stamp, stamp); err != nil {
+		t.Fatalf("chtimes run dir %s: %v", runID, err)
+	}
+}
+
+func TestCountDaemonsWindowIncludesRecentRuns(t *testing.T) {
+	agentDir := t.TempDir()
+	writeDaemonState(t, agentDir, "r1", map[string]interface{}{"state": "running"})
+	writeDaemonState(t, agentDir, "r2", map[string]interface{}{"state": "active"})
+	writeDaemonState(t, agentDir, "r3", map[string]interface{}{"state": "done"})
+	writeDaemonState(t, agentDir, "r4", map[string]interface{}{"state": "failed"})
+	writeDaemonState(t, agentDir, "r5", map[string]interface{}{"state": "queued"})
+	// One second inside the window; every state shows while recent.
+	inside := time.Now().Add(-(daemonListWindow - time.Second))
+	for _, runID := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		setRunDirMtime(t, agentDir, runID, inside)
+	}
+
+	counts := CountDaemons(agentDir)
+	if counts.Running != 2 || counts.Queued != 1 || counts.Done != 1 || counts.Failed != 1 || counts.Total != 5 {
+		t.Fatalf("recent-window counts = %+v, want running:2 queued:1 done:1 failed:1 total:5", counts)
+	}
+}
+
+func TestCountDaemonsWindowSkipsStaleRunsWithoutReadingState(t *testing.T) {
+	agentDir := t.TempDir()
+	writeDaemonState(t, agentDir, "fresh", map[string]interface{}{"state": "running"})
+
+	// Stale runs: their daemon.json files are fresh on disk and would each count
+	// as running/done/failed if opened, but the run directories are far outside
+	// the window. CountDaemons must short-circuit on the directory mtime before
+	// any state-file read, so none of these can leak into the summary.
+	for _, runID := range []string{"stale-running", "stale-done", "stale-failed"} {
+		writeDaemonState(t, agentDir, runID, map[string]interface{}{"state": "running"})
+		setRunDirMtime(t, agentDir, runID, time.Now().Add(-(daemonListWindow + time.Hour)))
+	}
+
+	counts := CountDaemons(agentDir)
+	if counts.Total != 1 || counts.Running != 1 || counts.Done != 0 || counts.Failed != 0 || counts.Queued != 0 {
+		t.Fatalf("stale runs leaked into summary: %+v", counts)
+	}
+}
+
+func TestCountDaemonsWindowBoundary(t *testing.T) {
+	now := time.Now()
+	if !withinDaemonListWindow(now.Add(-daemonListWindow), now) {
+		t.Error("run exactly daemonListWindow old should still be included")
+	}
+	if !withinDaemonListWindow(now, now) {
+		t.Error("run with zero age should be included")
+	}
+	if !withinDaemonListWindow(now.Add(time.Minute), now) {
+		t.Error("future-mtime run (clock skew) should be included")
+	}
+	if withinDaemonListWindow(now.Add(-(daemonListWindow + time.Nanosecond)), now) {
+		t.Error("run just past daemonListWindow should be excluded")
+	}
+}
+
+func TestCountDaemonsWindowGatesFlatDaemonJSON(t *testing.T) {
+	agentDir := t.TempDir()
+	writeDaemonState(t, agentDir, "sub", map[string]interface{}{"state": "done"})
+
+	// Legacy flat layout: a daemon.json directly under daemons/ is gated by its
+	// own file mtime, not a run-directory mtime.
+	flat := filepath.Join(agentDir, "daemons", "daemon.json")
+	if err := os.MkdirAll(filepath.Dir(flat), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flat, []byte(`{"state":"running"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-(daemonListWindow + time.Hour))
+	if err := os.Chtimes(flat, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	counts := CountDaemons(agentDir)
+	if counts.Running != 0 || counts.Total != 1 {
+		t.Fatalf("stale flat daemon.json counted: %+v", counts)
+	}
+}
+
+// BenchmarkCountDaemonsManyStaleRuns measures the per-second summary over a
+// daemons directory dominated by historical runs: the window gate must skip all
+// stale directories on directory metadata alone, never opening their state
+// files, so the tick stays cheap regardless of accumulated history.
+func BenchmarkCountDaemonsManyStaleRuns(b *testing.B) {
+	agentDir := b.TempDir()
+	daemonDir := filepath.Join(agentDir, "daemons")
+	staleBase := time.Now().Add(-(daemonListWindow + 30*24*time.Hour))
+	for i := 0; i < 1500; i++ {
+		runID := fmt.Sprintf("em-%04d", i)
+		runDir := filepath.Join(daemonDir, runID)
+		if err := os.MkdirAll(runDir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(runDir, "daemon.json"), []byte(`{"state":"done"}`), 0o644); err != nil {
+			b.Fatal(err)
+		}
+		stamp := staleBase.Add(time.Duration(i) * time.Second)
+		if err := os.Chtimes(runDir, stamp, stamp); err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := 0; i < 5; i++ {
+		runID := fmt.Sprintf("live-%d", i)
+		runDir := filepath.Join(daemonDir, runID)
+		if err := os.MkdirAll(runDir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(runDir, "daemon.json"), []byte(`{"state":"running"}`), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		counts := CountDaemons(agentDir)
+		if counts.Total != 5 || counts.Running != 5 {
+			b.Fatalf("bad counts: %+v", counts)
+		}
+	}
+}
+
 func BenchmarkDaemonDetailSnapshot1500Runs(b *testing.B) {
 	agentDir := b.TempDir()
 	base := time.Unix(1_700_000_000, 0)

--- a/tui/internal/fs/daemon_ledger_test.go
+++ b/tui/internal/fs/daemon_ledger_test.go
@@ -578,89 +578,6 @@ func TestDaemonLedgerSummaryZeroCLITokensFallsBackToLegacyTokens(t *testing.T) {
 	}
 }
 
-func TestDaemonDetailSnapshotBoundsRunContentsButCountsAllDirectories(t *testing.T) {
-	agentDir := t.TempDir()
-	base := time.Unix(1_700_000_000, 0)
-	for i := 1; i <= 5; i++ {
-		runID := fmt.Sprintf("em-%d", i)
-		state := "done"
-		if i == 5 {
-			state = "running"
-		}
-		writeDaemonState(t, agentDir, runID, map[string]interface{}{
-			"handle": fmt.Sprintf("em-%d", i),
-			"state":  state,
-		})
-		writeDaemonLedger(t, agentDir, runID, []string{
-			fmt.Sprintf(`{"ts":"2026-01-01T00:00:0%dZ","input":%d}`, i, i),
-		})
-		runDir := filepath.Join(agentDir, "daemons", runID)
-		stamp := base.Add(time.Duration(i) * time.Second)
-		if err := os.Chtimes(runDir, stamp, stamp); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	snapshot := ReadDaemonDetailSnapshot(agentDir, 2, 100)
-	if snapshot.TotalRuns != 5 || snapshot.Counts.Total != 5 || snapshot.ScannedRuns != 2 {
-		t.Fatalf("window/counts = scanned:%d total:%d counts:%+v", snapshot.ScannedRuns, snapshot.TotalRuns, snapshot.Counts)
-	}
-	if snapshot.Counts.Running != 1 || snapshot.TerminalRuns != 4 {
-		t.Fatalf("running/terminal = %d/%d, want 1/4", snapshot.Counts.Running, snapshot.TerminalRuns)
-	}
-	if got := snapshot.ByProvider["unknown"].Input; got != 9 {
-		t.Fatalf("recent-window input = %d, want 9 (runs 5+4)", got)
-	}
-	if len(snapshot.Recent) != 2 || snapshot.Recent[0].Input != 5 || snapshot.Recent[1].Input != 4 {
-		t.Fatalf("recent rows = %+v", snapshot.Recent)
-	}
-}
-
-func TestDaemonDetailSnapshotInvalidatesLiveRunOnNewLedgerRow(t *testing.T) {
-	agentDir := t.TempDir()
-	runID := "em-live"
-	writeDaemonState(t, agentDir, runID, map[string]interface{}{
-		"handle": "em-live",
-		"state":  "running",
-	})
-	writeDaemonLedger(t, agentDir, runID, []string{
-		`{"ts":"2026-01-01T00:00:01Z","input":1}`,
-	})
-	heartbeat := filepath.Join(agentDir, "daemons", runID, ".heartbeat")
-	if err := os.WriteFile(heartbeat, nil, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	first := ReadDaemonDetailSnapshot(agentDir, 128, 100)
-	if len(first.Recent) != 1 {
-		t.Fatalf("first rows = %d, want 1", len(first.Recent))
-	}
-	ledger := filepath.Join(agentDir, "daemons", runID, "logs", "token_ledger.jsonl")
-	f, err := os.OpenFile(ledger, os.O_APPEND|os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := f.WriteString(`{"ts":"2026-01-01T00:00:02Z","input":2}` + "\n"); err != nil {
-		f.Close()
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(heartbeat, future, future); err != nil {
-		t.Fatal(err)
-	}
-
-	second := ReadDaemonDetailSnapshot(agentDir, 128, 100)
-	if len(second.Recent) != 2 || second.Recent[0].Input != 2 {
-		t.Fatalf("live append hidden by cache: %+v", second.Recent)
-	}
-	if got := second.ByProvider["unknown"].Input; got != 3 {
-		t.Fatalf("live total input = %d, want 3", got)
-	}
-}
-
 // --- 10-minute live-window tests (CountDaemons) ---
 
 // setRunDirMtime backdates a run directory's mtime to stamp. The daemon.json
@@ -712,119 +629,44 @@ func TestCountDaemonsWindowSkipsStaleRunsWithoutReadingState(t *testing.T) {
 	}
 }
 
-func TestCountDaemonsWindowBoundary(t *testing.T) {
-	now := time.Now()
-	if !withinDaemonListWindow(now.Add(-daemonListWindow), now) {
-		t.Error("run exactly daemonListWindow old should still be included")
-	}
-	if !withinDaemonListWindow(now, now) {
-		t.Error("run with zero age should be included")
-	}
-	if !withinDaemonListWindow(now.Add(time.Minute), now) {
-		t.Error("future-mtime run (clock skew) should be included")
-	}
-	if withinDaemonListWindow(now.Add(-(daemonListWindow + time.Nanosecond)), now) {
-		t.Error("run just past daemonListWindow should be excluded")
-	}
-}
-
-func TestCountDaemonsWindowGatesFlatDaemonJSON(t *testing.T) {
+// TestDaemonDetailSnapshotReturnsRecentRuns proves the Ctrl+D detail snapshot
+// still reads only the newest recentRunN run directories in one stateless pass
+// (no cache, no retention) and returns their ledger rows, state counts, and
+// window metadata.
+func TestDaemonDetailSnapshotReturnsRecentRuns(t *testing.T) {
 	agentDir := t.TempDir()
-	writeDaemonState(t, agentDir, "sub", map[string]interface{}{"state": "done"})
-
-	// Legacy flat layout: a daemon.json directly under daemons/ is gated by its
-	// own file mtime, not a run-directory mtime.
-	flat := filepath.Join(agentDir, "daemons", "daemon.json")
-	if err := os.MkdirAll(filepath.Dir(flat), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(flat, []byte(`{"state":"running"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	stale := time.Now().Add(-(daemonListWindow + time.Hour))
-	if err := os.Chtimes(flat, stale, stale); err != nil {
-		t.Fatal(err)
-	}
-
-	counts := CountDaemons(agentDir)
-	if counts.Running != 0 || counts.Total != 1 {
-		t.Fatalf("stale flat daemon.json counted: %+v", counts)
-	}
-}
-
-// BenchmarkCountDaemonsManyStaleRuns measures the per-second summary over a
-// daemons directory dominated by historical runs: the window gate must skip all
-// stale directories on directory metadata alone, never opening their state
-// files, so the tick stays cheap regardless of accumulated history.
-func BenchmarkCountDaemonsManyStaleRuns(b *testing.B) {
-	agentDir := b.TempDir()
-	daemonDir := filepath.Join(agentDir, "daemons")
-	staleBase := time.Now().Add(-(daemonListWindow + 30*24*time.Hour))
-	for i := 0; i < 1500; i++ {
-		runID := fmt.Sprintf("em-%04d", i)
-		runDir := filepath.Join(daemonDir, runID)
-		if err := os.MkdirAll(runDir, 0o755); err != nil {
-			b.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(runDir, "daemon.json"), []byte(`{"state":"done"}`), 0o644); err != nil {
-			b.Fatal(err)
-		}
-		stamp := staleBase.Add(time.Duration(i) * time.Second)
-		if err := os.Chtimes(runDir, stamp, stamp); err != nil {
-			b.Fatal(err)
-		}
-	}
-	for i := 0; i < 5; i++ {
-		runID := fmt.Sprintf("live-%d", i)
-		runDir := filepath.Join(daemonDir, runID)
-		if err := os.MkdirAll(runDir, 0o755); err != nil {
-			b.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(runDir, "daemon.json"), []byte(`{"state":"running"}`), 0o644); err != nil {
-			b.Fatal(err)
-		}
-	}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		counts := CountDaemons(agentDir)
-		if counts.Total != 5 || counts.Running != 5 {
-			b.Fatalf("bad counts: %+v", counts)
-		}
-	}
-}
-
-func BenchmarkDaemonDetailSnapshot1500Runs(b *testing.B) {
-	agentDir := b.TempDir()
 	base := time.Unix(1_700_000_000, 0)
-	for i := 0; i < 1500; i++ {
-		runID := fmt.Sprintf("em-%04d", i)
+	for i := 1; i <= 5; i++ {
+		runID := fmt.Sprintf("em-%d", i)
+		state := "done"
+		if i == 5 {
+			state = "running"
+		}
+		writeDaemonState(t, agentDir, runID, map[string]interface{}{
+			"handle": fmt.Sprintf("em-%d", i),
+			"state":  state,
+		})
+		writeDaemonLedger(t, agentDir, runID, []string{
+			fmt.Sprintf(`{"ts":"2026-01-01T00:00:0%dZ","input":%d}`, i, i),
+		})
 		runDir := filepath.Join(agentDir, "daemons", runID)
-		logsDir := filepath.Join(runDir, "logs")
-		if err := os.MkdirAll(logsDir, 0o755); err != nil {
-			b.Fatal(err)
-		}
-		card := fmt.Sprintf(`{"handle":%q,"state":"done"}`, runID)
-		if err := os.WriteFile(filepath.Join(runDir, "daemon.json"), []byte(card), 0o644); err != nil {
-			b.Fatal(err)
-		}
-		ledger := fmt.Sprintf(`{"ts":"2026-01-01T00:00:00.%06dZ","input":1}`+"\n", i)
-		if err := os.WriteFile(filepath.Join(logsDir, "token_ledger.jsonl"), []byte(ledger), 0o644); err != nil {
-			b.Fatal(err)
-		}
 		stamp := base.Add(time.Duration(i) * time.Second)
 		if err := os.Chtimes(runDir, stamp, stamp); err != nil {
-			b.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		snapshot := ReadDaemonDetailSnapshot(agentDir, 128, 100)
-		if snapshot.TotalRuns != 1500 || snapshot.ScannedRuns != 128 || len(snapshot.Recent) != 100 {
-			b.Fatalf("bad snapshot: total=%d scanned=%d rows=%d", snapshot.TotalRuns, snapshot.ScannedRuns, len(snapshot.Recent))
-		}
+	snapshot := ReadDaemonDetailSnapshot(agentDir, 2, 100)
+	if snapshot.TotalRuns != 5 || snapshot.Counts.Total != 5 || snapshot.ScannedRuns != 2 {
+		t.Fatalf("window/counts = scanned:%d total:%d counts:%+v", snapshot.ScannedRuns, snapshot.TotalRuns, snapshot.Counts)
+	}
+	if snapshot.Counts.Running != 1 || snapshot.TerminalRuns != 4 {
+		t.Fatalf("running/terminal = %d/%d, want 1/4", snapshot.Counts.Running, snapshot.TerminalRuns)
+	}
+	if got := snapshot.ByProvider["unknown"].Input; got != 9 {
+		t.Fatalf("recent-window input = %d, want 9 (runs 5+4)", got)
+	}
+	if len(snapshot.Recent) != 2 || snapshot.Recent[0].Input != 5 || snapshot.Recent[1].Input != 4 {
+		t.Fatalf("recent rows = %+v", snapshot.Recent)
 	}
 }

--- a/tui/internal/fs/daemon_ledger_test.go
+++ b/tui/internal/fs/daemon_ledger_test.go
@@ -629,6 +629,42 @@ func TestCountDaemonsWindowSkipsStaleRunsWithoutReadingState(t *testing.T) {
 	}
 }
 
+// TestDaemonRecentLedgerSummaryReadsOnlyWindow proves the mail async-row token
+// summary aggregates only runs inside daemonListWindow (10 minutes): fresh runs
+// contribute per-call ledger totals (with the cli_tokens fallback for CLI
+// backends that write no ledger), while a stale run's ledger is never opened.
+func TestDaemonRecentLedgerSummaryReadsOnlyWindow(t *testing.T) {
+	agentDir := t.TempDir()
+	writeDaemonLedger(t, agentDir, "fresh-a", []string{
+		`{"input":100,"output":20,"thinking":5,"cached":40}`,
+		`{"input":200,"output":50,"thinking":10,"cached":80}`,
+	})
+	writeDaemonLedger(t, agentDir, "fresh-b", []string{
+		`{"input":300,"output":60,"thinking":15,"cached":120}`,
+	})
+	// In-window CLI-backend run with no per-call ledger: falls back to cli_tokens.
+	writeDaemonState(t, agentDir, "fresh-cli", map[string]interface{}{
+		"cli_tokens": map[string]interface{}{"input": 500, "output": 100, "thinking": 20, "cached": 50, "calls": 3},
+	})
+	// Stale run far outside the window: its ledger must never be read.
+	writeDaemonLedger(t, agentDir, "stale", []string{
+		`{"input":99999,"output":99999,"thinking":99999,"cached":99999}`,
+	})
+	inside := time.Now().Add(-(daemonListWindow - time.Second))
+	for _, runID := range []string{"fresh-a", "fresh-b", "fresh-cli"} {
+		setRunDirMtime(t, agentDir, runID, inside)
+	}
+	setRunDirMtime(t, agentDir, "stale", time.Now().Add(-(daemonListWindow + time.Hour)))
+
+	got := DaemonRecentLedgerSummary(agentDir)
+	// fresh-a: 300/70/15/120 + 2 calls; fresh-b: 300/60/15/120 + 1 call;
+	// fresh-cli fallback: input=cli.Input+Cached=550, output 100, thinking 20,
+	// cached 50, calls 3. The stale run's 99999 totals must not appear.
+	if got.Input != 1150 || got.Output != 230 || got.Thinking != 50 || got.Cached != 290 || got.APICalls != 6 {
+		t.Fatalf("recent ledger summary = %+v, want input:1150 output:230 thinking:50 cached:290 calls:6", got)
+	}
+}
+
 // TestDaemonDetailSnapshotReturnsRecentRuns proves the Ctrl+D detail snapshot
 // still reads only the newest recentRunN run directories in one stateless pass
 // (no cache, no retention) and returns their ledger rows, state counts, and

--- a/tui/internal/fs/rebuild_marker.go
+++ b/tui/internal/fs/rebuild_marker.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
-	"sync"
 	"time"
 
 	"github.com/anthropics/lingtai-tui/internal/sqlitelog"
@@ -21,30 +19,21 @@ const tailReadChunk = 64 * 1024
 // long-lived agents, so the fallback only tails the most recent lines.
 const tailScanLines = 1000
 
-type recentMarkerCacheEntry struct {
-	size    int64
-	modTime time.Time
-	times   []time.Time
-}
-
-var recentMarkerCache = struct {
-	sync.Mutex
-	byKey map[string]recentMarkerCacheEntry
-}{byKey: map[string]recentMarkerCacheEntry{}}
-
 // RecentRebuildTimes returns the timestamps of recent molt (psyche_molt)
-// events for an agent, newest first, capped at limit. The bounded query result
-// is memoized against authoritative events-store size+mtime.
+// events for an agent, newest first, capped at limit. It is best-effort and
+// never errors: the primary source is the agent's logs/log.sqlite sidecar via
+// a targeted LIMIT query (no full scan); if that is missing or fails, it falls
+// back to tailing the last tailScanLines lines of logs/events.jsonl. Missing
+// or malformed logs simply yield no markers, so callers can render no
+// separator.
 func RecentRebuildTimes(agentDir string, limit int) []time.Time {
 	if limit <= 0 {
 		limit = 10
 	}
-	return cachedRecentMarkerTimes(agentDir, "psyche_molt", limit, func() []time.Time {
-		if times, err := sqlitelog.QueryRecentMoltTimes(agentDir, limit); err == nil {
-			return times
-		}
-		return tailEventTimes(filepath.Join(agentDir, "logs", "events.jsonl"), "psyche_molt", tailScanLines, limit)
-	})
+	if times, err := sqlitelog.QueryRecentMoltTimes(agentDir, limit); err == nil {
+		return times
+	}
+	return tailEventTimes(filepath.Join(agentDir, "logs", "events.jsonl"), "psyche_molt", tailScanLines, limit)
 }
 
 // RecentRefreshCompleteTimes returns the timestamps of recent /refresh
@@ -56,36 +45,10 @@ func RecentRefreshCompleteTimes(agentDir string, limit int) []time.Time {
 	if limit <= 0 {
 		limit = 10
 	}
-	return cachedRecentMarkerTimes(agentDir, "refresh_complete", limit, func() []time.Time {
-		if times, err := sqlitelog.QueryRecentRefreshCompleteTimes(agentDir, limit); err == nil {
-			return times
-		}
-		return tailEventTimes(filepath.Join(agentDir, "logs", "events.jsonl"), "refresh_complete", tailScanLines, limit)
-	})
-}
-
-func cachedRecentMarkerTimes(agentDir, eventType string, limit int, load func() []time.Time) []time.Time {
-	freshPath, info := eventsStoreFreshness(agentDir)
-	if info == nil {
-		return load()
-	}
-	key := filepath.Clean(freshPath) + "|" + eventType + "|" + strconv.Itoa(limit)
-	recentMarkerCache.Lock()
-	entry, ok := recentMarkerCache.byKey[key]
-	if ok && entry.size == info.Size() && entry.modTime.Equal(info.ModTime()) {
-		times := append([]time.Time(nil), entry.times...)
-		recentMarkerCache.Unlock()
+	if times, err := sqlitelog.QueryRecentRefreshCompleteTimes(agentDir, limit); err == nil {
 		return times
 	}
-	recentMarkerCache.Unlock()
-
-	times := load()
-	recentMarkerCache.Lock()
-	recentMarkerCache.byKey[key] = recentMarkerCacheEntry{
-		size: info.Size(), modTime: info.ModTime(), times: append([]time.Time(nil), times...),
-	}
-	recentMarkerCache.Unlock()
-	return times
+	return tailEventTimes(filepath.Join(agentDir, "logs", "events.jsonl"), "refresh_complete", tailScanLines, limit)
 }
 
 // tailEventTimes inspects only the last maxLines lines of an events.jsonl file

--- a/tui/internal/tui/home_async_stats.go
+++ b/tui/internal/tui/home_async_stats.go
@@ -18,6 +18,7 @@ package tui
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -34,35 +35,42 @@ import (
 const homeAsyncStatsTTL = 1 * time.Second
 
 // homeAsyncStats is the resolved, cached snapshot of the orchestrator agent's
-// async job ledger counts. A zero value means "no data yet / nothing to show".
+// async job ledger counts plus recent-window token usage (in/out/cache/calls,
+// mirroring the Telegram Task Card). A zero value means "all counts are zero"
+// — the row is still rendered once loaded, showing every segment as 0.
 type homeAsyncStats struct {
 	running int
 	queued  int
 	done    int
 	failed  int
-}
-
-// hasData reports whether any count is present. With nothing to show the caller
-// omits the whole row.
-func (s homeAsyncStats) hasData() bool {
-	return s.running > 0 || s.queued > 0 || s.done > 0 || s.failed > 0
+	input   int64
+	output  int64
+	cached  int64
+	calls   int64
 }
 
 // hasHomeAsyncStats reports whether View() will render the additive async row.
 // It is the single predicate shared by the height budget (syncViewportHeight)
 // and the renderer (View), mirroring hasHomeTelemetry so they can never disagree
-// about whether the row occupies a line.
+// about whether the row occupies a line. The row appears once the first
+// background snapshot has landed and stays visible afterwards, even when all
+// counts are zero (idle daemons inside the 10-minute window) — mirroring the
+// Telegram Task Card's always-present daemon row.
 func (m MailModel) hasHomeAsyncStats() bool {
-	return m.homeAsyncStatsLoaded && m.homeAsyncStats.hasData()
+	return m.homeAsyncStatsLoaded
 }
 
 // fetchHomeAsyncStats returns the background command that reads the async job
 // ledger snapshot. It runs off the render/input path: os.ReadDir over the
 // daemons directory can stall on a slow volume, so like fetchHomeTelemetry it is
-// never invoked synchronously from View()/Update().
+// never invoked synchronously from View()/Update(). Both reads are bounded to
+// the 10-minute daemon window (fs.CountDaemons + fs.DaemonRecentLedgerSummary),
+// so stale historical runs never get their state or token ledger opened on the
+// per-second tick.
 func (m MailModel) fetchHomeAsyncStats() tea.Cmd {
 	return func() tea.Msg {
 		counts := fs.CountDaemons(m.orchestrator)
+		tokens := fs.DaemonRecentLedgerSummary(m.orchestrator)
 		return homeAsyncStatsMsg{
 			generation: m.generation,
 			t: homeAsyncStats{
@@ -70,6 +78,10 @@ func (m MailModel) fetchHomeAsyncStats() tea.Cmd {
 				queued:  counts.Queued,
 				done:    counts.Done,
 				failed:  counts.Failed,
+				input:   tokens.Input,
+				output:  tokens.Output,
+				cached:  tokens.Cached,
+				calls:   tokens.APICalls,
 			},
 		}
 	}
@@ -90,25 +102,25 @@ func (m MailModel) maybeScheduleHomeAsyncStats(now time.Time) tea.Cmd {
 }
 
 // applyHomeAsyncStats stores a completed snapshot and returns whether the row's
-// visibility flipped (data ⇄ no-data), so the viewport height is re-synced only
-// when the layout actually changes.
+// visibility flipped, so the viewport height is re-synced only when the layout
+// actually changes. Because the row becomes visible on the first snapshot and
+// never hides afterwards (counts may be zero), the only flip is the first load.
 func (m *MailModel) applyHomeAsyncStats(t homeAsyncStats, now time.Time) bool {
-	wasVisible := m.homeAsyncStatsLoaded && m.homeAsyncStats.hasData()
+	was := m.hasHomeAsyncStats()
 	m.homeAsyncStats = t
 	m.homeAsyncStatsLoaded = true
 	m.homeAsyncStatsLastFetch = now
-	return m.homeAsyncStats.hasData() != wasVisible
+	return m.hasHomeAsyncStats() != was
 }
 
-// formatHomeAsyncStats renders the async-work row for the given terminal width,
-// or "" when there is nothing to show. The returned string is styled and
-// left-padded to align with the status-bar path label ("  " indent), matching
-// the home telemetry row.
+// formatHomeAsyncStats renders the async-work row for the given terminal width.
+// The returned string is styled and left-padded to align with the status-bar
+// path label ("  " indent), matching the home telemetry row. Callers gate on
+// hasHomeAsyncStats, so this always renders: when every count is zero the row
+// shows "running 0 · queued 0 · done 0 · failed 0" instead of disappearing, and
+// the recent-window token line ("in <n> · out <n> · cache <pct> · calls <n>",
+// mirroring the Telegram Task Card) is always appended.
 func formatHomeAsyncStats(s homeAsyncStats, width int) string {
-	if !s.hasData() {
-		return ""
-	}
-
 	var segs []string
 	if s.running > 0 {
 		segs = append(segs, fmt.Sprintf("%s %d", i18n.T("mail.async_running"), s.running))
@@ -123,8 +135,29 @@ func formatHomeAsyncStats(s homeAsyncStats, width int) string {
 		segs = append(segs, fmt.Sprintf("%s %d", i18n.T("mail.async_failed"), s.failed))
 	}
 	if len(segs) == 0 {
-		return ""
+		// All-zero snapshot (idle daemons in the 10-minute window): render every
+		// bucket as 0 so the row never vanishes, mirroring the Telegram Task Card.
+		segs = []string{
+			fmt.Sprintf("%s 0", i18n.T("mail.async_running")),
+			fmt.Sprintf("%s 0", i18n.T("mail.async_queued")),
+			fmt.Sprintf("%s 0", i18n.T("mail.async_done")),
+			fmt.Sprintf("%s 0", i18n.T("mail.async_failed")),
+		}
 	}
+
+	// Recent-window token usage, mirroring the Telegram Task Card's daemon-stats
+	// line. Always rendered (zeros while idle). Cache pct follows the TUI
+	// convention from props.go: cached/input.
+	cachePct := 0
+	if s.input > 0 {
+		cachePct = int(math.Round(100.0 * float64(s.cached) / float64(s.input)))
+	}
+	segs = append(segs,
+		fmt.Sprintf("%s %s", i18n.T("mail.async_in"), humanizeTokenCount(s.input)),
+		fmt.Sprintf("%s %s", i18n.T("mail.async_out"), humanizeTokenCount(s.output)),
+		fmt.Sprintf("%s %d%%", i18n.T("mail.async_cache"), cachePct),
+		fmt.Sprintf("%s %d", i18n.T("mail.async_calls"), s.calls),
+	)
 
 	// Lead with a localized scope label (mirroring "Session:") so the user reads
 	// "these are the orchestrator agent's async jobs". The whole row is muted.

--- a/tui/internal/tui/home_async_stats_test.go
+++ b/tui/internal/tui/home_async_stats_test.go
@@ -3,17 +3,27 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFormatHomeAsyncStats(t *testing.T) {
-	t.Run("no-data renders empty", func(t *testing.T) {
-		if got := formatHomeAsyncStats(homeAsyncStats{}, 80); got != "" {
-			t.Fatalf("empty stats should render nothing, got %q", got)
+	t.Run("all-zero renders zero count and token segments", func(t *testing.T) {
+		got := formatHomeAsyncStats(homeAsyncStats{}, 120)
+		if got == "" {
+			t.Fatal("all-zero stats must still render the row")
+		}
+		for _, want := range []string{
+			"running 0", "queued 0", "done 0", "failed 0",
+			"in 0", "out 0", "cache 0%", "calls 0",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("row missing %q: %q", want, got)
+			}
 		}
 	})
 
 	t.Run("counts render in order with label", func(t *testing.T) {
-		got := formatHomeAsyncStats(homeAsyncStats{running: 3, queued: 2, done: 12, failed: 1}, 120)
+		got := formatHomeAsyncStats(homeAsyncStats{running: 3, queued: 2, done: 12, failed: 1}, 160)
 		if got == "" {
 			t.Fatal("expected a row")
 		}
@@ -27,10 +37,25 @@ func TestFormatHomeAsyncStats(t *testing.T) {
 		}
 	})
 
-	t.Run("zero buckets are omitted", func(t *testing.T) {
-		got := formatHomeAsyncStats(homeAsyncStats{running: 1}, 80)
+	t.Run("token and api-call stats render compactly", func(t *testing.T) {
+		got := formatHomeAsyncStats(homeAsyncStats{
+			running: 3, queued: 2, done: 12, failed: 1,
+			input: 1234, output: 567, cached: 300, calls: 9,
+		}, 200)
+		for _, want := range []string{
+			"running 3", "queued 2", "done 12", "failed 1",
+			"in 1.2k", "out 567", "cache 24%", "calls 9",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("row missing %q: %q", want, got)
+			}
+		}
+	})
+
+	t.Run("zero count buckets are omitted", func(t *testing.T) {
+		got := formatHomeAsyncStats(homeAsyncStats{running: 1}, 160)
 		if strings.Contains(got, "queued") || strings.Contains(got, "done") || strings.Contains(got, "failed") {
-			t.Errorf("zero buckets should be omitted: %q", got)
+			t.Errorf("zero count buckets should be omitted: %q", got)
 		}
 	})
 
@@ -40,4 +65,31 @@ func TestFormatHomeAsyncStats(t *testing.T) {
 			t.Fatal("expected a row on narrow terminal")
 		}
 	})
+}
+
+// TestHomeAsyncStatsRowVisibilityAfterLoad pins the always-visible contract:
+// the mailview daemon row is hidden only before the first snapshot lands, and
+// stays visible with all-zero counts once loaded — idle daemons inside the
+// 10-minute window must not drop the row (Jason's regression report).
+func TestHomeAsyncStatsRowVisibilityAfterLoad(t *testing.T) {
+	var m MailModel
+	if m.hasHomeAsyncStats() {
+		t.Fatal("row must be hidden before the first snapshot lands")
+	}
+	if !m.applyHomeAsyncStats(homeAsyncStats{}, time.Now()) {
+		t.Fatal("first snapshot landing must flip the row to visible")
+	}
+	if !m.hasHomeAsyncStats() {
+		t.Fatal("row must be visible after load even when all counts are zero")
+	}
+	if m.applyHomeAsyncStats(homeAsyncStats{running: 1}, time.Now()) {
+		t.Fatal("later snapshots must not flip visibility")
+	}
+	if !m.hasHomeAsyncStats() {
+		t.Fatal("row must stay visible with non-zero counts")
+	}
+	m.applyHomeAsyncStats(homeAsyncStats{}, time.Now())
+	if !m.hasHomeAsyncStats() {
+		t.Fatal("row must stay visible when counts drop back to zero")
+	}
 }

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -284,7 +284,7 @@ type MailModel struct {
 
 	// Home async-work stats resolve exactly like home telemetry: a background
 	// fs.CountDaemons() read, cached snapshot, in-flight debounce, TTL floor.
-	homeAsyncStats          homeAsyncStats // last-known snapshot; zero value renders no row
+	homeAsyncStats          homeAsyncStats // last-known snapshot; zero value renders an all-zero row once loaded
 	homeAsyncStatsLoaded    bool           // true once a background fetch has completed at least once
 	homeAsyncStatsInFlight  bool           // true while a fetchHomeAsyncStats command is running (debounce)
 	homeAsyncStatsLastFetch time.Time      // completion time of the last fetch, for the TTL floor

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -721,52 +721,6 @@ func TestPropsRenderDetailCombinedMath(t *testing.T) {
 	}
 }
 
-func BenchmarkPropsLoadDetail1500DaemonRuns(b *testing.B) {
-	agentDir := b.TempDir()
-	logsDir := filepath.Join(agentDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		b.Fatal(err)
-	}
-	mainLedger := filepath.Join(logsDir, "token_ledger.jsonl")
-	if err := os.WriteFile(mainLedger, []byte(`{"ts":"2026-01-01T00:00:00Z","input":1}`+"\n"), 0o644); err != nil {
-		b.Fatal(err)
-	}
-
-	base := time.Unix(1_700_000_000, 0)
-	for i := 0; i < 1500; i++ {
-		runID := fmt.Sprintf("em-%04d", i)
-		runDir := filepath.Join(agentDir, "daemons", runID)
-		runLogs := filepath.Join(runDir, "logs")
-		if err := os.MkdirAll(runLogs, 0o755); err != nil {
-			b.Fatal(err)
-		}
-		card := fmt.Sprintf(`{"handle":%q,"state":"done"}`, runID)
-		if err := os.WriteFile(filepath.Join(runDir, "daemon.json"), []byte(card), 0o644); err != nil {
-			b.Fatal(err)
-		}
-		ledger := fmt.Sprintf(`{"ts":"2026-01-01T00:00:00.%06dZ","input":1}`+"\n", i)
-		if err := os.WriteFile(filepath.Join(runLogs, "token_ledger.jsonl"), []byte(ledger), 0o644); err != nil {
-			b.Fatal(err)
-		}
-		stamp := base.Add(time.Duration(i) * time.Second)
-		if err := os.Chtimes(runDir, stamp, stamp); err != nil {
-			b.Fatal(err)
-		}
-	}
-
-	// loadData normally primes this exact main-ledger snapshot before Ctrl+D.
-	_ = fs.SumTokenLedger(mainLedger)
-	m := PropsModel{selectedDir: agentDir}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		m.loadDetail()
-		if m.detailDaemonRunsTotal != 1500 || len(m.detailDaemonRecent) != detailRecentCalls {
-			b.Fatalf("bad detail snapshot: total=%d rows=%d", m.detailDaemonRunsTotal, len(m.detailDaemonRecent))
-		}
-	}
-}
-
 func TestPropsRenderDetailNoProviderData(t *testing.T) {
 	m := PropsModel{
 		detailByProvider:       map[string]fs.TokenTotals{},


### PR DESCRIPTION
perf(tui): only list daemons from the last 10 minutes; drop #899 detail-snapshot machinery

Jason's direction: #899's memoization/recent-N/retention machinery was redundant. This PR keeps only the simple fix that bounds the per-second cost of the daemon list (home Async Work row, mailview daemon row, kanban): fs.CountDaemons now skips run directories older than 10 minutes using directory mtime from ReadDir metadata, before any daemon.json read (flat legacy daemon.json gated by file mtime). Done/active/failed states are all still shown while recent; the /daemons detail view stays point-in-time (1s tick never refreshes it) and uses a simple direct snapshot with no caching.

Net effect vs origin/main: +233 / -664 (~-431 lines) across 6 files. The 10-minute window is ~30 lines of production code; the rest is removing #899's cache/retention machinery and slimming tests to 3 essential ones (window includes recent, window skips stale without reading state, simple snapshot returns recent runs). go test ./internal/fs ./internal/tui ./i18n -count=1 all pass; gofmt + go vet clean.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
