### PR TITLE
fix(tui): render Email To active as seconds since last API call

### DIFF
--- a/tui/internal/fs/activity.go
+++ b/tui/internal/fs/activity.go
@@ -129,6 +129,7 @@ type networkStatusSnapshot struct {
 	Runtime    struct {
 		State          string             `json:"state"`
 		LastProgressAt tolerantJSONNumber `json:"last_progress_at"`
+			LastApiCallAt  tolerantJSONNumber `json:"last_api_call_at"`
 		NoProgressSecs tolerantJSONNumber `json:"no_progress_seconds"`
 		UptimeSeconds  tolerantJSONNumber `json:"uptime_seconds"`
 		StaminaLeft    tolerantJSONNumber `json:"stamina_left"`
@@ -230,6 +231,31 @@ func LastProgressAt(agentDir string, now time.Time) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	if !strings.EqualFold(status.Runtime.State, NetworkStatusActive) {
+		return time.Time{}, false
+	}
+	return statusFreshnessTime(now, unixSeconds(status.Runtime.LastProgressAt.Value))
+}
+
+// LastApiCallAt returns the agent's clamped runtime.last_api_call_at from its
+// .status.json, falling back to runtime.last_progress_at when the newer field
+// is absent (older kernels). Zero + false when the file is missing, both
+// fields are absent/invalid, the runtime state is not active, or the
+// timestamp is beyond the future grace window. This is the "how long has it
+// been active since its last API call" signal (Jason 2026-08-16): while the
+// model thinks or a tool runs, last_api_call_at stays put and the age grows;
+// when a new API call starts it resets.
+func LastApiCallAt(agentDir string, now time.Time) (time.Time, bool) {
+	status, _, ok := readNetworkStatusSnapshot(agentDir)
+	if !ok {
+		return time.Time{}, false
+	}
+	if !strings.EqualFold(status.Runtime.State, NetworkStatusActive) {
+		return time.Time{}, false
+	}
+	if status.Runtime.LastApiCallAt.OK {
+		return statusFreshnessTime(now, unixSeconds(status.Runtime.LastApiCallAt.Value))
+	}
+	if !status.Runtime.LastProgressAt.OK {
 		return time.Time{}, false
 	}
 	return statusFreshnessTime(now, unixSeconds(status.Runtime.LastProgressAt.Value))

--- a/tui/internal/fs/activity_test.go
+++ b/tui/internal/fs/activity_test.go
@@ -552,6 +552,72 @@ func TestComputeNetworkActivity_DaemonActiveOnlyWhenSoleSignal(t *testing.T) {
 	}
 }
 
+func TestLastApiCallAtPrefersLastApiCallOverProgress(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "ACTIVE", true)
+	now := time.Now()
+	writeStatus(t, agentDir, map[string]interface{}{
+		"runtime": map[string]interface{}{
+			"state":             "ACTIVE",
+			"last_progress_at":  now.Add(-2 * time.Second).Unix(),
+			"last_api_call_at":  now.Add(-10 * time.Second).Unix(),
+			"no_progress_seconds": "",
+		},
+	}, time.Now())
+
+	got, ok := LastApiCallAt(agentDir, now)
+	if !ok {
+		t.Fatal("LastApiCallAt should be ok")
+	}
+	if got.Sub(now) > 0 {
+		t.Fatalf("future timestamp not clamped: %v", got)
+	}
+	want := now.Add(-10 * time.Second)
+	if diff := got.Sub(want); diff < -2*time.Second || diff > 2*time.Second {
+		t.Fatalf("LastApiCallAt = %v, want ~%v", got, want)
+	}
+}
+
+func TestLastApiCallAtFallsBackToProgressWhenApiCallAbsent(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "ACTIVE", true)
+	now := time.Now()
+	writeStatus(t, agentDir, map[string]interface{}{
+		"runtime": map[string]interface{}{
+			"state":             "ACTIVE",
+			"last_progress_at":  now.Add(-4 * time.Second).Unix(),
+			"no_progress_seconds": "",
+		},
+	}, time.Now())
+
+	got, ok := LastApiCallAt(agentDir, now)
+	if !ok {
+		t.Fatal("LastApiCallAt should be ok via fallback")
+	}
+	want := now.Add(-4 * time.Second)
+	if diff := got.Sub(want); diff < -2*time.Second || diff > 2*time.Second {
+		t.Fatalf("LastApiCallAt fallback = %v, want ~%v", got, want)
+	}
+}
+
+func TestLastApiCallAtNoneWhenNotActive(t *testing.T) {
+	base := t.TempDir()
+	agentDir := writeActivityAgent(t, base, "alice", "IDLE", true)
+	now := time.Now()
+	writeStatus(t, agentDir, map[string]interface{}{
+		"runtime": map[string]interface{}{
+			"state":             "IDLE",
+			"last_api_call_at":  now.Add(-10 * time.Second).Unix(),
+			"no_progress_seconds": "",
+		},
+	}, time.Now())
+
+	if got, ok := LastApiCallAt(agentDir, now); ok || !got.IsZero() {
+		t.Fatalf("LastApiCallAt for non-active = %v ok=%v, want zero+false", got, ok)
+	}
+}
+
+
 func writeStatus(t *testing.T, agentDir string, status map[string]interface{}, mtime time.Time) {
 	t.Helper()
 	path := filepath.Join(agentDir, ".status.json")

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -80,8 +80,8 @@ type mailRefreshMsg struct {
 	selectorRows         []agentSelectorRow
 	directPublication    *fs.DirectMailPublication
 	directStates         map[string]string    // stable direct-thread key -> target lifecycle state
-	lastProgressAt       time.Time            // orchestrator .status.json runtime.last_progress_at (zero when absent)
-	directLastProgress   map[string]time.Time // stable direct-thread key -> target last_progress_at
+	lastApiCallAt       time.Time            // orchestrator .status.json runtime.last_api_call_at (fallback last_progress_at; zero when absent)
+	directLastApiCall   map[string]time.Time // stable direct-thread key -> target last_api_call_at
 	alive                bool
 	state                string // active, idle, stuck, asleep, suspended, or ""
 	activity             fs.NetworkActivity
@@ -712,8 +712,8 @@ func (m MailModel) refreshMail() tea.Msg {
 
 	alive, state, orchestrator := resolveAgentLifecycle(m.orchestrator)
 	directStates := resolveDirectLifecycleStates(selectorRows)
-	lastProgressAt, _ := fs.LastProgressAt(m.orchestrator, time.Now())
-	directLastProgress := make(map[string]time.Time, len(directStates))
+	lastApiCallAt, _ := fs.LastApiCallAt(m.orchestrator, time.Now())
+	directLastApiCall := make(map[string]time.Time, len(directStates))
 	for _, row := range selectorRows {
 		if row.Main {
 			continue
@@ -722,8 +722,8 @@ func (m MailModel) refreshMail() tea.Msg {
 		if key == "" {
 			continue
 		}
-		if lp, ok := fs.LastProgressAt(row.Target.Directory, time.Now()); ok {
-			directLastProgress[key] = lp
+		if lp, ok := fs.LastApiCallAt(row.Target.Directory, time.Now()); ok {
+			directLastApiCall[key] = lp
 		}
 	}
 	var activity fs.NetworkActivity
@@ -747,8 +747,8 @@ func (m MailModel) refreshMail() tea.Msg {
 		selectorRows:         selectorRows,
 		directPublication:    directPublication,
 		directStates:         directStates,
-		lastProgressAt:       lastProgressAt,
-		directLastProgress:   directLastProgress,
+		lastApiCallAt:       lastApiCallAt,
+		directLastApiCall:   directLastApiCall,
 		alive:                alive,
 		state:                state,
 		activity:             activity,
@@ -1192,7 +1192,7 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				m.cache = msg.cache
 				m.acceptedSnapshot = msg.acceptedSnapshot
 				m = m.installSelectorRows(msg.selectorRows)
-				m = m.installDirectLifecycleStates(msg.directStates, msg.directLastProgress)
+				m = m.installDirectLifecycleStates(msg.directStates, msg.directLastApiCall)
 				m.directPublication = msg.directPublication
 				m = m.clampAgentRail()
 				m, directVisibilityCmd = m.publishAcceptedDirectSnapshot()
@@ -1214,15 +1214,15 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 				m.quoteIdx++
 				m.pulseTick = 0
 				m.insightPending = false
-				m.activeSince = msg.lastProgressAt
+				m.activeSince = msg.lastApiCallAt
 				if m.activeSince.IsZero() {
 					m.activeSince = time.Now()
 				}
-			} else if isActive && !msg.lastProgressAt.IsZero() && !msg.lastProgressAt.Equal(m.activeSince) {
-				// Still active but the kernel reports a different last progress —
+			} else if isActive && !msg.lastApiCallAt.IsZero() && !msg.lastApiCallAt.Equal(m.activeSince) {
+				// Still active but the kernel reports a different last API call —
 				// adopt it so "active N sec" measures seconds since the last tool
 				// call (matches the kernel taskcard footer semantics).
-				m.activeSince = msg.lastProgressAt
+				m.activeSince = msg.lastApiCallAt
 			} else if !isActive {
 				// Not active — stop the elapsed timer so the badge drops it
 				m.activeSince = time.Time{}
@@ -2240,18 +2240,18 @@ func (m MailModel) humanName() string {
 	return i18n.T("mail.you")
 }
 
-func (m MailModel) installDirectLifecycleStates(states map[string]string, lastProgress map[string]time.Time) MailModel {
+func (m MailModel) installDirectLifecycleStates(states map[string]string, lastApiCall map[string]time.Time) MailModel {
 	now := time.Now()
 	next := make(map[string]directAgentLifecycle, len(states))
 	for key, state := range states {
 		status := m.directLifecycles[key]
 		if strings.EqualFold(state, "ACTIVE") {
 			if !strings.EqualFold(status.state, "ACTIVE") || status.activeSince.IsZero() {
-				status.activeSince = lastProgress[key]
+				status.activeSince = lastApiCall[key]
 				if status.activeSince.IsZero() {
 					status.activeSince = now
 				}
-			} else if lp, ok := lastProgress[key]; ok && !lp.IsZero() && !lp.Equal(status.activeSince) {
+			} else if lp, ok := lastApiCall[key]; ok && !lp.IsZero() && !lp.Equal(status.activeSince) {
 				// Still active but the target reports a different last progress —
 				// adopt it (matches kernel taskcard footer semantics).
 				status.activeSince = lp

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -2301,14 +2301,13 @@ func activeElapsedFor(state string, activeSince time.Time) string {
 		return ""
 	}
 	d := time.Since(activeSince)
-	if d < time.Minute {
-		return fmt.Sprintf(" %ds", int(d.Seconds()))
-	}
-	return fmt.Sprintf(" %dm", int(d.Minutes()))
+	return fmt.Sprintf(" %ds", int(d.Seconds()))
 }
 
-// activeElapsed returns a short " 12s" / " 3m" suffix while Main is ACTIVE,
-// or "" otherwise — the "how long has it been working" signal.
+// activeElapsed returns a short " 12s" / " 240s" suffix while Main is ACTIVE,
+// or "" otherwise — the "how long has it been working" signal, always in
+// whole seconds so the value matches the Telegram Task Card footer's
+// ``active (N s)`` (Jason 2026-08-16).
 func (m MailModel) activeElapsed() string {
 	return activeElapsedFor(m.orchState, m.activeSince)
 }

--- a/tui/internal/tui/mail_activity_indicator_test.go
+++ b/tui/internal/tui/mail_activity_indicator_test.go
@@ -46,8 +46,9 @@ func TestStateGlyphActiveAnimates(t *testing.T) {
 }
 
 // TestActiveElapsed verifies the elapsed suffix renders only while ACTIVE with
-// a non-zero start time, formatted as seconds under a minute and minutes above.
-// Offsets are mid-interval to avoid second/minute boundary flake.
+// a non-zero start time, always formatted as whole seconds so the value matches
+// the Telegram Task Card footer's ``active (N s)``. Offsets are mid-interval to
+// avoid second/minute boundary flake.
 func TestActiveElapsed(t *testing.T) {
 	now := time.Now()
 	cases := []struct {
@@ -59,7 +60,7 @@ func TestActiveElapsed(t *testing.T) {
 		{"not active drops timer", "idle", now.Add(-30 * time.Second), ""},
 		{"active but zero start", "active", time.Time{}, ""},
 		{"active seconds", "active", now.Add(-12500 * time.Millisecond), " 12s"},
-		{"active minutes", "active", now.Add(-210 * time.Second), " 3m"},
+		{"active minutes still seconds", "active", now.Add(-210 * time.Second), " 210s"},
 	}
 	for _, c := range cases {
 		m := MailModel{orchState: c.state, activeSince: c.since}

--- a/tui/internal/tui/mail_activity_indicator_test.go
+++ b/tui/internal/tui/mail_activity_indicator_test.go
@@ -74,8 +74,8 @@ func TestActiveElapsed(t *testing.T) {
 // ACTIVE, preserved while staying ACTIVE, and cleared on any non-ACTIVE refresh
 // (including the synthesized suspended/refreshing states, which arrive as
 // non-ACTIVE through the same mailRefreshMsg path). When the refresh carries a
-// kernel last_progress_at it is used as the baseline (so "active N sec" measures
-// seconds since the last tool call), falling back to wall-clock when absent.
+// kernel last_api_call_at it is used as the baseline (so "active N sec" measures
+// seconds since the last API call), falling back to wall-clock when absent.
 func TestActiveSinceLifecycle(t *testing.T) {
 	dir := t.TempDir()
 	m := NewMailModel(dir, "human", dir, dir, "orch", 20, dir, "en", false, 0)
@@ -96,9 +96,9 @@ func TestActiveSinceLifecycle(t *testing.T) {
 
 	// Stay ACTIVE with fresh kernel progress → baseline advances to it.
 	progress := time.Now().Add(-4 * time.Second)
-	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true, lastProgressAt: progress})
+	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true, lastApiCallAt: progress})
 	if !m.activeSince.Equal(progress) {
-		t.Errorf("activeSince should advance to last_progress_at; was %v, now %v", first, m.activeSince)
+		t.Errorf("activeSince should advance to last_api_call_at; was %v, now %v", first, m.activeSince)
 	}
 
 	// Leave ACTIVE → timer cleared so the badge drops the elapsed suffix.


### PR DESCRIPTION
## Summary

Jason 10360/10361 asked that the number after "active" in TUI Email To match
Telegram Task Card's footer, and 10373 chose option **B** with the semantic:
**"active N" means how long the agent has been active since its last API call**
(`llm_call`) — the most useful signal while the model thinks or a tool runs.

This PR makes TUI Email To's `active Ns` render whole seconds and measure from
`runtime.last_api_call_at` (falling back to `last_progress_at` on older status
files), consistent with the kernel Task Card footer (kernel PR
feat/taskcard-active-api-call-seconds-20260816).

## Changes

- `internal/fs/activity.go`: add `LastApiCallAt` tolerant JSON field + reader
  function that prefers `last_api_call_at` with `last_progress_at` fallback,
  ACTIVE-gated like the taskcard footer.
- `internal/tui/mail.go`: wire `activeSince` to `LastApiCallAt`; keep `%ds`
  rendering (previous commit 13404599).
- Tests: `LastApiCallAt` preference/fallback/non-active; `activeSince` lifecycle
  updated to the API-call anchor.

## Validation

- `go build ./...` clean
- `go vet ./internal/fs/ ./internal/tui/` clean
- `go test ./internal/fs/ ./internal/tui/ -count=1` PASS

## Semantic (from Jason 10373)

> this i want it to mean how much time it has been active SINCE last api call
> this is most useful info

Both TUI Email To and Telegram Task Card footer now show the same value for the
same agent: seconds since its last API call while ACTIVE.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
