### PR TITLE
feat(tui): default agent context to 500k

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1876,7 +1876,7 @@ type AgentOpts struct {
 func DefaultAgentOpts() AgentOpts {
 	return AgentOpts{
 		Language:       "en",
-		ContextLimit:   300000,
+		ContextLimit:   500000,
 		SoulDelay:      nil,
 		MaxRpm:         60,
 		MaxAedAttempts: DefaultMaxAedAttempts,

--- a/tui/internal/preset/preset_context_limit_test.go
+++ b/tui/internal/preset/preset_context_limit_test.go
@@ -12,13 +12,13 @@ import (
 // intended budget. This is the canonical default; the firstrun wizard's
 // zero/invalid-input fallbacks mirror it.
 func TestDefaultAgentOpts_ContextLimit(t *testing.T) {
-	if got := DefaultAgentOpts().ContextLimit; got != 300000 {
-		t.Errorf("DefaultAgentOpts().ContextLimit = %d, want 300000", got)
+	if got := DefaultAgentOpts().ContextLimit; got != 500000 {
+		t.Errorf("DefaultAgentOpts().ContextLimit = %d, want 500000", got)
 	}
 }
 
 // TestGenerateInitJSON_WritesContextLimit verifies the default flows into the
-// generated manifest as 300000, and — crucially — that an explicit user
+// generated manifest as 500000, and — crucially — that an explicit user
 // override is preserved verbatim rather than being clamped back to the default.
 func TestGenerateInitJSON_WritesContextLimit(t *testing.T) {
 	withTempPresets(t, func() {
@@ -46,13 +46,13 @@ func TestGenerateInitJSON_WritesContextLimit(t *testing.T) {
 			return m
 		}
 
-		// Default flows through to the manifest as 300000.
+		// Default flows through to the manifest as 500000.
 		if err := GenerateInitJSONWithOpts(DefaultPreset(), "alice", "alice", lingtaiDir, globalDir, DefaultAgentOpts()); err != nil {
 			t.Fatalf("GenerateInitJSONWithOpts: %v", err)
 		}
 		// JSON numbers decode as float64.
-		if v, ok := readManifest("alice")["context_limit"].(float64); !ok || int(v) != 300000 {
-			t.Errorf("alice context_limit = %v (ok=%v), want 300000", readManifest("alice")["context_limit"], ok)
+		if v, ok := readManifest("alice")["context_limit"].(float64); !ok || int(v) != 500000 {
+			t.Errorf("alice context_limit = %v (ok=%v), want 500000", readManifest("alice")["context_limit"], ok)
 		}
 
 		// Explicit override is preserved, not reset to the default.

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -2280,7 +2280,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					// Stash current values for the adaptive-commit finalizer.
 					ctxLimit, _ := strconv.Atoi(m.ctxLimitInput.Value())
 					if ctxLimit <= 0 {
-						ctxLimit = 300000
+						ctxLimit = 500000
 					}
 					soulDelay := resolveSoulDelay(m.soulDelayInput.Value(), m.soulFlowEnabledIdx == 1)
 					maxRpm, _ := strconv.Atoi(m.maxRpmInput.Value())
@@ -2322,7 +2322,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 				}
 				ctxLimit, err := strconv.Atoi(m.ctxLimitInput.Value())
 				if err != nil || ctxLimit <= 0 {
-					ctxLimit = 300000
+					ctxLimit = 500000
 				}
 				soulDelay := resolveSoulDelay(m.soulDelayInput.Value(), m.soulFlowEnabledIdx == 1)
 				maxRpm, err := strconv.Atoi(m.maxRpmInput.Value())
@@ -3985,7 +3985,7 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 	}
 
 	// Numeric defaults — overridden by saved init.json values in setup mode below.
-	m.ctxLimitInput.SetValue("300000")
+	m.ctxLimitInput.SetValue("500000")
 	m.soulDelayInput.SetValue("")
 	m.maxRpmInput.SetValue("60")
 	m.maxAedInput.SetValue(strconv.Itoa(preset.DefaultMaxAedAttempts))


### PR DESCRIPTION
## Summary
- Make 500,000 the canonical context-limit default for agents created through LingTai TUI.
- Keep first-run prefill and zero/invalid input fallbacks aligned with that default.
- Preserve explicit and valid saved agent context-limit values; add/update the existing generated-manifest regression coverage.

## Validation
- `git diff --check`
- `cd tui && go test ./internal/preset ./internal/tui ./internal/headless`
- `cd tui && go build ./...`
- Independent Terra review: APPROVE (no blockers).

## Scope
- TUI new-agent defaults only; no migration, flag, global TUI preference, kernel runtime change, or saved-preset rewrite.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai