### PR TITLE
fix(tui): never unlink a live .agent.lock inode on wait timeout

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1247,7 +1247,7 @@ func (a *App) hardRefresh() error {
 //
 // Sequence:
 //  1. Touch `.suspend` so a cooperative agent exits cleanly.
-//  2. Wait for `.agent.lock` to free (up to 60s, then forced).
+//  2. Wait for `.agent.lock` to free (up to 60s; never unlinked while held).
 //  3. If `ps` still shows `lingtai run <dir>`, SIGTERM (then SIGKILL) those
 //     PIDs — this is what makes /refresh actually forceful rather than a
 //     polite request.
@@ -1269,10 +1269,12 @@ func hardRefreshDir(lingtaiCmd, dir string) error {
 	if process.IsAgentRunning(dir) {
 		_ = process.TerminateAgentProcesses(dir)
 	}
-	// Clear lingering handshake files. waitForLockClear may have force-removed
-	// .agent.lock; the others (.refresh/.refresh.taken/.suspend) get removed
-	// here so the new interpreter doesn't immediately observe a stale signal.
-	os.Remove(filepath.Join(dir, ".agent.lock"))
+	// Clear lingering handshake files. .agent.lock is removed only after this
+	// process takes ownership of its current inode (waitForLockClear may
+	// already have done so); the others (.refresh/.refresh.taken/.suspend) are
+	// one-shot markers and get removed here so the new interpreter doesn't
+	// immediately observe a stale signal.
+	removeAgentLockIfOwned(filepath.Join(dir, ".agent.lock"))
 	os.Remove(filepath.Join(dir, ".refresh"))
 	os.Remove(filepath.Join(dir, ".refresh.taken"))
 	os.Remove(suspendFile)
@@ -1289,20 +1291,28 @@ func hardRefreshDir(lingtaiCmd, dir string) error {
 	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
-// waitForLockClear polls for .agent.lock to free (force-removing it after
-// 60s if the holder is gone). Used by hardRefreshDir between suspend and
-// relaunch so we don't stomp a still-running agent's init.json.
+// waitForLockClear polls for .agent.lock to free. If the deadline expires, the
+// lock is removed only when this process can prove ownership of its current
+// inode (see removeAgentLockIfOwned); a lock still held by a live process is
+// never unlinked, so a workdir lease can never be detached from its pathname
+// by timeout cleanup. Used by hardRefreshDir between suspend and relaunch so
+// we don't stomp a still-running agent's init.json.
 func waitForLockClear(dir string) {
 	lockFile := filepath.Join(dir, ".agent.lock")
-	for i := 0; i < 120; i++ { // 120 × 500ms = 60s max
+	for i := 0; i < lockWaitAttempts; i++ {
 		if tryLock(lockFile) {
 			return
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(lockWaitInterval)
 	}
-	// Process likely died without releasing lock — clean up
-	os.Remove(lockFile)
+	removeAgentLockIfOwned(lockFile)
 }
+
+// Lock-wait tuning; overridable in tests to keep the poll fast.
+var (
+	lockWaitAttempts = 120
+	lockWaitInterval = 500 * time.Millisecond
+)
 
 // resetActivePresetToDefault rewrites manifest.preset.active to match
 // manifest.preset.default in the agent's init.json. Best-effort: any error
@@ -1714,7 +1724,7 @@ func hardRefreshDirWithPreset(lingtaiCmd, dir, presetPath string) error {
 	if process.IsAgentRunning(dir) {
 		_ = process.TerminateAgentProcesses(dir)
 	}
-	os.Remove(filepath.Join(dir, ".agent.lock"))
+	removeAgentLockIfOwned(filepath.Join(dir, ".agent.lock"))
 	os.Remove(filepath.Join(dir, ".refresh"))
 	os.Remove(filepath.Join(dir, ".refresh.taken"))
 	os.Remove(suspendFile)
@@ -1730,22 +1740,23 @@ func hardRefreshDirWithPreset(lingtaiCmd, dir, presetPath string) error {
 	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
-// reviveDir waits for .agent.lock to free (force-removing it if the holder
-// is gone), then relaunches the agent. Used by /cpr (dead agent, no prior
-// suspend) and as the tail of hardRefreshDir (after writing .suspend).
+// reviveDir waits for .agent.lock to free, then relaunches the agent. A lock
+// still held past the deadline is left in place — never unlinked out from
+// under a live holder (see removeAgentLockIfOwned). Used by /cpr (dead agent,
+// no prior suspend) and as the tail of hardRefreshDir (after writing
+// .suspend).
 func reviveDir(lingtaiCmd, dir string) error {
 	lockFile := filepath.Join(dir, ".agent.lock")
 	locked := true
-	for i := 0; i < 120; i++ { // 120 × 500ms = 60s max
+	for i := 0; i < lockWaitAttempts; i++ {
 		if tryLock(lockFile) {
 			locked = false
 			break
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(lockWaitInterval)
 	}
 	if locked {
-		// Process likely died without releasing lock — clean up
-		os.Remove(lockFile)
+		removeAgentLockIfOwned(lockFile)
 	}
 	cmd, err := process.LaunchAgent(lingtaiCmd, dir)
 	if err != nil {

--- a/tui/internal/tui/lock_unix.go
+++ b/tui/internal/tui/lock_unix.go
@@ -22,3 +22,42 @@ func tryLock(path string) bool {
 	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 	return true
 }
+
+// removeAgentLockIfOwned removes path only when this process can prove that no
+// live descriptor holds the lock on its current inode: it takes a non-blocking
+// exclusive flock on the inode currently at path, and only when that succeeds
+// (the previous holder is gone) re-checks that the pathname still resolves to
+// the same inode (os.SameFile) before unlinking. If a newcomer has already
+// replaced the pathname with a fresh inode, no unlink happens, so a live
+// workdir lease can never be detached from its pathname by timeout cleanup.
+// Returns true when the path no longer needs removal.
+func removeAgentLockIfOwned(path string) bool {
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if os.IsNotExist(err) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return false // still held by another live descriptor
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+	fdInfo, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	pathInfo, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return true // already gone
+	}
+	if err != nil || !os.SameFile(fdInfo, pathInfo) {
+		return false // pathname now names a different inode; leave it alone
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/tui/internal/tui/lock_unix_test.go
+++ b/tui/internal/tui/lock_unix_test.go
@@ -1,0 +1,167 @@
+//go:build !windows
+
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWaitForLockClearDoesNotUnlinkHeldLockInode is the POSIX regression from
+// #886: a lock held past the wait deadline must not be unlinked, and the
+// pathname must keep naming the same inode.
+func TestWaitForLockClearDoesNotUnlinkHeldLockInode(t *testing.T) {
+	dir := t.TempDir()
+	lockFile := filepath.Join(dir, ".agent.lock")
+	holder, err := os.OpenFile(lockFile, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+
+	before, err := os.Stat(lockFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origAttempts, origInterval := lockWaitAttempts, lockWaitInterval
+	lockWaitAttempts, lockWaitInterval = 1, 0
+	defer func() {
+		lockWaitAttempts, lockWaitInterval = origAttempts, origInterval
+	}()
+
+	waitForLockClear(dir)
+
+	after, err := os.Stat(lockFile)
+	if err != nil {
+		t.Fatalf("held lock path was removed after timeout: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatalf("held lock path inode changed after timeout")
+	}
+}
+
+// TestRemoveAgentLockIfOwnedRemovesUnlockedCurrentInode: a stale, unlocked
+// lock file is safe to remove.
+func TestRemoveAgentLockIfOwnedRemovesUnlockedCurrentInode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".agent.lock")
+	if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !removeAgentLockIfOwned(path) {
+		t.Fatalf("removeAgentLockIfOwned(%q) = false for unlocked lock file", path)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("lock file still exists after safe removal: %v", err)
+	}
+}
+
+// TestRemoveAgentLockIfOwnedLeavesHeldLockInode: a lock held by a live
+// descriptor must be left untouched on disk, at the same inode.
+func TestRemoveAgentLockIfOwnedLeavesHeldLockInode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".agent.lock")
+	holder, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removeAgentLockIfOwned(path) {
+		t.Fatalf("removeAgentLockIfOwned(%q) = true for held lock", path)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("held lock path was removed: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatalf("held lock path inode changed")
+	}
+}
+
+// TestWaitForLockClearSkipsReplacedInode: when the pathname has been replaced
+// by a fresh inode that a newcomer actively holds, the deadline must expire
+// without unlinking that live fresh lease — exactly the #886 hazard that an
+// unconditional unlink of the pathname would enable.
+func TestWaitForLockClearSkipsReplacedInode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".agent.lock")
+
+	// Old holder: inode A, lock held for the whole poll.
+	oldHolder, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldHolder.Close()
+	if err := syscall.Flock(int(oldHolder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("lock old inode: %v", err)
+	}
+	defer syscall.Flock(int(oldHolder.Fd()), syscall.LOCK_UN)
+	oldInfo, err := oldHolder.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Newcomer unlinks the path and replaces it with inode B, holding it.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	newHolder, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newHolder.Close()
+	if err := syscall.Flock(int(newHolder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("lock new inode: %v", err)
+	}
+	defer syscall.Flock(int(newHolder.Fd()), syscall.LOCK_UN)
+	newInfo, err := newHolder.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(oldInfo, newInfo) {
+		t.Fatalf("replacement didn't create a distinct inode")
+	}
+
+	// Timeout cleanup must leave the newcomer's live inode B in place.
+	origAttempts, origInterval := lockWaitAttempts, lockWaitInterval
+	lockWaitAttempts, lockWaitInterval = 1, 0
+	defer func() {
+		lockWaitAttempts, lockWaitInterval = origAttempts, origInterval
+	}()
+	waitForLockClear(dir)
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("newcomer lock path was removed: %v", err)
+	}
+	if !os.SameFile(newInfo, after) {
+		t.Fatalf("newcomer lock inode changed or was replaced")
+	}
+}
+
+// TestWaitForLockClearReturnsQuicklyForUnlockedLock keeps the happy path
+// covered with a fast poll (no 60s stall when no lock exists).
+func TestWaitForLockClearReturnsQuicklyForUnlockedLock(t *testing.T) {
+	dir := t.TempDir()
+	origAttempts, origInterval := lockWaitAttempts, lockWaitInterval
+	lockWaitAttempts, lockWaitInterval = 2, time.Millisecond
+	defer func() {
+		lockWaitAttempts, lockWaitInterval = origAttempts, origInterval
+	}()
+
+	waitForLockClear(dir)
+}

--- a/tui/internal/tui/lock_windows.go
+++ b/tui/internal/tui/lock_windows.go
@@ -31,3 +31,18 @@ func tryLock(path string) bool {
 	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped)
 	return true
 }
+
+// removeAgentLockIfOwned removes path only when no other process holds the
+// lock. Windows open/delete sharing makes the POSIX unlink-inode race a
+// non-issue here, and a live holder's open handle normally blocks deletion
+// anyway; tryLock probes with the same LockFileEx the agent's holder competes
+// on. Returns true when the path no longer needs removal.
+func removeAgentLockIfOwned(path string) bool {
+	if !tryLock(path) {
+		return false
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Closes #886.

## Summary

The TUI's refresh/CPR timeout paths (`waitForLockClear`, `reviveDir`, and the `.agent.lock` sweep in `hardRefreshDir`/`hardRefreshDirWithPreset`) used to call `os.Remove(".agent.lock")` the moment the 60s polling deadline expired. On POSIX, unlinking the pathname does not release the holder's `flock`: the old inode stays locked, a later opener can create a fresh inode under the same pathname and lock it independently, and the workdir lease name no longer refers to a single exclusion object — a live lease gets detached from its pathname.

This change never unlinks `.agent.lock` merely because the deadline expired:

- New `removeAgentLockIfOwned` (Unix): takes a non-blocking exclusive `flock` on the inode currently at the path. If that fails, another live descriptor still owns the lease and nothing is removed (fail closed). Only after the flock succeeds does it re-check that the pathname still resolves to the same inode (`os.SameFile`) before unlinking, so a newcomer's replacement inode is never destroyed. The rule now applies to both duplicated cleanup loops (`waitForLockClear` and `reviveDir`) and to the post-kill sweep in `hardRefreshDir`/`hardRefreshDirWithPreset`.
- Windows: thin `removeAgentLockIfOwned` backed by the existing `tryLock` probe; a live holder's open handle blocks deletion anyway, and the probe never reports free while the lease is held.
- Lock-wait attempts/interval are now package vars (same pattern as the launch-heartbeat tuning) so the timeout path is fast to regression-test.

This supersedes the stale, conflicting PR #894, which implemented the same approach against an older base and conflicts with the Windows lock probing merged in #890.

## Validation

- `go build ./...`, `go vet ./internal/tui/`, and `GOOS=windows GOARCH=amd64 go build ./...` all clean.
- New POSIX regression tests (`tui/internal/tui/lock_unix_test.go`, run with `-race`):
  - `TestWaitForLockClearDoesNotUnlinkHeldLockInode` — lock held past the deadline: path survives with the same inode.
  - `TestWaitForLockClearSkipsReplacedInode` — pathname replaced by a fresh, held inode: newcomer lease survives the deadline.
  - `TestRemoveAgentLockIfOwnedLeavesHeldLockInode` — live descriptor prevents removal.
  - `TestRemoveAgentLockIfOwnedRemovesUnlockedCurrentInode` — stale unlocked lock is safely removed.
  - `TestWaitForLockClearReturnsQuicklyForUnlockedLock` — happy path stays fast.
- Full `go test ./internal/tui/` passes.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
