### PR TITLE
fix(tui): keep draft Codex OAuth zero-write

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -1117,6 +1117,18 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 			m.message = fmt.Sprintf("Failed to encode tokens: %v", err)
 			return m, nil
 		}
+		if m.draftMode {
+			// Draft only: keep the completed OAuth bundle in memory. The
+			// project-create finalizer persists it after explicit confirmation;
+			// m.codexAuth still reflects the successful session for this UI.
+			if m.draft != nil {
+				m.draft.DraftCodexTokens = secretBytes(data)
+			}
+			m.codexAuth.valid = true
+			m.codexAuth.email = msg.Tokens.Email
+			m.codexAuth.label = codexAccountName(codexAccount{Email: msg.Tokens.Email, Legacy: true})
+			return m, nil
+		}
 		authPath := legacyCodexAuthPath(m.globalDir)
 		if err := os.MkdirAll(filepath.Dir(authPath), 0o755); err != nil {
 			m.message = fmt.Sprintf("Failed to save tokens: %v", err)
@@ -1124,22 +1136,6 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 		}
 		if err := os.WriteFile(authPath, data, 0o600); err != nil {
 			m.message = fmt.Sprintf("Failed to save tokens: %v", err)
-			return m, nil
-		}
-		if m.draftMode {
-			// Draft mode: persist the completed OAuth bundle to disk NOW
-			// (legacy codex-auth.json) so a successful codex login survives
-			// even when the user abandons the wizard — the preset-first flow
-			// (create preset, then project) may never reach the finalizer's
-			// pre-publish dependency phase. Keep the draft copy as well so
-			// project_create.go's finalizer verify step still passes; it
-			// rewrites the identical bundle idempotently.
-			if m.draft != nil {
-				m.draft.DraftCodexTokens = secretBytes(data)
-			}
-			m.codexAuth.valid = true
-			m.codexAuth.email = msg.Tokens.Email
-			m.codexAuth.label = codexAccountName(codexAccount{Email: msg.Tokens.Email, Legacy: true})
 			return m, nil
 		}
 		m.refreshCodexAuth()
@@ -1573,19 +1569,13 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 							// draft session) — the arm above already
 							// blocked the pre-existing-disk-auth case
 							// before m.codexLogoutArmed could ever become
-							// true. Since CodexOAuthDoneMsg's draftMode
-							// branch now persists the bundle to disk
-							// immediately (the same legacy
-							// codex-auth.json the non-draft path writes),
-							// logging out here must remove that file too,
-							// then clear the in-memory draft.
+							// true. The draft bundle was never written to
+							// codex-auth.json, so clear it in memory and
+							// restore the real read-only disk state for the row.
 							if m.draft != nil {
 								m.draft.DraftCodexTokens = nil
 							}
-							_ = os.Remove(legacyCodexAuthPath(m.globalDir))
-							m.codexAuth.valid = false
-							m.codexAuth.email = ""
-							m.codexAuth.label = ""
+							m.refreshCodexAuth()
 						} else {
 							authPath := legacyCodexAuthPath(m.globalDir)
 							_ = os.Remove(authPath)

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -4259,7 +4259,20 @@ func (m FirstRunModel) presetAuthState() preset.AuthState {
 
 func (m FirstRunModel) presetCredentialState(p preset.Preset) (preset.CredentialFamily, bool) {
 	rr := preset.ResolvePresetWithAuth(p, m.existingKeys, m.presetAuthState())
-	return rr.Family, rr.ManifestValid && rr.HasKey
+	authValid := rr.HasKey
+	// A brand-new draft keeps its OAuth bundle in memory until explicit
+	// Create. The unbound legacy Codex preset is exactly the preset whose
+	// finalizer writes that bundle to codex-auth.json, so allow its picker
+	// gate to consume the draft bundle without restoring an eager global write.
+	// Explicit (including whitespace-only) codex_auth_path bindings stay
+	// fail-closed and must have their own on-disk credential.
+	if rr.ManifestValid && !authValid &&
+		rr.Family == preset.CredentialFamilyCodexSingle &&
+		m.draftMode && m.draft != nil && !m.draft.DraftCodexTokens.Empty() &&
+		rr.CodexAuthRef == "" {
+		authValid = true
+	}
+	return rr.Family, rr.ManifestValid && authValid
 }
 
 func (m FirstRunModel) presetCredentialHintKey(family preset.CredentialFamily) string {

--- a/tui/internal/tui/launcher_test.go
+++ b/tui/internal/tui/launcher_test.go
@@ -752,77 +752,128 @@ func TestDraftFirstRun_CodexDeleteBlockedForPreExistingAuth(t *testing.T) {
 	}
 }
 
-// TestDraftFirstRun_CodexDeleteAllowedForSessionLogin proves the OTHER half
-// of blocker 5's fix: when the Codex login happened DURING this draft
-// session (draft.DraftCodexTokens non-empty, exactly what
-// CodexOAuthDoneMsg's draftMode branch sets — see firstrun.go), clearing it
-// via Delete remains fully functional and honest. Since the draftMode login
-// now persists immediately to the legacy codex-auth.json (so a preset-first
-// flow keeps the credential even if the wizard is abandoned), the same-session
-// logout must remove that persisted file as well as the in-memory draft. This
-// proves the blocking guard in blocker 5's fix is scoped correctly — it must
-// not also break the legitimate, already-tested "undo a same-session login"
-// path.
-func TestDraftFirstRun_CodexDeleteAllowedForSessionLogin(t *testing.T) {
-	m, home, _ := buildDraftModel(t)
+// TestDraftFirstRun_CodexOAuthDeleteRestoresPreExistingAuth proves a draft
+// re-login can be discarded without changing the pre-existing legacy auth on
+// disk or leaving the credential row falsely logged out. It drives the real
+// OAuth-done message and two-press Delete confirmation, then verifies both
+// isolated filesystem snapshots and the restored original account display.
+func TestDraftFirstRun_CodexOAuthDeleteRestoresPreExistingAuth(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	globalDir := filepath.Join(home, ".lingtai-tui")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir globalDir: %v", err)
+	}
+	authPath := legacyCodexAuthPath(globalDir)
+	seedTokens := CodexTokens{
+		AccessToken:  "original-access-token",
+		RefreshToken: "original-refresh-token",
+		Email:        "original@example.com",
+	}
+	seedData, err := json.Marshal(seedTokens)
+	if err != nil {
+		t.Fatalf("marshal seed tokens: %v", err)
+	}
+	if err := os.WriteFile(authPath, seedData, 0o600); err != nil {
+		t.Fatalf("seed original codex-auth.json: %v", err)
+	}
+
+	projectRoot := t.TempDir()
+	draft := NewProjectDraft(projectRoot)
+	m := NewDraftFirstRunModel(filepath.Join(projectRoot, ".lingtai"), globalDir, false, draft)
 	m.step = stepPickPreset
 	m.presets = nil
 	m.cursor = 0
-	globalDir := filepath.Join(home, ".lingtai-tui")
 
-	// Simulate a completed same-session OAuth login via the real message
-	// path (CodexOAuthDoneMsg), not a synthetic direct field assignment.
+	if !m.codexAuth.valid || m.codexAuth.email != seedTokens.Email {
+		t.Fatalf("expected original configured account before draft re-login, got valid=%v email=%q", m.codexAuth.valid, m.codexAuth.email)
+	}
+
+	homeBefore := dirSnapshot(t, home)
+	projectBefore := dirSnapshot(t, projectRoot)
+
+	m, _ = m.Update(CodexOAuthDoneMsg{
+		Tokens: &CodexTokens{AccessToken: "draft-access-token", RefreshToken: "draft-refresh-token", Email: "draft@example.com"},
+	})
+	if m.draft.DraftCodexTokens.Empty() {
+		t.Fatal("expected DraftCodexTokens after the draft re-login")
+	}
+	if !m.codexAuth.valid || m.codexAuth.email != "draft@example.com" {
+		t.Fatalf("expected draft account displayed before deletion, got valid=%v email=%q", m.codexAuth.valid, m.codexAuth.email)
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if !m.codexLogoutArmed {
+		t.Fatal("expected Delete to arm for the same-session draft credentials")
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	if !m.draft.DraftCodexTokens.Empty() {
+		t.Fatal("expected DraftCodexTokens cleared after confirmed draft deletion")
+	}
+	assertSnapshotsEqual(t, "draft re-login/delete home", homeBefore, dirSnapshot(t, home))
+	assertSnapshotsEqual(t, "draft re-login/delete project", projectBefore, dirSnapshot(t, projectRoot))
+
+	rawAfter, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("original codex-auth.json must remain readable: %v", err)
+	}
+	if string(rawAfter) != string(seedData) {
+		t.Fatal("original codex-auth.json changed during draft re-login/delete")
+	}
+	if !m.codexAuth.valid || m.codexAuth.email != seedTokens.Email {
+		t.Fatalf("expected original account restored after draft deletion, got valid=%v email=%q", m.codexAuth.valid, m.codexAuth.email)
+	}
+	wantLabel := codexAccountName(codexAccount{Email: seedTokens.Email, Legacy: true})
+	if got := m.codexAuthDisplayLabel(); got != wantLabel {
+		t.Fatalf("expected original account display %q after draft deletion, got %q", wantLabel, got)
+	}
+}
+
+// TestDraftFirstRun_CodexOAuthThenCancelDoesNotPersist proves a completed
+// Codex OAuth in a pre-confirmation Create draft is memory-only. The real
+// OAuth completion and Esc cancellation paths must leave both the project root
+// and the isolated home unchanged: no project .lingtai and no global
+// codex-auth.json may appear before explicit Create.
+func TestDraftFirstRun_CodexOAuthThenCancelDoesNotPersist(t *testing.T) {
+	m, home, projectRoot := buildDraftModel(t)
+	m.step = stepPickPreset
+	m.presets = nil
+	m.cursor = 0
+
+	homeBefore := dirSnapshot(t, home)
+	projectBefore := dirSnapshot(t, projectRoot)
+
+	// Drive the real completion message rather than populating the draft
+	// directly; the wizard still displays the in-memory successful login.
 	m, _ = m.Update(CodexOAuthDoneMsg{
 		Tokens: &CodexTokens{AccessToken: "session-token", RefreshToken: "session-refresh", Email: "session@example.com"},
 	})
 	if m.draft.DraftCodexTokens.Empty() {
-		t.Fatal("expected DraftCodexTokens to be populated after a same-session OAuth completion")
+		t.Fatal("expected DraftCodexTokens to be populated after a draft OAuth completion")
 	}
 	if !m.codexAuth.valid {
-		t.Fatal("expected codexAuth.valid=true after the same-session login")
+		t.Fatal("expected codexAuth.valid=true for the in-memory draft login")
+	}
+	assertSnapshotsEqual(t, "draft Codex OAuth before cancellation home", homeBefore, dirSnapshot(t, home))
+	assertSnapshotsEqual(t, "draft Codex OAuth before cancellation project", projectBefore, dirSnapshot(t, projectRoot))
+
+	// Esc at the draft entry step is the actual cancellation path.
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected draft Esc cancellation command")
+	}
+	if _, ok := runCmd(cmd).(ProjectDraftCancelledMsg); !ok {
+		t.Fatal("expected ProjectDraftCancelledMsg after draft OAuth cancellation")
 	}
 
-	// The draftMode login persists immediately: the legacy codex-auth.json
-	// must exist on disk after the OAuth completion.
-	authPath := legacyCodexAuthPath(globalDir)
-	if raw, err := os.ReadFile(authPath); err != nil {
-		t.Fatalf("expected codex-auth.json persisted by draftMode login: %v", err)
-	} else if !strings.Contains(string(raw), "session-token") {
-		t.Fatalf("expected persisted codex-auth.json to contain the session token, got %q", raw)
+	assertSnapshotsEqual(t, "draft Codex OAuth then cancel home", homeBefore, dirSnapshot(t, home))
+	assertSnapshotsEqual(t, "draft Codex OAuth then cancel project", projectBefore, dirSnapshot(t, projectRoot))
+	if _, err := os.Stat(filepath.Join(projectRoot, ".lingtai")); !os.IsNotExist(err) {
+		t.Fatalf("draft cancellation must not create project .lingtai: %v", err)
 	}
-
-	before := dirSnapshot(t, home)
-
-	// Two-press Del: arm, then confirm.
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
-	if !m.codexLogoutArmed {
-		t.Fatal("expected the logout to arm for a same-session login — this path must remain unblocked")
-	}
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
-
-	// The only expected filesystem change from this logout is the
-	// persisted codex-auth.json being removed; everything else must be
-	// untouched.
-	after := dirSnapshot(t, home)
-	if len(after) != len(before)-1 {
-		t.Fatalf("expected exactly one file removed by same-session logout: before=%v after=%v", before, after)
-	}
-	if _, ok := after[filepath.Join(".lingtai-tui", "codex-auth.json")]; ok {
-		t.Fatalf("expected codex-auth.json absent after logout, got %v", after)
-	}
-
-	if !m.draft.DraftCodexTokens.Empty() {
-		t.Fatal("expected DraftCodexTokens cleared after confirming the in-memory logout")
-	}
-	if m.codexAuth.valid {
-		t.Fatal("expected codexAuth.valid=false after clearing the same-session login")
-	}
-	if m.message != i18n.T("firstrun.preset_pick.codex_logged_out") {
-		t.Fatalf("expected the normal logged-out message for a same-session login, got %q", m.message)
-	}
-	// The persisted file must be removed too.
-	if _, err := os.Stat(authPath); !os.IsNotExist(err) {
-		t.Fatalf("expected codex-auth.json removed after same-session logout, stat err=%v", err)
+	if _, err := os.Stat(legacyCodexAuthPath(filepath.Join(home, ".lingtai-tui"))); !os.IsNotExist(err) {
+		t.Fatalf("draft cancellation must not persist global codex auth: %v", err)
 	}
 }
 

--- a/tui/internal/tui/launcher_test.go
+++ b/tui/internal/tui/launcher_test.go
@@ -830,6 +830,61 @@ func TestDraftFirstRun_CodexOAuthDeleteRestoresPreExistingAuth(t *testing.T) {
 	}
 }
 
+// TestDraftFirstRun_CodexOAuthUnlocksUnboundCodexPreset proves the actual
+// first-time draft path stays reachable without restoring an eager write: a
+// completed in-memory OAuth bundle must let the user open, save, and carry an
+// unbound legacy Codex preset into Review, where explicit Create will persist
+// the same bundle. Explicit/bound Codex refs remain covered by the resolver's
+// normal fail-closed path.
+func TestDraftFirstRun_CodexOAuthUnlocksUnboundCodexPreset(t *testing.T) {
+	m, home, _ := buildDraftModel(t)
+	m.step = stepPickPreset
+	p := preset.Preset{
+		Name:        "draft-codex",
+		Description: preset.PresetDescription{Summary: "draft Codex preset"},
+		Source:      preset.SourceTemplate,
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{"provider": "codex", "model": "gpt-5.6-sol"},
+		},
+	}
+	m.presets = []preset.Preset{p}
+	m.cursor = 0
+	before := dirSnapshot(t, home)
+
+	m, _ = m.Update(CodexOAuthDoneMsg{
+		Tokens: &CodexTokens{AccessToken: "session-access", RefreshToken: "session-refresh", Email: "fresh@example.com"},
+	})
+	if m.draft == nil || m.draft.DraftCodexTokens.Empty() {
+		t.Fatal("expected first-time draft OAuth bundle to remain in memory")
+	}
+	if _, err := os.Stat(legacyCodexAuthPath(m.globalDir)); !os.IsNotExist(err) {
+		t.Fatalf("first-time draft OAuth must not eagerly persist codex auth: %v", err)
+	}
+
+	// Drive the same Enter handler a user uses on the Codex preset row. Before
+	// the fix, its disk-only gate stayed at stepPickPreset with a login hint.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.step != stepEditPreset {
+		t.Fatalf("fresh draft Codex OAuth did not open the unbound preset editor: step=%v message=%q", m.step, m.message)
+	}
+	if m.message != "" {
+		t.Fatalf("fresh draft Codex OAuth unexpectedly left picker warning %q", m.message)
+	}
+
+	// Save through the host's actual editor-completion message, then resolve
+	// the saved draft preset into Review. This proves the repaired route reaches
+	// the explicit-Create handoff without any pre-confirmation filesystem write.
+	m, _ = m.Update(PresetEditorCommitMsg{Preset: p})
+	if m.draft == nil || m.draft.DraftPreset == nil || m.draft.DraftPreset.Name != p.Name {
+		t.Fatalf("draft editor save did not capture Codex preset: %+v", m.draft)
+	}
+	m, _ = m.enterReviewStep("")
+	if m.step != stepReview || m.draft.DraftPreset == nil || m.draft.DraftPreset.Name != p.Name {
+		t.Fatalf("saved first-time Codex preset did not reach Review: step=%v draft=%+v", m.step, m.draft)
+	}
+	assertSnapshotsEqual(t, "first-time draft Codex preset flow", before, dirSnapshot(t, home))
+}
+
 // TestDraftFirstRun_CodexOAuthThenCancelDoesNotPersist proves a completed
 // Codex OAuth in a pre-confirmation Create draft is memory-only. The real
 // OAuth completion and Esc cancellation paths must leave both the project root


### PR DESCRIPTION
## Summary

- Keep a draft Create-flow Codex OAuth completion in `DraftCodexTokens` until the user explicitly creates the project; do not write global `codex-auth.json` from an unconfirmed draft.
- Restore a pre-existing global Codex account in the draft UI after a draft re-login is deleted, rather than falsely displaying it as logged out.
- Add focused regressions for OAuth-then-cancel zero-write behavior and pre-existing-auth re-login/delete restoration.

## Validation

- `go test ./internal/tui -count=1 -run '^(TestDraftFirstRun_CodexDeleteBlockedForPreExistingAuth|TestDraftFirstRun_CodexOAuthDeleteRestoresPreExistingAuth|TestDraftFirstRun_CodexOAuthThenCancelDoesNotPersist|TestPickPreset_OAuthDoneWritesOnMatchingEpoch|TestRunProjectCreate_DependenciesPersistBeforeRenameFailure|TestRunProjectCreate_PendingCodexPersistenceFailureDoesNotPublishProject|TestRunProjectCreate_SuccessPublishesResolvableSavedRefAndCredentialsBeforeLaunch)$'`
- `git diff --check`
- Independent R2 whole-diff review: P0/P1/P2 none; exact patch SHA verified.

## Notes

- The existing no-project startup gate remains the owner of preventing ordinary startup from creating `<cwd>/.lingtai`.
- `go test ./...` in the isolated review snapshot retained two unrelated root architecture reachability failures outside this patch (`api-semantic-scholar-batch.md` and `lock_windows_test.go`); the reviewed `internal/tui` package passed.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
