### PR TITLE
feat(tui): show tool call reasoning

### DIFF
--- a/tui/internal/fs/session.go
+++ b/tui/internal/fs/session.go
@@ -34,6 +34,7 @@ type SessionEntry struct {
 	Sources     []string          `json:"sources,omitempty"`     // notification entries — list of source keys (email, soul, system, ...)
 	Meta        *NotificationMeta `json:"meta,omitempty"`        // notification entries — vital signs at injection time (kernel build_meta + injection_seq)
 	ApiCallID   string            `json:"api_call_id,omitempty"` // llm/tool entries — one LLM API round-trip grouping id
+	Reasoning   string            `json:"reasoning,omitempty"`   // tool_call entries — own LTP _reasoning, rendered directly above the call
 	TokenUsage  *TokenUsage       `json:"token_usage,omitempty"` // llm_response entries — per-round token scalars (input/output/cached)
 	Summary     *AprioriSummary   `json:"summary,omitempty"`     // apriori_summary entries — the model-visible summary=true result that replaced the raw payload
 
@@ -1712,6 +1713,11 @@ func parseEventMap(raw map[string]interface{}) *SessionEntry {
 	if apiCallID, ok := raw["api_call_id"].(string); ok {
 		e.ApiCallID = apiCallID
 	}
+	if eventType == "tool_call" {
+		if args, ok := raw["tool_args"].(map[string]interface{}); ok {
+			e.Reasoning, _ = args["_reasoning"].(string)
+		}
+	}
 
 	if eventType == "insight" {
 		if q, ok := raw["question"].(string); ok {
@@ -2002,7 +2008,7 @@ func extractSessionEventText(entry map[string]interface{}, eventType string) str
 					}
 					return fmt.Sprintf("%s.%s", name, action)
 				}
-				data, _ := json.Marshal(argsMap)
+				data, _ := json.Marshal(toolCallArgsWithoutReasoning(argsMap))
 				args = string(data)
 			}
 		}
@@ -2014,6 +2020,19 @@ func extractSessionEventText(entry map[string]interface{}, eventType string) str
 		return formatToolResultEvent(entry)
 	}
 	return ""
+}
+
+// toolCallArgsWithoutReasoning returns a copy of argsMap without the private
+// reasoning field. It protects every structured tool-call display path,
+// including legacy/non-LTP maps that do not carry an action selector.
+func toolCallArgsWithoutReasoning(argsMap map[string]interface{}) map[string]interface{} {
+	rest := make(map[string]interface{}, len(argsMap))
+	for k, v := range argsMap {
+		if k != "_reasoning" {
+			rest[k] = v
+		}
+	}
+	return rest
 }
 
 // renderLTPToolParams renders the parameter portion of an LTP v2 tool_call

--- a/tui/internal/fs/tool_call_render_test.go
+++ b/tui/internal/fs/tool_call_render_test.go
@@ -46,6 +46,17 @@ func TestExtractSessionEventTextToolCallLTP(t *testing.T) {
 			want: `web({"query":"hello"})`,
 		},
 		{
+			name: "non-ltp-map-args-reasoning-dropped",
+			raw: map[string]interface{}{
+				"tool_name": "web",
+				"tool_args": map[string]interface{}{
+					"query":      "hello",
+					"_reasoning": "private diary text",
+				},
+			},
+			want: `web({"query":"hello"})`,
+		},
+		{
 			name: "string-args-pass-through",
 			raw: map[string]interface{}{
 				"tool_name": "bash",
@@ -110,5 +121,27 @@ func TestExtractSessionEventTextToolCallLTP(t *testing.T) {
 				t.Errorf("extractSessionEventText(tool_call) = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseEventMapToolCallCarriesReasoningSeparately(t *testing.T) {
+	e := parseEventMap(map[string]interface{}{
+		"type":      "tool_call",
+		"ts":        float64(1787010000),
+		"tool_name": "file",
+		"tool_args": map[string]interface{}{
+			"action":     "read",
+			"input":      map[string]interface{}{"file_path": "/tmp/x"},
+			"_reasoning": "inspect the source",
+		},
+	})
+	if e == nil {
+		t.Fatal("parseEventMap returned nil")
+	}
+	if e.Reasoning != "inspect the source" {
+		t.Fatalf("Reasoning = %q, want tool call's own _reasoning", e.Reasoning)
+	}
+	if e.Body != `file.read({"file_path":"/tmp/x"})` {
+		t.Fatalf("Body = %q, want rendered params without private _reasoning", e.Body)
 	}
 }

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -49,6 +49,7 @@ type ChatMessage struct {
 	Source      string               // for Type=="aed": subtype ("attempt" | "exhausted" | "timeout")
 	Meta        *fs.NotificationMeta // for Type=="notification": kernel vital signs at injection time (issue #40)
 	ApiCallID   string               // for text_output/tool_call/tool_result: LLM API round-trip grouping id
+	Reasoning   string               // for Type=="tool_call": its own LTP _reasoning, rendered immediately above the call
 	TokenUsage  *fs.TokenUsage       // for Type=="llm_response": per-round token scalars; rendered as a footer at the bottom of the api_call group
 	Summary     *fs.AprioriSummary   // for Type=="apriori_summary" (and tool_result carrying the artifact): the model-visible summary=true result
 }
@@ -889,6 +890,7 @@ func sessionEntryToChatMessage(e fs.SessionEntry, humanAddr string) ChatMessage 
 		Source:      e.Source,
 		Meta:        e.Meta,
 		ApiCallID:   e.ApiCallID,
+		Reasoning:   e.Reasoning,
 		TokenUsage:  e.TokenUsage,
 		Summary:     e.Summary,
 	}
@@ -1741,6 +1743,12 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 					}
 				} else {
 					body = truncateToolBody(body, m.toolCallTruncate)
+				}
+			}
+			if msg.Type == "tool_call" && msg.Reasoning != "" {
+				reasoning := lipgloss.NewStyle().Width(wrapWidth).Render("[Reasoning] " + msg.Reasoning)
+				for _, line := range strings.Split(reasoning, "\n") {
+					b.WriteString(thinkingStyle.Render("  "+RuneBullet+" "+line) + "\n")
 				}
 			}
 			wrapped := lipgloss.NewStyle().Width(wrapWidth).Render(tsPrefix + "[" + msg.Type + "] " + body)

--- a/tui/internal/tui/toolcall_display_test.go
+++ b/tui/internal/tui/toolcall_display_test.go
@@ -450,3 +450,49 @@ func TestRenderMessages_ShowsFullToolEntriesAtVerboseExtended(t *testing.T) {
 		t.Fatalf("Ctrl+O level 2 should render full tool_call/tool_result bodies, got %q", out)
 	}
 }
+
+func TestSessionEntryToChatMessageCarriesToolCallReasoning(t *testing.T) {
+	got := sessionEntryToChatMessage(fs.SessionEntry{
+		Type:      "tool_call",
+		Body:      "file.read({})",
+		Reasoning: "inspect the source",
+	}, "human")
+	if got.Reasoning != "inspect the source" {
+		t.Fatalf("Reasoning = %q, want tool call's own reasoning", got.Reasoning)
+	}
+}
+
+func TestRenderMessages_PlacesEachToolCallReasoningImmediatelyBeforeItsOwnCall(t *testing.T) {
+	m := MailModel{width: 100, verbose: verboseThinking}
+	out := m.renderMessages([]ChatMessage{
+		{Type: "tool_call", Body: "file.read({})", Reasoning: "inspect the source", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:26Z"},
+		{Type: "tool_call", Body: "shell.run({})", Reasoning: "run focused tests", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:27Z"},
+	})
+
+	firstReasoning := strings.Index(out, "[Reasoning] inspect the source")
+	firstCall := strings.Index(out, "[tool_call] file.read({})")
+	secondReasoning := strings.Index(out, "[Reasoning] run focused tests")
+	secondCall := strings.Index(out, "[tool_call] shell.run({})")
+	if firstReasoning < 0 || firstCall < 0 || secondReasoning < 0 || secondCall < 0 {
+		t.Fatalf("rendered output missing reasoning/call pair: %q", out)
+	}
+	if !(firstReasoning < firstCall && firstCall < secondReasoning && secondReasoning < secondCall) {
+		t.Fatalf("reasoning must directly precede its own call rather than follow API grouping: %q", out)
+	}
+}
+
+func TestRenderMessages_OmitsMissingToolCallReasoning(t *testing.T) {
+	m := MailModel{width: 100, verbose: verboseThinking}
+	out := m.renderMessages([]ChatMessage{{
+		Type:      "tool_call",
+		Body:      "file.read({})",
+		ApiCallID: "api_one",
+		Timestamp: "2026-06-08T07:08:26Z",
+	}})
+	if strings.Contains(out, "[Reasoning]") {
+		t.Fatalf("tool call with no logged reasoning must not render a synthetic reasoning line: %q", out)
+	}
+	if !strings.Contains(out, "[tool_call] file.read({})") {
+		t.Fatalf("tool call should otherwise render unchanged: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve each structured tool call's own `_reasoning` separately from displayed arguments
- render `[Reasoning]` in the existing diary/thinking color immediately above that exact tool call
- keep absent/legacy reasoning silent and filter `_reasoning` from both LTP and non-LTP structured argument displays

## Validation
- `go test ./internal/fs ./internal/tui -count=1`
- post-fix `go test ./internal/fs -count=1`
- focused parser/display pipeline tests
- `git diff --check`

## Review
- isolated exact-base-plus-patch review: P0 none / P1 none / P2 none (em-6fd4)

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai