### PR TITLE
Remove dead kanban plumbing

### DIFF
--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -31,7 +31,6 @@ type PropsModel struct {
 	// Manual snapshot: selected agent status plus bounded network/picker data.
 	selectedDir    string         // working dir of the shown agent (defaults to orchDir)
 	selectedStatus fs.AgentStatus // cached .status.json for selected agent
-	agentDirs      []string       // all discovered agent dirs (for picker)
 	agentNodes     []fs.AgentNode // discovered agents (for picker display)
 	network        fs.Network
 	// requestGeneration is issued only on the Bubble Tea update loop. It
@@ -110,7 +109,6 @@ type propsLoadMsg struct {
 	generation     uint64
 	network        fs.Network
 	selectedStatus fs.AgentStatus
-	agentDirs      []string
 	agentNodes     []fs.AgentNode
 
 	selectedRaw        map[string]any
@@ -152,12 +150,6 @@ func (m PropsModel) loadSnapshot() tea.Msg {
 	net, _ := fs.BuildNetworkWithOptions(m.baseDir, fs.KanbanNetworkOptions(&msg.readStats))
 	msg.network = net
 	msg.agentNodes = net.Nodes
-	for _, node := range net.Nodes {
-		if node.WorkingDir != "" {
-			msg.agentDirs = append(msg.agentDirs, node.WorkingDir)
-		}
-	}
-
 	agentRaw := map[string]any{}
 	initRaw := map[string]any{}
 	if m.selectedDir != "" {
@@ -348,7 +340,6 @@ func (m *PropsModel) applySnapshot(msg propsLoadMsg) {
 	m.network = msg.network
 	m.mailStatsAvailable = false
 	m.selectedStatus = msg.selectedStatus
-	m.agentDirs = msg.agentDirs
 	m.agentNodes = msg.agentNodes
 	m.selectedRaw = msg.selectedRaw
 	m.selectedLLM = msg.selectedLLM

--- a/tui/internal/tui/rebuild_separator_test.go
+++ b/tui/internal/tui/rebuild_separator_test.go
@@ -120,18 +120,6 @@ func TestRenderMainCallRowsInsertsMoltSeparatorLabel(t *testing.T) {
 	}
 }
 
-func TestRebuildSeparatorIndexesUsesCodexEpochResetRow(t *testing.T) {
-	entries := []fs.LedgerEntry{
-		{TS: ts(3000), CodexWSDeltaReason: "ok"},
-		{TS: ts(2000), CodexWSDeltaReason: "epoch_reset"},
-		{TS: ts(1000), CodexWSDeltaReason: "ok"},
-	}
-	got := rebuildSeparatorIndexes(entries, nil)
-	if len(got) != 1 || !got[1] {
-		t.Fatalf("expected separator after epoch_reset row index 1, got %v", got)
-	}
-}
-
 func TestRenderMainCallRowsInsertsSeparatorFromEpochReset(t *testing.T) {
 	m := PropsModel{
 		detailRecent: []fs.LedgerEntry{
@@ -154,64 +142,65 @@ func TestRenderMainCallRowsInsertsSeparatorFromEpochReset(t *testing.T) {
 	}
 }
 
-func TestRebuildSeparatorIndexesBetweenCalls(t *testing.T) {
+func TestLedgerSeparatorLabelKeysBetweenCalls(t *testing.T) {
 	entries := []fs.LedgerEntry{
 		{TS: ts(3000)}, // index 0 (newest)
 		{TS: ts(2000)}, // index 1
 		{TS: ts(1000)}, // index 2 (oldest)
 	}
-	// A rebuild at 2500 sits between row 0 (3000) and row 1 (2000).
-	rebuilds := []time.Time{time.Unix(2500, 0).UTC()}
+	// A molt at 2500 sits between row 0 (3000) and row 1 (2000).
+	moltTimes := []time.Time{time.Unix(2500, 0).UTC()}
 
-	got := rebuildSeparatorIndexes(entries, rebuilds)
-	if len(got) != 1 || !got[0] {
-		t.Fatalf("expected separator after index 0, got %v", got)
+	got := ledgerSeparatorLabelKeys(entries, moltTimes, nil)
+	if len(got) != 1 || len(got[0]) != 1 || got[0][0] != ledgerSeparatorMoltLabel {
+		t.Fatalf("expected molt separator after index 0, got %v", got)
 	}
 }
 
-func TestRebuildSeparatorIndexesMultiple(t *testing.T) {
+func TestLedgerSeparatorLabelKeysMultiple(t *testing.T) {
 	entries := []fs.LedgerEntry{
 		{TS: ts(4000)},
 		{TS: ts(3000)},
 		{TS: ts(2000)},
 		{TS: ts(1000)},
 	}
-	rebuilds := []time.Time{
+	moltTimes := []time.Time{
 		time.Unix(3500, 0).UTC(), // between idx 0 and 1
 		time.Unix(1500, 0).UTC(), // between idx 2 and 3
 	}
-	got := rebuildSeparatorIndexes(entries, rebuilds)
-	if !got[0] || !got[2] {
+	got := ledgerSeparatorLabelKeys(entries, moltTimes, nil)
+	if len(got[0]) != 1 || got[0][0] != ledgerSeparatorMoltLabel ||
+		len(got[2]) != 1 || got[2][0] != ledgerSeparatorMoltLabel {
 		t.Fatalf("expected separators after index 0 and 2, got %v", got)
 	}
-	if got[1] || got[3] {
+	if len(got[1]) != 0 || len(got[3]) != 0 {
 		t.Fatalf("unexpected separators at 1 or 3: %v", got)
 	}
 }
 
-func TestRebuildSeparatorIndexesNoneWhenOutOfRange(t *testing.T) {
+func TestLedgerSeparatorLabelKeysNoneWhenOutOfRange(t *testing.T) {
 	entries := []fs.LedgerEntry{
 		{TS: ts(3000)},
 		{TS: ts(2000)},
 	}
-	// Rebuilds older than all rows or newer than all rows produce no
+	// Molts older than all rows or newer than all rows produce no
 	// in-list separator (best effort: no marker).
-	rebuilds := []time.Time{
+	moltTimes := []time.Time{
 		time.Unix(500, 0).UTC(),  // older than oldest
 		time.Unix(9000, 0).UTC(), // newer than newest
 	}
-	got := rebuildSeparatorIndexes(entries, rebuilds)
+	got := ledgerSeparatorLabelKeys(entries, moltTimes, nil)
 	if len(got) != 0 {
 		t.Fatalf("expected no separators, got %v", got)
 	}
 }
 
-func TestRebuildSeparatorIndexesEmptyInputs(t *testing.T) {
-	if got := rebuildSeparatorIndexes(nil, []time.Time{time.Unix(1, 0)}); len(got) != 0 {
+func TestLedgerSeparatorLabelKeysEmptyInputs(t *testing.T) {
+	if got := ledgerSeparatorLabelKeys(nil, []time.Time{time.Unix(1, 0)}, nil); len(got) != 0 {
 		t.Fatalf("expected none for no entries, got %v", got)
 	}
 	entries := []fs.LedgerEntry{{TS: ts(1000)}}
-	if got := rebuildSeparatorIndexes(entries, nil); len(got) != 0 {
+	if got := ledgerSeparatorLabelKeys(entries, nil, nil); len(got) != 0 {
 		t.Fatalf("expected none for no rebuilds, got %v", got)
 	}
 }
@@ -257,15 +246,15 @@ func TestRenderMainCallRowsNoSeparatorWithoutRebuild(t *testing.T) {
 	}
 }
 
-func TestRebuildSeparatorIndexesSkipsMalformedTS(t *testing.T) {
+func TestLedgerSeparatorLabelKeysSkipsMalformedTS(t *testing.T) {
 	entries := []fs.LedgerEntry{
 		{TS: "not-a-time"},
 		{TS: ts(2000)},
 		{TS: ts(1000)},
 	}
-	rebuilds := []time.Time{time.Unix(1500, 0).UTC()} // between idx 1 and 2
-	got := rebuildSeparatorIndexes(entries, rebuilds)
-	if len(got) != 1 || !got[1] {
-		t.Fatalf("expected separator after index 1 only, got %v", got)
+	moltTimes := []time.Time{time.Unix(1500, 0).UTC()} // between idx 1 and 2
+	got := ledgerSeparatorLabelKeys(entries, moltTimes, nil)
+	if len(got) != 1 || len(got[1]) != 1 || got[1][0] != ledgerSeparatorMoltLabel {
+		t.Fatalf("expected molt separator after index 1 only, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

- remove the unused `PropsModel.agentDirs` data path; the kanban picker continues to use `agentNodes`
- remove the uncalled auto-refresh Ctrl+R message helper
- retire a production-dead separator compatibility wrapper and test the real label-producing helper directly
- correct the TUI Anatomy description of kanban auto-refresh: the one-second tick refreshes only the outer dashboard, while picker/detail remain point-in-time

## Why

The kanban model carried discovered agent directories twice: `loadData` built both `agentNodes` and a second `agentDirs` slice, but all picker rendering and selection consumed only `agentNodes`. The package also retained an uncalled auto-refresh helper and a separator wrapper used only by tests.

Removing these paths makes the current ownership explicit before later performance work, without changing visible behavior, refresh cadence, selection order, detail semantics, or separator placement.

## Behavior preserved

- agent picker data, order, and selection still come from `agentNodes`
- normal kanban auto-refresh still runs once per app tick
- auto-refresh still skips the agent picker and Ctrl+D detail view
- detail still refreshes only when opened, when the selected agent changes, or on explicit Ctrl+R
- molt/reconstruction separator labels and positions are still produced by `ledgerSeparatorLabelKeys`
- no UI strings, i18n, layout, network options, filesystem readers, or runtime behavior changed

## Validation

- `go test ./internal/tui -run 'Test(Props|AppAutoRefresh|AutoRefresh|.*Separator)' -count=1`
- `go test ./internal/tui -count=1`
- `go vet ./internal/tui`
- `go build ./...`
- `git diff --check <base>...HEAD`

The repository-wide architecture coverage test reports the same three pre-existing untracked-from-Anatomy files on both `main` and this branch; this change adds no architecture-graph failure. All Anatomy citations changed by this PR were checked against the final source ranges.
