### PR TITLE
fix(liveness): default shared heartbeat threshold to 10s

### DIFF
--- a/portal/internal/fs/ANATOMY.md
+++ b/portal/internal/fs/ANATOMY.md
@@ -59,7 +59,7 @@ The portal's read-focused window into a `.lingtai/` project directory. Same shap
 - `SumTokenLedger(path)` (`portal/internal/fs/agent.go:277-305`) — reads and sums a single `token_ledger.jsonl`.
 
 ### Heartbeat (`heartbeat.go`)
-- `IsAlive(dir, thresholdSec)` (`portal/internal/fs/heartbeat.go:11-21`) — reads `.agent.heartbeat`, returns true if fresher than threshold (5.0s, shared with the kernel liveness contract).
+- `IsAlive(dir, thresholdSec)` (`portal/internal/fs/heartbeat.go`) — reads `.agent.heartbeat`, returns true only for a strict age-below-threshold comparison; its default threshold comes from the shared environment setting.
 - `IsAliveHuman()` (`portal/internal/fs/heartbeat.go:24-26`) — always true.
 
 ### Mail (`mail.go`)
@@ -122,6 +122,6 @@ All state is read from the project's `.lingtai/` directory. The portal only writ
 
 - **`reconstruct.go` is the portal-specific addition.** The TUI shows live topology; the portal reconstructs historical topology tapes from `events.jsonl` + mailbox data. The reconstruction replays agent states chronologically using activity-driven sampling on a 3s grid (a frame per `agent_state` event, per mail message, per agent's first-seen time, plus one heartbeat per 60s during quiet stretches) — not a dense uniform grid, so reconstruction stays O(events) rather than O(duration/3s). Agents appear when their first event fires and mail accumulates cumulatively. This is the data source for the `/replay` endpoint.
 - **Mailbox id shape.** `newMailboxID` preserves the short `YYYYMMDDTHHMMSS-xxxx` (20 chars, UTC, 4 hex chars of UUID4 entropy) compatibility shape shared with the kernel and TUI (`tui/internal/fs/mail.go`). The portal reads existing directory names and message `id`/`_mailbox_id` records without rewriting them.
-- **`IsAlive`** uses a threshold resolved by `AgentAliveThresholdSec()`, which defaults to 5 seconds and can be overridden via the `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` env var (missing/blank/malformed/non-finite/zero/negative values fall back to the default). This window is a Portal-side presentation/operational setting, independent of the kernel's own heartbeat liveness config. A stale or missing heartbeat only clears `AgentNode.Alive` in `BuildNetwork`; it does not rewrite the manifest `State`.
+- **`IsAlive`** uses a threshold resolved by `AgentAliveThresholdSec()`, which defaults to 10 seconds and can be overridden via the shared `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` env var (missing/blank/malformed/non-finite/zero/negative values fall back to the default). The TUI, Portal, and kernel use this same liveness setting. A stale or missing heartbeat only clears `AgentNode.Alive` in `BuildNetwork`; it does not rewrite the manifest `State`.
 - **Atomic writes** (location, signals) use temp-file + rename, matching the kernel's filesystem contract.
 - **Capability parsing** handles both `[]string` (from TUI-generated presets) and tuple format (from live agents), so the portal works with projects the TUI hasn't touched.

--- a/portal/internal/fs/heartbeat.go
+++ b/portal/internal/fs/heartbeat.go
@@ -14,17 +14,16 @@ import (
 const AgentAliveThresholdEnvVar = "LINGTAI_AGENT_ALIVE_THRESHOLD_SEC"
 
 // DefaultAgentAliveThresholdSec is the fallback heartbeat-liveness window
-// when AgentAliveThresholdEnvVar is unset or invalid. This window is a
-// Portal-side presentation/operational setting, intentionally independent of
-// the kernel's own heartbeat liveness config (src/lingtai/kernel/config.py).
-const DefaultAgentAliveThresholdSec = 5.0
+// when AgentAliveThresholdEnvVar is unset or invalid. It is shared with the
+// TUI and kernel heartbeat-liveness contract.
+const DefaultAgentAliveThresholdSec = 10.0
 
 // AgentAliveThresholdSec resolves the heartbeat-liveness window from
 // AgentAliveThresholdEnvVar, falling back to DefaultAgentAliveThresholdSec
 // when the variable is missing, blank, malformed, non-finite, zero, or
 // negative. Callers apply the result with a strict age < threshold
-// comparison (see IsAlive below) so a live agent is never reported dead or
-// suspended.
+// comparison (see IsAlive below). Liveness observation never rewrites the
+// manifest lifecycle state.
 func AgentAliveThresholdSec() float64 {
 	raw := strings.TrimSpace(os.Getenv(AgentAliveThresholdEnvVar))
 	if raw == "" {

--- a/portal/internal/fs/heartbeat_test.go
+++ b/portal/internal/fs/heartbeat_test.go
@@ -9,14 +9,12 @@ import (
 	"time"
 )
 
-// TestAgentAliveThresholdSec_Default pins the fallback heartbeat-liveness
-// window to 5s. This window is a Portal-side presentation/operational
-// setting, intentionally independent of the kernel's own heartbeat liveness
-// config.
+// TestAgentAliveThresholdSec_Default pins the shared fallback
+// heartbeat-liveness window to 10s.
 func TestAgentAliveThresholdSec_Default(t *testing.T) {
 	t.Setenv(AgentAliveThresholdEnvVar, "")
-	if got := AgentAliveThresholdSec(); got != 5.0 {
-		t.Fatalf("AgentAliveThresholdSec() = %v, want default 5.0", got)
+	if got := AgentAliveThresholdSec(); got != 10.0 {
+		t.Fatalf("AgentAliveThresholdSec() = %v, want default 10.0", got)
 	}
 }
 
@@ -39,29 +37,29 @@ func TestAgentAliveThresholdSec_InvalidFallsBackToDefault(t *testing.T) {
 	}
 }
 
-func TestIsAlive_TwoSecondOldHeartbeat_Alive(t *testing.T) {
+func TestIsAlive_EightSecondOldHeartbeat_Alive(t *testing.T) {
 	dir := t.TempDir()
-	ts := fmt.Sprintf("%f", float64(time.Now().Add(-2*time.Second).Unix()))
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-8*time.Second).UnixNano())/1e9)
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
 	if !IsAlive(dir, AgentAliveThresholdSec()) {
-		t.Error("expected alive for 2s-old heartbeat under the default 5s threshold")
+		t.Error("expected alive for 8s-old heartbeat under the default 10s threshold")
 	}
 }
 
-func TestIsAlive_FiveSecondOldHeartbeat_Stale(t *testing.T) {
+func TestIsAlive_TenSecondOldHeartbeat_Stale(t *testing.T) {
 	// Strict boundary: an age at or beyond the threshold is stale
 	// (age < threshold, not age <= threshold).
 	dir := t.TempDir()
-	ts := fmt.Sprintf("%f", float64(time.Now().Add(-5*time.Second).Unix()))
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-10*time.Second).UnixNano())/1e9)
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
 	if IsAlive(dir, AgentAliveThresholdSec()) {
-		t.Error("expected stale for 5s-old heartbeat (strict age < threshold boundary)")
+		t.Error("expected stale for 10s-old heartbeat (strict age < threshold boundary)")
 	}
 }
 
 // TestBuildNetwork_HeartbeatAgeDrivesAliveState is the Portal topology-level
-// regression for issue #845: a 2s-old heartbeat (alive under the default
-// threshold) must not be marked dead, while a 6s-old heartbeat (stale
+// regression for issue #845: an 8s-old heartbeat (alive under the default
+// threshold) must not be marked dead, while an 11s-old heartbeat (stale
 // under the default threshold) is not alive. Neither age rewrites the
 // manifest ACTIVE state: heartbeat freshness is liveness evidence (Alive),
 // not permission to fabricate a lifecycle state (false-suspended fix,
@@ -71,7 +69,7 @@ func TestBuildNetwork_HeartbeatAgeDrivesAliveState(t *testing.T) {
 
 	bobDir := filepath.Join(base, "bob")
 	writeAgentManifest(t, bobDir, "bob", false) // manifest state "ACTIVE"
-	ts := fmt.Sprintf("%f", float64(time.Now().Add(-2*time.Second).Unix()))
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-8*time.Second).Unix()))
 	os.WriteFile(filepath.Join(bobDir, ".agent.heartbeat"), []byte(ts), 0o644)
 
 	net, err := BuildNetwork(base)
@@ -88,16 +86,16 @@ func TestBuildNetwork_HeartbeatAgeDrivesAliveState(t *testing.T) {
 		t.Fatal("bob node not found")
 	}
 	if !bob.Alive {
-		t.Errorf("bob with 2s-old heartbeat should be alive under the default 5s threshold, got Alive=false")
+		t.Errorf("bob with 8s-old heartbeat should be alive under the default 10s threshold, got Alive=false")
 	}
 	if bob.State == "SUSPENDED" {
-		t.Errorf("bob with 2s-old heartbeat must not be SUSPENDED, got State=%q", bob.State)
+		t.Errorf("bob with 8s-old heartbeat must not be SUSPENDED, got State=%q", bob.State)
 	}
 
-	// A 6s-old heartbeat is stale under the default threshold too: not
+	// An 11s-old heartbeat is stale under the default threshold too: not
 	// alive, but the manifest's ACTIVE state must survive untouched —
 	// liveness and lifecycle state are observed independently.
-	staleTs := fmt.Sprintf("%f", float64(time.Now().Add(-6*time.Second).Unix()))
+	staleTs := fmt.Sprintf("%f", float64(time.Now().Add(-11*time.Second).Unix()))
 	os.WriteFile(filepath.Join(bobDir, ".agent.heartbeat"), []byte(staleTs), 0o644)
 
 	net, err = BuildNetwork(base)
@@ -114,10 +112,10 @@ func TestBuildNetwork_HeartbeatAgeDrivesAliveState(t *testing.T) {
 		t.Fatal("bob node not found after stale heartbeat")
 	}
 	if bob.Alive {
-		t.Error("bob with 6s-old heartbeat should not be alive")
+		t.Error("bob with 11s-old heartbeat should not be alive")
 	}
 	if bob.State != "ACTIVE" {
-		t.Errorf("bob with 6s-old heartbeat must keep manifest state ACTIVE, got State=%q", bob.State)
+		t.Errorf("bob with 11s-old heartbeat must keep manifest state ACTIVE, got State=%q", bob.State)
 	}
 }
 
@@ -176,7 +174,7 @@ func TestBuildNetwork_SuspendedManifestStaysSuspendedWhenDead(t *testing.T) {
 	if err := os.WriteFile(manifestPath, out, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	staleTs := fmt.Sprintf("%f", float64(time.Now().Add(-6*time.Second).Unix()))
+	staleTs := fmt.Sprintf("%f", float64(time.Now().Add(-11*time.Second).Unix()))
 	os.WriteFile(filepath.Join(carolDir, ".agent.heartbeat"), []byte(staleTs), 0o644)
 
 	net, err := BuildNetwork(base)
@@ -193,7 +191,7 @@ func TestBuildNetwork_SuspendedManifestStaysSuspendedWhenDead(t *testing.T) {
 		t.Fatal("carol node not found")
 	}
 	if carol.Alive {
-		t.Error("carol with 6s-old heartbeat should not be alive")
+		t.Error("carol with 11s-old heartbeat should not be alive")
 	}
 	if carol.State != "SUSPENDED" {
 		t.Errorf("carol with genuine manifest SUSPENDED state should stay SUSPENDED, got State=%q", carol.State)

--- a/tui/internal/fs/heartbeat.go
+++ b/tui/internal/fs/heartbeat.go
@@ -14,17 +14,16 @@ import (
 const AgentAliveThresholdEnvVar = "LINGTAI_AGENT_ALIVE_THRESHOLD_SEC"
 
 // DefaultAgentAliveThresholdSec is the fallback heartbeat-liveness window
-// when AgentAliveThresholdEnvVar is unset or invalid. This window is a
-// TUI-side presentation/operational setting, intentionally independent of
-// the kernel's own heartbeat liveness config (src/lingtai/kernel/config.py).
-const DefaultAgentAliveThresholdSec = 5.0
+// when AgentAliveThresholdEnvVar is unset or invalid. It is shared with the
+// Portal and kernel heartbeat-liveness contract.
+const DefaultAgentAliveThresholdSec = 10.0
 
 // AgentAliveThresholdSec resolves the heartbeat-liveness window from
 // AgentAliveThresholdEnvVar, falling back to DefaultAgentAliveThresholdSec
 // when the variable is missing, blank, malformed, non-finite, zero, or
 // negative. Callers apply the result with a strict age < threshold
-// comparison (see ReadHeartbeat/IsAlive below) so a live agent is never
-// reported dead or suspended.
+// comparison (see ReadHeartbeat/IsAlive below). Liveness observation never
+// rewrites the manifest lifecycle state.
 func AgentAliveThresholdSec() float64 {
 	raw := strings.TrimSpace(os.Getenv(AgentAliveThresholdEnvVar))
 	if raw == "" {

--- a/tui/internal/fs/heartbeat_test.go
+++ b/tui/internal/fs/heartbeat_test.go
@@ -8,13 +8,12 @@ import (
 	"time"
 )
 
-// TestAgentAliveThresholdSec_Default pins the fallback heartbeat-liveness
-// window to 5s. This window is a TUI-side presentation/operational setting,
-// intentionally independent of the kernel's own heartbeat liveness config.
+// TestAgentAliveThresholdSec_Default pins the shared fallback
+// heartbeat-liveness window to 10s.
 func TestAgentAliveThresholdSec_Default(t *testing.T) {
 	t.Setenv(AgentAliveThresholdEnvVar, "")
-	if got := AgentAliveThresholdSec(); got != 5.0 {
-		t.Fatalf("AgentAliveThresholdSec() = %v, want default 5.0", got)
+	if got := AgentAliveThresholdSec(); got != 10.0 {
+		t.Fatalf("AgentAliveThresholdSec() = %v, want default 10.0", got)
 	}
 }
 
@@ -46,32 +45,32 @@ func TestIsAlive_FreshHeartbeat(t *testing.T) {
 	}
 }
 
-func TestIsAlive_TwoSecondOldHeartbeat_Alive(t *testing.T) {
+func TestIsAlive_NineSecondOldHeartbeat_Alive(t *testing.T) {
 	dir := t.TempDir()
-	ts := fmt.Sprintf("%f", float64(time.Now().Add(-2*time.Second).Unix()))
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-9*time.Second).UnixNano())/1e9)
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
 	if !IsAlive(dir, AgentAliveThresholdSec()) {
-		t.Error("expected alive for 2s-old heartbeat under the default 5s threshold")
+		t.Error("expected alive for 9s-old heartbeat under the default 10s threshold")
 	}
 }
 
-func TestIsAlive_FiveSecondOldHeartbeat_Stale(t *testing.T) {
+func TestIsAlive_TenSecondOldHeartbeat_Stale(t *testing.T) {
 	// Strict boundary: an age at or beyond the threshold is stale
 	// (age < threshold, not age <= threshold).
 	dir := t.TempDir()
-	ts := fmt.Sprintf("%f", float64(time.Now().Add(-5*time.Second).Unix()))
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-10*time.Second).UnixNano())/1e9)
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
 	if IsAlive(dir, AgentAliveThresholdSec()) {
-		t.Error("expected stale for 5s-old heartbeat (strict age < threshold boundary)")
+		t.Error("expected stale for 10s-old heartbeat (strict age < threshold boundary)")
 	}
 }
 
-func TestIsAlive_SixSecondOldHeartbeat_Stale(t *testing.T) {
+func TestIsAlive_ElevenSecondOldHeartbeat_Stale(t *testing.T) {
 	dir := t.TempDir()
-	ts := fmt.Sprintf("%f", float64(time.Now().Add(-6*time.Second).Unix()))
+	ts := fmt.Sprintf("%f", float64(time.Now().Add(-11*time.Second).UnixNano())/1e9)
 	os.WriteFile(filepath.Join(dir, ".agent.heartbeat"), []byte(ts), 0o644)
 	if IsAlive(dir, AgentAliveThresholdSec()) {
-		t.Error("expected dead for 6s-old heartbeat")
+		t.Error("expected dead for 11s-old heartbeat")
 	}
 }
 

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
@@ -20,7 +20,7 @@ This is a nested `lingtai-portal-guide` reference. It covers how the portal inte
 | `ASLEEP` | Agent is in sleep mode (`.sleep` signal or explicit lifecycle transition) |
 | `SUSPENDED` | Agent process is not running (kernel/manifest reports it as such) |
 
-Heartbeat is the portal's liveness ground truth, but it is observed independently from the manifest lifecycle state. `BuildNetwork()` calls `IsAlive(..., AgentAliveThresholdSec())`, which resolves the liveness window from the `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` env var (default 5 seconds; missing, blank, malformed, non-finite, zero, or negative values fall back to the default). A stale or missing heartbeat only clears `AgentNode.Alive` — it does not rewrite `.agent.json`'s stored `state`, so a genuinely `SUSPENDED` manifest stays `SUSPENDED` while an `ACTIVE`/`IDLE`/etc. agent with a stale heartbeat keeps its real state and is simply reported not alive.
+Heartbeat is the portal's liveness ground truth, but it is observed independently from the manifest lifecycle state. `BuildNetwork()` calls `IsAlive(..., AgentAliveThresholdSec())`, which resolves the shared TUI/Portal/kernel liveness window from the `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` env var (default 10 seconds; missing, blank, malformed, non-finite, zero, or negative values fall back to the default). A stale or missing heartbeat only clears `AgentNode.Alive` — it does not rewrite `.agent.json`'s stored `state`, so a genuinely `SUSPENDED` manifest stays `SUSPENDED` while an `ACTIVE`/`IDLE`/etc. agent with a stale heartbeat keeps its real state and is simply reported not alive.
 
 ## Recording
 

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/anthropics/lingtai-tui/i18n"
 	"github.com/anthropics/lingtai-tui/internal/config"
 	"github.com/anthropics/lingtai-tui/internal/doctorreport"
+	"github.com/anthropics/lingtai-tui/internal/fs"
 	"github.com/anthropics/lingtai-tui/internal/preset"
 	"github.com/anthropics/lingtai-tui/internal/sqlitelog"
 )
@@ -1709,10 +1710,10 @@ func checkKernelHealth(orchDir, globalDir string, lines *[]doctorLine) bool {
 	// K6 was the former project migration/version-chain diagnostic. Runtime
 	// migrations are retired, so /doctor reports kernel/runtime health only.
 
-	// K7. Orchestrator heartbeat. Uses the canonical 3.0s liveness threshold
-	// from app.go / mail.go / nirvana.go. No remediation suggestion — a stale
-	// heartbeat can mean ASLEEP, SUSPENDED, crashed, or just lagging; the
-	// main view is the authoritative place for state and recovery actions.
+	// K7. Orchestrator heartbeat. Uses the shared env-resolved liveness
+	// threshold from fs.AgentAliveThresholdSec(), matching the rest of the TUI.
+	// No remediation suggestion — a stale heartbeat can mean ASLEEP, SUSPENDED,
+	// crashed, or just lagging; the main view is authoritative for recovery.
 	age, hbErr := readHeartbeatAge(orchDir)
 	switch {
 	case hbErr != nil && os.IsNotExist(hbErr):
@@ -1723,7 +1724,7 @@ func checkKernelHealth(orchDir, globalDir string, lines *[]doctorLine) bool {
 		*lines = append(*lines, doctorLine{
 			Text: i18n.TF("doctor.heartbeat_unreadable", hbErr.Error()), Warn: true,
 		})
-	case age < 3*time.Second:
+	case age.Seconds() < fs.AgentAliveThresholdSec():
 		*lines = append(*lines, doctorLine{
 			Text: i18n.TF("doctor.heartbeat_fresh", formatHeartbeatAge(age)), OK: true,
 		})


### PR DESCRIPTION
## Summary

- Make the existing `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` setting default to **10 seconds** in both TUI and Portal.
- Keep parsing safe: missing, blank, malformed, non-finite, zero, and negative values fall back to the default; valid positive values override it.
- Keep stale heartbeat separate from lifecycle state: TUI/Portal report `Alive=false` without fabricating `SUSPENDED`.
- Make `/doctor` use the same resolved threshold rather than its former local 3-second check.

## Paired change

This is paired with the kernel branch of the same name, which makes the kernel use the same environment setting and documents its import-time resolution.

## Validation

- `GOPROXY=off go test ./internal/fs` (TUI): PASS
- `GOPROXY=off go test ./internal/fs` (Portal): PASS
- `GOPROXY=off go test ./internal/tui` (TUI): PASS
- Final detached-snapshot independent review: **APPROVED — P0=0, P1=0, P2=0**

No merge, release, deployment, or live configuration change is part of this PR.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
