### PR TITLE
feat(process): launch agents through kernel CLI

### DIFF
--- a/tui/internal/process/launcher.go
+++ b/tui/internal/process/launcher.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/anthropics/lingtai-tui/internal/config"
 	"github.com/anthropics/lingtai-tui/internal/fs"
@@ -93,6 +94,14 @@ func resolvePython(agentDir, fallbackCmd string) string {
 // in that case. The kernel's flock guarantees correctness of on-disk state,
 // but a duplicate Python process still shows up in `ps`/`lingtai-tui list`
 // and can mislead users; this guard keeps the process accounting honest.
+func kernelCLI(python string) string {
+	name := "lingtai-agent"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(filepath.Dir(python), name)
+}
+
 func LaunchAgent(lingtaiCmd, agentDir string) (*exec.Cmd, error) {
 	if IsAgentRunning(agentDir) {
 		return nil, ErrAgentAlreadyRunning
@@ -119,7 +128,7 @@ func launchAgentUnsafe(lingtaiCmd, agentDir string) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("ensure addons: %w", err)
 	}
 
-	cmd := exec.Command(python, "-m", "lingtai", "run", agentDir)
+	cmd := exec.Command(kernelCLI(python), "run", agentDir)
 	// Redirect agent output to a log file instead of the TUI terminal
 	logPath := filepath.Join(agentDir, "logs")
 	if err := os.MkdirAll(logPath, 0o755); err != nil {

--- a/tui/internal/process/launcher_test.go
+++ b/tui/internal/process/launcher_test.go
@@ -58,6 +58,16 @@ func writeStubPython(t *testing.T, dir, logPath string, exitStatus int) string {
 	return p
 }
 
+func writeStubLingtaiAgent(t *testing.T, dir, logPath string, exitStatus int) string {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" >> %q\nexit %d\n", logPath, exitStatus)
+	p := filepath.Join(dir, "lingtai-agent")
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
 func readInvocationLog(t *testing.T, logPath string) string {
 	t.Helper()
 	data, err := os.ReadFile(logPath)
@@ -115,6 +125,7 @@ func TestLaunchAgentUnsafeValidAddonKeyKeepsLaunchBehavior(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "python-calls.log")
 	stub := writeStubPython(t, dir, logPath, 0)
+	writeStubLingtaiAgent(t, dir, logPath, 0)
 
 	agentDir := filepath.Join(dir, "alice")
 	if err := os.MkdirAll(agentDir, 0o755); err != nil {
@@ -144,7 +155,7 @@ func TestLaunchAgentUnsafeValidAddonKeyKeepsLaunchBehavior(t *testing.T) {
 	}
 
 	calls := readInvocationLog(t, logPath)
-	for _, want := range []string{"-c", "import lingtai.addons.imap", "-m", "lingtai", "run"} {
+	for _, want := range []string{"-c", "import lingtai.addons.imap", "run"} {
 		if !strings.Contains(calls, want) {
 			t.Errorf("interpreter log missing %q; got:\n%s", want, calls)
 		}


### PR DESCRIPTION
## Summary
- launch each agent through its venv-local `lingtai-agent run <agentDir>` entrypoint instead of `python -m lingtai run <agentDir>`
- preserve addon preflight, duplicate-launch protection, signal cleanup, log redirection, and child lifecycle behavior
- add focused regression coverage with separate Python-probe and kernel-CLI stubs

## Validation
- `go test ./internal/process`
- `git diff --check`

## Scope
Narrow first TUI headless slice only: the final agent execution suffix. It does not migrate provisioning, readiness polling, lifecycle policy, host inventory, bootstrap, presets, or update behavior.