### PR TITLE
feat(tui): route headless project creation through kernel CLI

### DIFF
--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -21,6 +21,7 @@ related_files:
   - tui/internal/fs/heartbeat_test.go
   - tui/internal/fs/atomic_write.go
   - tui/internal/fs/atomic_write_permissions_unix_test.go
+  - tui/internal/fs/exclusive_lock.go
   - tui/internal/fs/file_ops_unix.go
   - tui/internal/fs/file_ops_windows.go
   - tui/internal/fs/mail.go
@@ -120,6 +121,7 @@ The TUI's filesystem window into an agent working directory (`<project>/.lingtai
 | **atomic_write.go / file_ops_*.go** | | |
 | `writeAtomicReplacement` / `createAtomicReplacementTemp` / `writeAtomicBytes` | `tui/internal/fs/atomic_write.go:15-106` | writes through a random exclusive same-directory temp, preserves an existing target's permission bits or applies the caller fallback through the process umask for a new target, flushes and closes before atomic replacement, cleans every unpublished temp, and best-effort flushes the parent directory |
 | `replaceFile` / `lockFileExclusive` / `unlockFile` | `tui/internal/fs/file_ops_unix.go:10-20`, `tui/internal/fs/file_ops_windows.go:11-31` | supplies platform replacement and advisory-lock operations: rename/flock on non-Windows and `MoveFileEx` with replacement/write-through plus `LockFileEx`/`UnlockFileEx` on Windows |
+| `AcquireExclusiveFileLock` / `ExclusiveFileLock.Release` | `tui/internal/fs/exclusive_lock.go` | reusable stable-file advisory-exclusive lock: canonical path mutex, ensured lock parent, blocking OS lock, then idempotent unlock/close/mutex release; the sidecar is never removed |
 | **mail.go** | | |
 | `newMailboxID()` | `tui/internal/fs/mail.go:33` | builds `YYYYMMDDTHHMMSS-xxxx` short id matching the kernel's `_new_mailbox_id` |
 | `prepareMailDirs` | `tui/internal/fs/mail.go:55` | allocates a short id and creates every mailbox leaf the send will write, retrying on collisions in any target folder |

--- a/tui/internal/fs/exclusive_lock.go
+++ b/tui/internal/fs/exclusive_lock.go
@@ -1,0 +1,88 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var exclusiveFileLockPathLocks sync.Map // canonical lock path -> *sync.Mutex
+
+// ExclusiveFileLock owns an advisory, exclusive file lock and its local path
+// mutex. Release unlocks and closes the file, then releases the local mutex; it
+// never removes the stable lock file.
+type ExclusiveFileLock struct {
+	mu        sync.Mutex
+	file      *os.File
+	pathMutex *sync.Mutex
+	released  bool
+}
+
+// AcquireExclusiveFileLock blocks until this process owns an advisory,
+// exclusive lock for lockPath. The stable lock file is retained after Release.
+func AcquireExclusiveFileLock(lockPath string) (*ExclusiveFileLock, error) {
+	if strings.TrimSpace(lockPath) == "" {
+		return nil, fmt.Errorf("exclusive lock path is empty")
+	}
+	canonicalPath, err := filepath.Abs(filepath.Clean(lockPath))
+	if err != nil {
+		return nil, fmt.Errorf("resolve exclusive lock path: %w", err)
+	}
+
+	value, _ := exclusiveFileLockPathLocks.LoadOrStore(canonicalPath, &sync.Mutex{})
+	pathMutex := value.(*sync.Mutex)
+	pathMutex.Lock()
+
+	if err := os.MkdirAll(filepath.Dir(canonicalPath), 0o755); err != nil {
+		pathMutex.Unlock()
+		return nil, fmt.Errorf("create lock parent: %w", err)
+	}
+	file, err := os.OpenFile(canonicalPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		pathMutex.Unlock()
+		return nil, fmt.Errorf("open exclusive lock: %w", err)
+	}
+	if err := lockFileExclusive(file); err != nil {
+		_ = file.Close()
+		pathMutex.Unlock()
+		return nil, fmt.Errorf("lock exclusive file: %w", err)
+	}
+
+	return &ExclusiveFileLock{file: file, pathMutex: pathMutex}, nil
+}
+
+// Release unlocks, closes, and frees the local path mutex. It is safe to call
+// more than once. It never removes the stable lock file.
+func (lock *ExclusiveFileLock) Release() error {
+	if lock == nil {
+		return nil
+	}
+
+	lock.mu.Lock()
+	if lock.released {
+		lock.mu.Unlock()
+		return nil
+	}
+	lock.released = true
+	file := lock.file
+	pathMutex := lock.pathMutex
+	lock.file = nil
+	lock.pathMutex = nil
+	lock.mu.Unlock()
+
+	var result error
+	if file != nil {
+		if err := unlockFile(file); err != nil {
+			result = fmt.Errorf("unlock exclusive file: %w", err)
+		}
+		if err := file.Close(); err != nil && result == nil {
+			result = fmt.Errorf("close exclusive lock: %w", err)
+		}
+	}
+	if pathMutex != nil {
+		pathMutex.Unlock()
+	}
+	return result
+}

--- a/tui/internal/globalmigrate/ANATOMY.md
+++ b/tui/internal/globalmigrate/ANATOMY.md
@@ -36,7 +36,7 @@ maintenance: |
 
 ## Connections
 
-- **Called by `tui/main.go`** (`tui/main.go:1001`, `tui/main.go:1457`) on the interactive startup and doctor paths, and by `tui/internal/headless/spawn.go:95` so a headless spawn advances machine state identically.
+- **Called by `tui/main.go`** (`tui/main.go:1001`, `tui/main.go:1457`) on the interactive startup and doctor paths, and by `tui/internal/headless/spawn.go:112` so a headless spawn advances machine state identically.
 - **Runs before `preset.Bootstrap`** in the startup order — which is exactly why a destructive step here can eat user data (see Notes).
 - **Reads/writes `~/.lingtai-tui/meta.json` only.** Directory resolution comes from `tui/internal/config/`.
 - **Independent of `tui/internal/migrate/`.** Same conventions and shape, disjoint version space and target directory. Do not renumber across the two.

--- a/tui/internal/headless/ANATOMY.md
+++ b/tui/internal/headless/ANATOMY.md
@@ -10,6 +10,7 @@ related_files:
   - tui/internal/headless/presets_test.go
   - tui/internal/headless/spawn.go
   - tui/internal/headless/spawn_test.go
+  - tui/internal/headless/spawn_serialization_test.go
   - tui/main.go
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
@@ -34,14 +35,14 @@ maintenance: |
 | `ExitError` | `tui/internal/headless/headless.go:37` | writes the error document to stderr and exits nonzero; used directly by `tui/main.go` argument parsing before a subcommand is entered |
 | `PresetEntry` / `PresetsOutput` | `tui/internal/headless/presets.go:10,19` | the `presets` output schema — name, source (template/saved), description, and the resolved ref an `init.json` can cite |
 | `RunPresets` | `tui/internal/headless/presets.go:25` | lists presets through `internal/preset`, honoring the mutually exclusive `--saved-only` / `--templates-only` filters |
-| `SpawnOpts` / `SpawnOutput` | `tui/internal/headless/spawn.go:37,47` | the existing `spawn` input options (target dir, preset, agent name, language) and output document (agent dir, name, preset, PID, readiness) |
-| `RunSpawn` | `tui/internal/headless/spawn.go:73` | the whole non-interactive create-and-launch path: global-dir resolution, `globalmigrate.Run`, a TUI-owned covenant temp input, complete trusted kernel create, shared-library/language compatibility writes, deliberately best-effort plain recipe bundle/apply work, required recipe-state persistence, registration, launch, then the existing bounded readiness wait (`defaultReadyTimeout`, `tui/internal/headless/spawn.go:21`) before emitting JSON |
+| `SpawnOpts` / `SpawnOutput` | `tui/internal/headless/spawn.go:42,53` | the existing `spawn` input options (target dir, preset, agent name, language) and output document (agent dir, name, preset, PID, readiness) |
+| `RunSpawn` | `tui/internal/headless/spawn.go:78` | the whole non-interactive create-and-launch path: after argument validation, a per-resolved-root stable sibling `<root>.lingtai-spawn.lock` blocks cooperating creators before the `.lingtai` precheck and remains held through global setup, trusted kernel create, required post-create policy, and registration; it releases before launch/readiness. The rest resolves global state, runs `globalmigrate.Run`, uses a TUI-owned covenant temp input, performs complete trusted kernel create, shared-library/language compatibility writes, deliberately best-effort plain recipe bundle/apply work, required recipe-state persistence, registration, launch, then the existing bounded readiness wait (`defaultReadyTimeout`, `tui/internal/headless/spawn.go:21`) before emitting JSON |
 
 ## Connections
 
 - **Called by `tui/main.go`** — `bootstrapMain`, `presetsMain`, and `spawnMain` are thin argv parsers over this package. The adjacent `doctorMain` and `selfUpdateMain` subcommands deliberately do NOT route through here: they repair the local install via `internal/config` rather than emitting headless JSON.
 - **Calls `tui/internal/preset/`** for preset enumeration, selected-preset resolution, the TUI-owned covenant input, bundled utilities, and the retained plain-recipe state.
-- **Calls `tui/internal/globalmigrate/`** (`tui/internal/headless/spawn.go:112`) so a headless spawn advances per-machine state exactly like an interactive start.
+- **Calls `tui/internal/globalmigrate/`** (`tui/internal/headless/spawn.go:136`) so a headless spawn advances per-machine state exactly like an interactive start.
 - **Calls `tui/internal/process/`** to seed through `CreateProject` and, only after its complete success protocol, to retain the existing guarded agent launch; it calls `tui/internal/fs/` to observe the new agent's manifest/heartbeat while waiting for readiness.
 
 ## Composition

--- a/tui/internal/headless/ANATOMY.md
+++ b/tui/internal/headless/ANATOMY.md
@@ -34,15 +34,15 @@ maintenance: |
 | `ExitError` | `tui/internal/headless/headless.go:37` | writes the error document to stderr and exits nonzero; used directly by `tui/main.go` argument parsing before a subcommand is entered |
 | `PresetEntry` / `PresetsOutput` | `tui/internal/headless/presets.go:10,19` | the `presets` output schema — name, source (template/saved), description, and the resolved ref an `init.json` can cite |
 | `RunPresets` | `tui/internal/headless/presets.go:25` | lists presets through `internal/preset`, honoring the mutually exclusive `--saved-only` / `--templates-only` filters |
-| `SpawnOpts` / `SpawnOutput` | `tui/internal/headless/spawn.go:30,40` | the `spawn` input options (target dir, preset, agent name, language) and its output document (agent dir, name, preset, PID, readiness) |
-| `RunSpawn` | `tui/internal/headless/spawn.go:65` | the whole non-interactive create-and-launch path: global-dir resolution, `globalmigrate.Run`, project init, manifest write, launch, then a bounded readiness wait (`defaultReadyTimeout`, `tui/internal/headless/spawn.go:17`) before emitting JSON |
+| `SpawnOpts` / `SpawnOutput` | `tui/internal/headless/spawn.go:37,47` | the existing `spawn` input options (target dir, preset, agent name, language) and output document (agent dir, name, preset, PID, readiness) |
+| `RunSpawn` | `tui/internal/headless/spawn.go:73` | the whole non-interactive create-and-launch path: global-dir resolution, `globalmigrate.Run`, a TUI-owned covenant temp input, complete trusted kernel create, shared-library/language compatibility writes, deliberately best-effort plain recipe bundle/apply work, required recipe-state persistence, registration, launch, then the existing bounded readiness wait (`defaultReadyTimeout`, `tui/internal/headless/spawn.go:21`) before emitting JSON |
 
 ## Connections
 
 - **Called by `tui/main.go`** — `bootstrapMain`, `presetsMain`, and `spawnMain` are thin argv parsers over this package. The adjacent `doctorMain` and `selfUpdateMain` subcommands deliberately do NOT route through here: they repair the local install via `internal/config` rather than emitting headless JSON.
-- **Calls `tui/internal/preset/`** for preset enumeration and for seeding a new agent's `init.json`.
-- **Calls `tui/internal/globalmigrate/`** (`tui/internal/headless/spawn.go:95`) so a headless spawn advances per-machine state exactly like an interactive start.
-- **Calls `tui/internal/process/`** to init the project and launch the agent subprocess, and `tui/internal/fs/` to observe the new agent's manifest/heartbeat while waiting for readiness.
+- **Calls `tui/internal/preset/`** for preset enumeration, selected-preset resolution, the TUI-owned covenant input, bundled utilities, and the retained plain-recipe state.
+- **Calls `tui/internal/globalmigrate/`** (`tui/internal/headless/spawn.go:112`) so a headless spawn advances per-machine state exactly like an interactive start.
+- **Calls `tui/internal/process/`** to seed through `CreateProject` and, only after its complete success protocol, to retain the existing guarded agent launch; it calls `tui/internal/fs/` to observe the new agent's manifest/heartbeat while waiting for readiness.
 
 ## Composition
 
@@ -52,6 +52,7 @@ maintenance: |
 
 ## Notes
 
-- **stdout is a protocol.** Anything printed on stdout by a headless command must be part of the documented JSON document. Diagnostics belong on stderr. Adding a stray `fmt.Println` breaks every scripted caller.
+- **stdout is a protocol.** Anything printed on stdout by a headless command must be part of the documented JSON document. Kernel-create stdout/stderr are captured, never forwarded as a second document; handler exit-1 JSON is rendered as one headless stderr error object. Adding a stray `fmt.Println` breaks every scripted caller.
+- **Create is conservative.** Registration and launch require exit 0 plus exactly one `{"status":"created"}` result for the requested agent with a nonempty canonical `preset_ref`. Exit 2, timeout/cancel/signal, startup failure, or malformed output is reported through the existing `init_failed` code with a structured reason; it neither registers/launches nor deletes a possibly partial tree. After trusted success, the caller restores only `.lingtai/.library_shared`; a later library/language/recipe-state persistence/registration failure emits `recovery_state:"created_unregistered"` with the project and agent identities instead of launching. The plain recipe bundle/apply paths remain deliberately best-effort legacy side effects: persisted `plain` state records the selected recipe, not proof that every optional recipe artifact was copied or applied. The temporary covenant source is TUI-owned and removed only after the child is terminal.
 - **Readiness is bounded, not guaranteed.** `RunSpawn` waits up to `defaultReadyTimeout` for the agent to publish a heartbeat and reports what it observed; it does not block forever, and a not-yet-ready agent is reported, not treated as a failure to launch.
 - **Error codes are the stable surface.** `invalid_args`, `init_failed`, `bootstrap_failed`, and the spawn-specific codes are consumed by callers. Rename one only with the callers in the same change.

--- a/tui/internal/headless/spawn.go
+++ b/tui/internal/headless/spawn.go
@@ -32,6 +32,11 @@ var (
 	readySleep              = time.Sleep
 	readyPollInterval       = 200 * time.Millisecond
 	processExitGrace        = 2 * time.Second
+	// Package-local defaults keep focused tests coordinated with the actual
+	// acquisition/release boundary without changing the headless public surface.
+	acquireSpawnSerializationLock       = fs.AcquireExclusiveFileLock
+	releaseSpawnSerializationLock       = func(lock *fs.ExclusiveFileLock) error { return lock.Release() }
+	beforeSpawnSerializationLockAcquire = func() {}
 )
 
 // SpawnOpts holds the parsed flags for the spawn subcommand.
@@ -88,6 +93,24 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 		WriteError(stderr, fmt.Sprintf("invalid agent name %q: %s", agentName, err.Error()), "invalid_args")
 		return 1
 	}
+
+	// Serialize cooperating headless creators for this root before the .lingtai
+	// precheck. The persistent sibling sidecar keeps the kernel target empty.
+	beforeSpawnSerializationLockAcquire()
+	spawnLock, err := acquireSpawnSerializationLock(spawnSerializationLockPath(opts.Dir))
+	if err != nil {
+		WriteError(stderr, "cannot acquire project serialization lock: "+err.Error(), "init_failed")
+		return 1
+	}
+	releaseSpawnLock := func() error {
+		if spawnLock == nil {
+			return nil
+		}
+		lock := spawnLock
+		spawnLock = nil
+		return releaseSpawnSerializationLock(lock)
+	}
+	defer func() { _ = releaseSpawnLock() }()
 
 	// Validate: target must not already have .lingtai/
 	lingtaiDir := filepath.Join(opts.Dir, ".lingtai")
@@ -244,6 +267,16 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 		return 1
 	}
 
+	// A competing creator now sees a complete created/registered root at its
+	// guarded precheck, so do not hold it through launch or readiness waiting.
+	if err := releaseSpawnLock(); err != nil {
+		// Registration already succeeded, so the created_unregistered recovery
+		// protocol is not honest here. Retain the established init_failed shape
+		// without launching after an incomplete release boundary.
+		WriteError(stderr, "project was created and registered but serialization lock release did not complete cleanly; it was not launched: "+err.Error(), "init_failed")
+		return 1
+	}
+
 	// Launch the agent (async — start and return immediately)
 	pid := 0
 	status := "created"
@@ -304,6 +337,19 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 		ReadyTimeoutSeconds:         readyTimeout.Seconds(),
 	})
 	return 0
+}
+
+// spawnSerializationLockPath returns the stable sibling lock path for root. A
+// resolved root makes an existing symlink alias share the same lock identity;
+// an unresolved root remains creatable through its cleaned absolute input.
+func spawnSerializationLockPath(root string) string {
+	identity := filepath.Clean(root)
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		if absolute, err := filepath.Abs(filepath.Clean(resolved)); err == nil {
+			identity = absolute
+		}
+	}
+	return identity + ".lingtai-spawn.lock"
 }
 
 func selectedPresetFile(p preset.Preset) (string, error) {

--- a/tui/internal/headless/spawn.go
+++ b/tui/internal/headless/spawn.go
@@ -1,10 +1,14 @@
 package headless
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/anthropics/lingtai-tui/internal/config"
@@ -17,6 +21,10 @@ import (
 const defaultReadyTimeout = 10 * time.Second
 
 var (
+	createProject           = process.CreateProject
+	registerProject         = config.Register
+	saveRecipeState         = preset.SaveRecipeState
+	runtimeReady            = config.RuntimeReady
 	launchAgent             = process.LaunchAgent
 	findAgentProcesses      = process.FindAgentProcesses
 	terminateAgentProcesses = process.TerminateAgentProcesses
@@ -112,7 +120,7 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 	// creates/repairs/upgrades) — a not-ready runtime surfaces as an
 	// actionable error instead of a silent install.
 	if !opts.SkipLaunch {
-		if err := config.RuntimeReady(globalDir); err != nil {
+		if err := runtimeReady(globalDir); err != nil {
 			WriteError(stderr, err.Error(), "bootstrap_failed")
 			return 1
 		}
@@ -139,25 +147,77 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 	if lang == "" {
 		lang = "en"
 	}
-
-	// Initialize project (.lingtai/, human dir, meta.json)
-	if err := process.InitProject(lingtaiDir); err != nil {
-		WriteError(stderr, "project init failed: "+err.Error(), "init_failed")
+	presetPath, err := selectedPresetFile(p)
+	if err != nil {
+		WriteError(stderr, "cannot resolve selected preset: "+err.Error(), "init_failed")
 		return 1
 	}
 
-	// Populate bundled library skills
+	// The kernel's create contract takes covenant contents only through a file.
+	// Materialize the selected TUI covenant in a new, TUI-owned input and remove
+	// only that input after the child has reached a terminal result.
+	covenantFile, err := materializeSpawnCovenant(globalDir, lang)
+	if err != nil {
+		WriteError(stderr, "cannot prepare covenant input: "+err.Error(), "init_failed")
+		return 1
+	}
+	createResult, createErr := createProject(context.Background(), config.LingtaiCmd(globalDir), process.ProjectCreateRequest{
+		Dir:          opts.Dir,
+		AgentName:    agentName,
+		Preset:       presetPath,
+		CovenantFile: covenantFile,
+	})
+	cleanupErr := os.Remove(covenantFile)
+	if createErr != nil {
+		writeProjectCreateFailure(stderr, createErr)
+		return 1
+	}
+
+	// Keep the kernel's canonical preset reference as trusted create state even
+	// though the public SpawnOutput preserves its existing selected-preset field.
+	// The adapter already validates this protocol; this guard keeps an injected
+	// or future adapter from registering or launching a partial exit-0 result.
+	canonicalPresetRef := createResult.PresetRef
+	if canonicalPresetRef == "" || !filepath.IsAbs(canonicalPresetRef) {
+		writeProjectCreateFailure(stderr, &process.ProjectCreateError{
+			Kind:     process.ProjectCreateTransportFailure,
+			Reason:   "malformed_result",
+			ExitCode: createResult.ExitCode,
+			Stdout:   createResult.Stdout,
+			Stderr:   createResult.Stderr,
+			Cause:    fmt.Errorf("kernel success omitted a canonical preset reference"),
+		})
+		return 1
+	}
+
+	agentDir := filepath.Join(lingtaiDir, agentName)
+	if err := os.MkdirAll(filepath.Join(lingtaiDir, ".library_shared"), 0o755); err != nil {
+		// The kernel owns the seed tree. Restore only the TUI-required shared
+		// library directory and never compensate by deleting kernel-created data.
+		writeCreatedProjectRecovery(stderr, opts.Dir, agentName, agentDir, "shared_library_setup", err)
+		return 1
+	}
+	if cleanupErr != nil {
+		// The kernel result is known, but do not proceed to registration or
+		// launch when TUI-owned sensitive input cleanup was not completed.
+		writeCreatedProjectRecovery(stderr, opts.Dir, agentName, agentDir, "temporary_covenant_cleanup", cleanupErr)
+		return 1
+	}
+	if err := preserveSpawnLanguage(agentDir, lang); err != nil {
+		// Kernel create has no language argument. Preserve the existing
+		// headless language behavior only after its complete success protocol,
+		// and never compensate by deleting the project on a later TUI failure.
+		writeCreatedProjectRecovery(stderr, opts.Dir, agentName, agentDir, "language_compatibility", err)
+		return 1
+	}
+
+	// Populate bundled library skills after kernel seeding succeeds.
 	preset.PopulateBundledLibrary(globalDir)
 
-	// Generate init.json with default opts
-	agentOpts := preset.DefaultAgentOpts()
-	agentOpts.Language = lang
-	if err := preset.GenerateInitJSONWithOpts(p, agentName, agentName, lingtaiDir, globalDir, agentOpts); err != nil {
-		WriteError(stderr, "init.json generation failed: "+err.Error(), "init_failed")
-		return 1
-	}
-
-	// Apply the plain recipe (no greet, no behavioral constraints)
+	// Apply the existing plain recipe (no greet, no behavioral constraints).
+	// This legacy bundle/apply work is deliberately best-effort: recipe state
+	// records the selected recipe, not proof that every optional recipe artifact
+	// was copied or applied.
 	recipeDir := preset.RecipeDir(globalDir, "plain")
 	if recipeDir != "" {
 		if err := preset.CopyBundle(recipeDir, opts.Dir); err != nil {
@@ -168,13 +228,21 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 		preset.ApplyRecipe(opts.Dir, lang, subst)
 	}
 
-	// Save recipe state
-	preset.SaveRecipeState(lingtaiDir, preset.RecipeState{Recipe: "plain"})
+	// Persist the selected TUI-only plain recipe state before registration. Unlike
+	// the best-effort bundle/apply side effects above, this is required TUI
+	// metadata after trusted kernel creation.
+	if err := saveRecipeState(lingtaiDir, preset.RecipeState{Recipe: "plain"}); err != nil {
+		writeCreatedProjectRecovery(stderr, opts.Dir, agentName, agentDir, "recipe_state_persistence", err)
+		return 1
+	}
 
-	agentDir := filepath.Join(lingtaiDir, agentName)
-
-	// Register project in global registry (non-fatal)
-	config.Register(globalDir, opts.Dir)
+	// Register only after a fully trusted kernel create result and required
+	// TUI-side metadata writes. A registration failure is a known-created recovery
+	// state, not a successful spawn: the kernel has no rollback command.
+	if err := registerProject(globalDir, opts.Dir); err != nil {
+		writeCreatedProjectRecovery(stderr, opts.Dir, agentName, agentDir, "registration", err)
+		return 1
+	}
 
 	// Launch the agent (async — start and return immediately)
 	pid := 0
@@ -236,6 +304,132 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 		ReadyTimeoutSeconds:         readyTimeout.Seconds(),
 	})
 	return 0
+}
+
+func selectedPresetFile(p preset.Preset) (string, error) {
+	ref := preset.RefFor(p)
+	if ref == "" {
+		return "", fmt.Errorf("loaded preset has no reference")
+	}
+	if strings.HasPrefix(ref, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		ref = filepath.Join(home, ref[2:])
+	}
+	return filepath.Abs(ref)
+}
+
+func materializeSpawnCovenant(globalDir, lang string) (string, error) {
+	data, err := os.ReadFile(preset.CovenantPath(globalDir, lang))
+	if err != nil {
+		return "", err
+	}
+	if len(data) == 0 {
+		return "", fmt.Errorf("selected covenant is empty")
+	}
+	file, err := os.CreateTemp("", "lingtai-spawn-covenant-*")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	fail := func(cause error) (string, error) {
+		_ = file.Close()
+		_ = os.Remove(path) // only the file this function created
+		return "", cause
+	}
+	if _, err := file.Write(data); err != nil {
+		return fail(err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path) // only the file this function created
+		return "", err
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		_ = os.Remove(path) // only the file this function created
+		return "", err
+	}
+	return absolute, nil
+}
+
+// preserveSpawnLanguage is the narrow compatibility mapping for the existing
+// headless language option. The kernel project-create grammar intentionally has
+// no language flag, so this runs only after its trusted terminal success.
+func preserveSpawnLanguage(agentDir, lang string) error {
+	initPath := filepath.Join(agentDir, "init.json")
+	data, err := os.ReadFile(initPath)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	var init map[string]interface{}
+	if err := decoder.Decode(&init); err != nil {
+		return err
+	}
+	var extra interface{}
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("init.json contains more than one JSON document")
+		}
+		return err
+	}
+	manifest, ok := init["manifest"].(map[string]interface{})
+	if !ok || manifest == nil {
+		return fmt.Errorf("init.json manifest is missing")
+	}
+	manifest["language"] = lang
+	updated, err := json.MarshalIndent(init, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(initPath, updated, 0o644)
+}
+
+// writeCreatedProjectRecovery reports a known kernel-created project that could
+// not complete a later TUI compatibility or registration step. It deliberately
+// leaves the seed in place for repair and prevents any later launch or retry.
+func writeCreatedProjectRecovery(stderr io.Writer, projectDir, agentName, agentDir, step string, cause error) {
+	WriteErrorDetail(stderr, fmt.Sprintf("project was created but %s failed; it was not registered or launched: %v", strings.ReplaceAll(step, "_", " "), cause), "init_failed", map[string]interface{}{
+		"recovery_state": "created_unregistered",
+		"recovery_step":  step,
+		"project_dir":    projectDir,
+		"agent_name":     agentName,
+		"agent_dir":      agentDir,
+		"cause":          cause.Error(),
+	})
+}
+
+func writeProjectCreateFailure(stderr io.Writer, err error) {
+	var failure *process.ProjectCreateError
+	if errors.As(err, &failure) && failure.Kind == process.ProjectCreateHandlerFailure {
+		details := map[string]interface{}{
+			"kernel_code": failure.Code,
+		}
+		if failure.Stderr != "" {
+			details["kernel_stderr"] = failure.Stderr
+		}
+		WriteErrorDetail(stderr, failure.Message, "init_failed", details)
+		return
+	}
+
+	details := map[string]interface{}{}
+	message := "project create outcome is unknown; it was not registered or launched"
+	if errors.As(err, &failure) {
+		details["reason"] = failure.Reason
+		details["exit_code"] = failure.ExitCode
+		if failure.Stdout != "" {
+			details["kernel_stdout"] = failure.Stdout
+		}
+		if failure.Stderr != "" {
+			details["kernel_stderr"] = failure.Stderr
+		}
+	} else {
+		details["cause"] = err.Error()
+	}
+	WriteErrorDetail(stderr, message, "init_failed", details)
 }
 
 type readinessResult struct {

--- a/tui/internal/headless/spawn_serialization_test.go
+++ b/tui/internal/headless/spawn_serialization_test.go
@@ -1,0 +1,536 @@
+package headless
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anthropics/lingtai-tui/internal/fs"
+	"github.com/anthropics/lingtai-tui/internal/preset"
+	"github.com/anthropics/lingtai-tui/internal/process"
+)
+
+const spawnSerializationHelperEnv = "LINGTAI_SPAWN_SERIALIZATION_HELPER"
+
+func TestRunSpawn_SerializationLockFailureWritesOneInitError(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("block lock parent\n"), 0o644); err != nil {
+		t.Fatalf("create lock-parent blocker: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{
+		Dir:        filepath.Join(blocker, "project"),
+		Preset:     "minimax",
+		AgentName:  "alice",
+		Language:   "en",
+		SkipLaunch: true,
+	})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout JSON", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one JSON error: %v\n%s", err, stderr.String())
+	}
+	if response["code"] != "init_failed" || !strings.Contains(fmt.Sprint(response["error"]), "cannot acquire project serialization lock") {
+		t.Fatalf("lock acquisition response = %#v", response)
+	}
+}
+
+func TestRunSpawn_SerializationReleaseFailureDoesNotLaunch(t *testing.T) {
+	prepareSpawnSerializationHome(t)
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	stubSuccessfulSpawnCreate(t)
+	stubSpawnRegister(t, func(string, string) error { return nil })
+
+	originalRelease := releaseSpawnSerializationLock
+	releaseSpawnSerializationLock = func(lock *fs.ExclusiveFileLock) error {
+		if err := lock.Release(); err != nil {
+			return err
+		}
+		return fmt.Errorf("simulated serialization lock release failure")
+	}
+	t.Cleanup(func() { releaseSpawnSerializationLock = originalRelease })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after serialization lock release failure")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{
+		Dir:       filepath.Join(t.TempDir(), "project"),
+		Preset:    "minimax",
+		AgentName: "alice",
+		Language:  "en",
+	})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout JSON", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one JSON error: %v\n%s", err, stderr.String())
+	}
+	if response["code"] != "init_failed" || !strings.Contains(fmt.Sprint(response["error"]), "created and registered") {
+		t.Fatalf("release failure response = %#v", response)
+	}
+	if _, hasRecoveryState := response["recovery_state"]; hasRecoveryState {
+		t.Fatalf("release failure must not claim an unregistered recovery state: %#v", response)
+	}
+}
+
+func TestRunSpawn_SerializesSameRootAcrossProcesses(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "project")
+	runSpawnSerializationContention(t, target, target, target+".lingtai-spawn.lock")
+}
+
+func TestRunSpawn_SerializesRealRootAndSymlinkAliasAcrossProcesses(t *testing.T) {
+	fixture := t.TempDir()
+	realTarget := filepath.Join(fixture, "real-project")
+	if err := os.MkdirAll(realTarget, 0o755); err != nil {
+		t.Fatalf("create real target: %v", err)
+	}
+	aliasTarget := filepath.Join(fixture, "project-alias")
+	if err := os.Symlink(realTarget, aliasTarget); err != nil {
+		t.Skipf("symlink fixture unavailable: %v", err)
+	}
+
+	runSpawnSerializationContention(t, realTarget, aliasTarget, realTarget+".lingtai-spawn.lock")
+	if _, err := os.Stat(aliasTarget + ".lingtai-spawn.lock"); !os.IsNotExist(err) {
+		t.Fatalf("symlink alias unexpectedly created a second sibling lock: %v", err)
+	}
+}
+
+func runSpawnSerializationContention(t *testing.T, ownerTarget, contenderTarget, lockPath string) {
+	t.Helper()
+	prepareSpawnSerializationHome(t)
+	controls := t.TempDir()
+
+	owner, err := startSpawnSerializationHelper(ownerTarget, "owner", spawnSerializationHelperControls{
+		Entered:      filepath.Join(controls, "A.entered-create"),
+		Release:      filepath.Join(controls, "A.release"),
+		ResultPrefix: filepath.Join(controls, "A.result"),
+	})
+	if err != nil {
+		t.Fatalf("start owner helper: %v", err)
+	}
+	t.Cleanup(owner.stop)
+	if err := waitForSpawnSerializationPaths(10*time.Second, filepath.Join(controls, "A.entered-create")); err != nil {
+		t.Fatalf("owner did not enter create while holding the lock: %v\n%s", err, owner.output.String())
+	}
+
+	contender, err := startSpawnSerializationHelper(contenderTarget, "contender", spawnSerializationHelperControls{
+		Started:      filepath.Join(controls, "B.started"),
+		Acquiring:    filepath.Join(controls, "B.acquiring-lock"),
+		Entered:      filepath.Join(controls, "B.entered-create"),
+		Registered:   filepath.Join(controls, "B.registered"),
+		Launched:     filepath.Join(controls, "B.launched"),
+		ResultPrefix: filepath.Join(controls, "B.result"),
+	})
+	if err != nil {
+		owner.stop()
+		t.Fatalf("start contender helper: %v", err)
+	}
+	t.Cleanup(contender.stop)
+	if err := waitForSpawnSerializationPaths(10*time.Second, filepath.Join(controls, "B.started"), filepath.Join(controls, "B.acquiring-lock")); err != nil {
+		owner.stop()
+		contender.stop()
+		t.Fatalf("contender did not reach lock acquisition while owner held it: %v\n%s", err, contender.output.String())
+	}
+	assertSpawnSerializationBlocked(t, contender, filepath.Join(controls, "B.entered-create"))
+
+	if err := os.WriteFile(filepath.Join(controls, "A.release"), []byte("release owner\n"), 0o644); err != nil {
+		owner.stop()
+		contender.stop()
+		t.Fatalf("release owner helper: %v", err)
+	}
+	if err := owner.wait(10 * time.Second); err != nil {
+		contender.stop()
+		t.Fatalf("owner helper did not complete: %v\n%s", err, owner.output.String())
+	}
+	ownerResult := readSpawnSerializationResult(t, filepath.Join(controls, "A.result"))
+	assertSpawnSerializationSuccess(t, ownerResult)
+
+	if err := contender.wait(10 * time.Second); err != nil {
+		t.Fatalf("contender helper did not complete: %v\n%s", err, contender.output.String())
+	}
+	contenderResult := readSpawnSerializationResult(t, filepath.Join(controls, "B.result"))
+	assertSpawnSerializationAlreadyInitialized(t, contenderResult)
+	assertSpawnSerializationNoContenderSideEffects(t,
+		filepath.Join(controls, "B.entered-create"),
+		filepath.Join(controls, "B.registered"),
+		filepath.Join(controls, "B.launched"),
+	)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("stable sibling lock file was not retained: %v", err)
+	}
+}
+
+func TestRunSpawn_SerializationLockReleasesAfterOwnerCrash(t *testing.T) {
+	prepareSpawnSerializationHome(t)
+	target := filepath.Join(t.TempDir(), "project")
+	controls := t.TempDir()
+
+	owner, err := startSpawnSerializationHelper(target, "crash-owner", spawnSerializationHelperControls{Entered: filepath.Join(controls, "A.entered-create"), Release: filepath.Join(controls, "A.release"), ResultPrefix: filepath.Join(controls, "A.result")})
+	if err != nil {
+		t.Fatalf("start crash owner helper: %v", err)
+	}
+	t.Cleanup(owner.stop)
+	if err := waitForSpawnSerializationPaths(10*time.Second, filepath.Join(controls, "A.entered-create")); err != nil {
+		t.Fatalf("crash owner did not enter create while holding the lock: %v\n%s", err, owner.output.String())
+	}
+	if _, err := os.Stat(filepath.Join(target, ".lingtai")); !os.IsNotExist(err) {
+		owner.stop()
+		t.Fatalf("crash owner created .lingtai before the kill boundary: %v", err)
+	}
+
+	contender, err := startSpawnSerializationHelper(target, "crash-contender", spawnSerializationHelperControls{Started: filepath.Join(controls, "B.started"), Acquiring: filepath.Join(controls, "B.acquiring-lock"), Entered: filepath.Join(controls, "B.entered-create"), ResultPrefix: filepath.Join(controls, "B.result")})
+	if err != nil {
+		owner.stop()
+		t.Fatalf("start crash-release contender helper: %v", err)
+	}
+	t.Cleanup(contender.stop)
+	if err := waitForSpawnSerializationPaths(10*time.Second, filepath.Join(controls, "B.started"), filepath.Join(controls, "B.acquiring-lock")); err != nil {
+		owner.stop()
+		contender.stop()
+		t.Fatalf("crash-release contender did not start: %v\n%s", err, contender.output.String())
+	}
+	assertSpawnSerializationBlocked(t, contender, filepath.Join(controls, "B.entered-create"))
+
+	if err := owner.cmd.Process.Kill(); err != nil {
+		owner.stop()
+		contender.stop()
+		t.Fatalf("kill crash owner helper: %v", err)
+	}
+	if err := owner.wait(10 * time.Second); err == nil {
+		contender.stop()
+		t.Fatal("crash owner unexpectedly exited cleanly after Kill")
+	}
+
+	if err := contender.wait(10 * time.Second); err != nil {
+		t.Fatalf("contender did not acquire the released crash lock: %v\n%s", err, contender.output.String())
+	}
+	contenderResult := readSpawnSerializationResult(t, filepath.Join(controls, "B.result"))
+	assertSpawnSerializationSuccess(t, contenderResult)
+	if _, err := os.Stat(filepath.Join(controls, "B.entered-create")); err != nil {
+		t.Fatalf("contender never became the creator after owner crash: %v", err)
+	}
+}
+
+// TestRunSpawnSerializationHelper is selected in separate test-binary processes
+// so each helper gets its own package-level create/register seams while the OS
+// lock remains the only coordination mechanism between them.
+func TestRunSpawnSerializationHelper(t *testing.T) {
+	if os.Getenv(spawnSerializationHelperEnv) != "1" {
+		return
+	}
+
+	target := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_TARGET")
+	role := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_ROLE")
+	started := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_STARTED")
+	acquiring := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_ACQUIRING")
+	entered := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_ENTERED")
+	release := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_RELEASE")
+	registered := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_REGISTERED")
+	launched := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_LAUNCHED")
+	resultPrefix := os.Getenv("LINGTAI_SPAWN_SERIALIZATION_RESULT")
+	if target == "" || (role != "owner" && role != "crash-owner" && role != "contender" && role != "crash-contender") || resultPrefix == "" {
+		t.Fatalf("invalid helper controls: target=%q role=%q result=%q", target, role, resultPrefix)
+	}
+	if started != "" {
+		if err := os.WriteFile(started, []byte("helper started\n"), 0o644); err != nil {
+			t.Fatalf("publish helper start barrier: %v", err)
+		}
+	}
+	if acquiring != "" {
+		originalBeforeAcquire := beforeSpawnSerializationLockAcquire
+		beforeSpawnSerializationLockAcquire = func() {
+			if err := os.WriteFile(acquiring, []byte("about to acquire lock\n"), 0o644); err != nil {
+				t.Fatalf("publish lock-acquisition barrier: %v", err)
+			}
+		}
+		t.Cleanup(func() { beforeSpawnSerializationLockAcquire = originalBeforeAcquire })
+	}
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	if role == "contender" {
+		stubSpawnRegister(t, func(string, string) error {
+			if err := os.WriteFile(registered, []byte("register called\n"), 0o644); err != nil {
+				return err
+			}
+			return fmt.Errorf("contender register should not be called")
+		})
+		originalLaunch := launchAgent
+		launchAgent = func(string, string) (*exec.Cmd, error) {
+			if err := os.WriteFile(launched, []byte("launch called\n"), 0o644); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("contender launch should not be called")
+		}
+		t.Cleanup(func() { launchAgent = originalLaunch })
+	} else {
+		stubSpawnRegister(t, func(string, string) error { return nil })
+	}
+	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+		if entered != "" {
+			if err := os.WriteFile(entered, []byte("entered create\n"), 0o644); err != nil {
+				return process.ProjectCreateResult{}, err
+			}
+		}
+		if role == "owner" || role == "crash-owner" {
+			if err := waitForSpawnSerializationPaths(30*time.Second, release); err != nil {
+				return process.ProjectCreateResult{}, err
+			}
+		}
+		return seedSpawnSerializationProject(request)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{
+		Dir:        target,
+		Preset:     "minimax",
+		AgentName:  "alice",
+		Language:   "en",
+		SkipLaunch: role != "contender",
+	})
+	writeSpawnSerializationResult(t, resultPrefix, code, stdout.Bytes(), stderr.Bytes())
+}
+
+func prepareSpawnSerializationHome(t *testing.T) {
+	t.Helper()
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	if err := preset.RefreshTemplates(); err != nil {
+		t.Fatalf("refresh templates: %v", err)
+	}
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatalf("bootstrap presets: %v", err)
+	}
+}
+
+func seedSpawnSerializationProject(request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+	agentDir := filepath.Join(request.Dir, ".lingtai", request.AgentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		return process.ProjectCreateResult{}, err
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte(`{"manifest":{"agent_name":"`+request.AgentName+`"}}`), 0o644); err != nil {
+		return process.ProjectCreateResult{}, err
+	}
+	return process.ProjectCreateResult{
+		Status: "created", AgentName: request.AgentName, PresetRef: request.Preset, ExitCode: 0,
+	}, nil
+}
+
+type spawnSerializationHelperProcess struct {
+	cmd      *exec.Cmd
+	output   bytes.Buffer
+	done     chan error
+	finished bool
+	waitErr  error
+}
+
+type spawnSerializationHelperControls struct {
+	Started      string
+	Acquiring    string
+	Entered      string
+	Release      string
+	Registered   string
+	Launched     string
+	ResultPrefix string
+}
+
+func startSpawnSerializationHelper(target, role string, controls spawnSerializationHelperControls) (*spawnSerializationHelperProcess, error) {
+	process := &spawnSerializationHelperProcess{done: make(chan error, 1)}
+	process.cmd = exec.Command(os.Args[0], "-test.run=^TestRunSpawnSerializationHelper$")
+	process.cmd.Env = append(os.Environ(),
+		spawnSerializationHelperEnv+"=1",
+		"LINGTAI_SPAWN_SERIALIZATION_TARGET="+target,
+		"LINGTAI_SPAWN_SERIALIZATION_ROLE="+role,
+		"LINGTAI_SPAWN_SERIALIZATION_STARTED="+controls.Started,
+		"LINGTAI_SPAWN_SERIALIZATION_ACQUIRING="+controls.Acquiring,
+		"LINGTAI_SPAWN_SERIALIZATION_ENTERED="+controls.Entered,
+		"LINGTAI_SPAWN_SERIALIZATION_RELEASE="+controls.Release,
+		"LINGTAI_SPAWN_SERIALIZATION_REGISTERED="+controls.Registered,
+		"LINGTAI_SPAWN_SERIALIZATION_LAUNCHED="+controls.Launched,
+		"LINGTAI_SPAWN_SERIALIZATION_RESULT="+controls.ResultPrefix,
+	)
+	process.cmd.Stdout = &process.output
+	process.cmd.Stderr = &process.output
+	if err := process.cmd.Start(); err != nil {
+		return nil, err
+	}
+	go func() {
+		process.done <- process.cmd.Wait()
+	}()
+	return process, nil
+}
+
+func (process *spawnSerializationHelperProcess) wait(timeout time.Duration) error {
+	if process.finished {
+		return process.waitErr
+	}
+	select {
+	case process.waitErr = <-process.done:
+		process.finished = true
+		return process.waitErr
+	case <-time.After(timeout):
+		_ = process.cmd.Process.Kill()
+		select {
+		case process.waitErr = <-process.done:
+			process.finished = true
+			return fmt.Errorf("helper timed out and was killed: %w", process.waitErr)
+		case <-time.After(5 * time.Second):
+			return fmt.Errorf("helper timed out and did not terminate after kill")
+		}
+	}
+}
+
+func (process *spawnSerializationHelperProcess) stillRunning() error {
+	if process.finished {
+		return fmt.Errorf("helper already exited: %w", process.waitErr)
+	}
+	select {
+	case process.waitErr = <-process.done:
+		process.finished = true
+		return fmt.Errorf("helper exited while expected to block: %w\n%s", process.waitErr, process.output.String())
+	default:
+		return nil
+	}
+}
+
+func (process *spawnSerializationHelperProcess) stop() {
+	if process == nil || process.finished {
+		return
+	}
+	_ = process.cmd.Process.Kill()
+	select {
+	case process.waitErr = <-process.done:
+		process.finished = true
+	case <-time.After(5 * time.Second):
+	}
+}
+
+type spawnSerializationResult struct {
+	code   int
+	stdout []byte
+	stderr []byte
+}
+
+func writeSpawnSerializationResult(t *testing.T, prefix string, code int, stdout, stderr []byte) {
+	t.Helper()
+	if err := os.WriteFile(prefix+".code", []byte(strconv.Itoa(code)+"\n"), 0o644); err != nil {
+		t.Fatalf("write helper result code: %v", err)
+	}
+	if err := os.WriteFile(prefix+".stdout", stdout, 0o644); err != nil {
+		t.Fatalf("write helper stdout: %v", err)
+	}
+	if err := os.WriteFile(prefix+".stderr", stderr, 0o644); err != nil {
+		t.Fatalf("write helper stderr: %v", err)
+	}
+}
+
+func readSpawnSerializationResult(t *testing.T, prefix string) spawnSerializationResult {
+	t.Helper()
+	codeData, err := os.ReadFile(prefix + ".code")
+	if err != nil {
+		t.Fatalf("read helper result code: %v", err)
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(string(codeData)))
+	if err != nil {
+		t.Fatalf("parse helper result code %q: %v", codeData, err)
+	}
+	stdout, err := os.ReadFile(prefix + ".stdout")
+	if err != nil {
+		t.Fatalf("read helper stdout: %v", err)
+	}
+	stderr, err := os.ReadFile(prefix + ".stderr")
+	if err != nil {
+		t.Fatalf("read helper stderr: %v", err)
+	}
+	return spawnSerializationResult{code: code, stdout: stdout, stderr: stderr}
+}
+
+func assertSpawnSerializationBlocked(t *testing.T, process *spawnSerializationHelperProcess, entered string) {
+	t.Helper()
+	if err := process.stillRunning(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(entered); !os.IsNotExist(err) {
+		t.Fatalf("contender reached create while it should block on the owner: %v", err)
+	}
+}
+
+func assertSpawnSerializationNoContenderSideEffects(t *testing.T, paths ...string) {
+	t.Helper()
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("contender performed a prohibited side effect at %q: %v", path, err)
+		}
+	}
+}
+
+func assertSpawnSerializationSuccess(t *testing.T, result spawnSerializationResult) {
+	t.Helper()
+	if result.code != 0 || len(result.stderr) != 0 {
+		t.Fatalf("success result code/stderr = %d/%q", result.code, result.stderr)
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(result.stdout, &response); err != nil {
+		t.Fatalf("success stdout is not one JSON document: %v\n%s", err, result.stdout)
+	}
+	if response["status"] != "created" {
+		t.Fatalf("success response = %#v", response)
+	}
+}
+
+func assertSpawnSerializationAlreadyInitialized(t *testing.T, result spawnSerializationResult) {
+	t.Helper()
+	if result.code != 1 || len(result.stdout) != 0 {
+		t.Fatalf("contender result code/stdout = %d/%q, want 1 and no stdout", result.code, result.stdout)
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(result.stderr, &response); err != nil {
+		t.Fatalf("contender stderr is not one JSON error: %v\n%s", err, result.stderr)
+	}
+	if response["code"] != "already_initialized" {
+		t.Fatalf("contender response = %#v", response)
+	}
+}
+
+func waitForSpawnSerializationPaths(timeout time.Duration, paths ...string) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		missing := ""
+		for _, path := range paths {
+			if _, err := os.Stat(path); err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("stat barrier %q: %w", path, err)
+				}
+				missing = path
+				break
+			}
+		}
+		if missing == "" {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %q", missing)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/tui/internal/headless/spawn_test.go
+++ b/tui/internal/headless/spawn_test.go
@@ -2,8 +2,11 @@ package headless
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,6 +16,64 @@ import (
 	"github.com/anthropics/lingtai-tui/internal/preset"
 	"github.com/anthropics/lingtai-tui/internal/process"
 )
+
+func stubSpawnCreate(t *testing.T, fn func(context.Context, string, process.ProjectCreateRequest) (process.ProjectCreateResult, error)) {
+	t.Helper()
+	original := createProject
+	createProject = fn
+	t.Cleanup(func() { createProject = original })
+}
+
+func stubSpawnRegister(t *testing.T, fn func(string, string) error) {
+	t.Helper()
+	original := registerProject
+	registerProject = fn
+	t.Cleanup(func() { registerProject = original })
+}
+
+func stubSpawnSaveRecipeState(t *testing.T, fn func(string, preset.RecipeState) error) {
+	t.Helper()
+	original := saveRecipeState
+	saveRecipeState = fn
+	t.Cleanup(func() { saveRecipeState = original })
+}
+
+func stubSuccessfulSpawnCreate(t *testing.T) {
+	t.Helper()
+	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+		if !filepath.IsAbs(request.CovenantFile) {
+			t.Errorf("covenant file = %q, want absolute path", request.CovenantFile)
+		}
+		if data, err := os.ReadFile(request.CovenantFile); err != nil || len(data) == 0 {
+			t.Errorf("covenant input is not readable and nonempty: data=%q err=%v", data, err)
+		}
+		lingtaiDir := filepath.Join(request.Dir, ".lingtai")
+		for _, dir := range []string{
+			filepath.Join(lingtaiDir, "human", "mailbox", "inbox"),
+			filepath.Join(lingtaiDir, "human", "mailbox", "outbox"),
+			filepath.Join(lingtaiDir, "human", "mailbox", "sent"),
+			filepath.Join(lingtaiDir, "human", "mailbox", "archive"),
+			filepath.Join(lingtaiDir, "human", "mailbox", "schedules"),
+			filepath.Join(lingtaiDir, request.AgentName, "mailbox", "inbox"),
+		} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return process.ProjectCreateResult{}, err
+			}
+		}
+		for path, body := range map[string][]byte{
+			filepath.Join(lingtaiDir, "human", ".agent.json"):           []byte(`{"agent_name":"human"}`),
+			filepath.Join(lingtaiDir, request.AgentName, ".agent.json"): []byte(`{"agent_name":"` + request.AgentName + `"}`),
+			filepath.Join(lingtaiDir, request.AgentName, "init.json"):   []byte(`{"manifest":{"agent_name":"` + request.AgentName + `"}}`),
+		} {
+			if err := os.WriteFile(path, body, 0o644); err != nil {
+				return process.ProjectCreateResult{}, err
+			}
+		}
+		return process.ProjectCreateResult{
+			Status: "created", AgentName: request.AgentName, PresetRef: request.Preset, ExitCode: 0,
+		}, nil
+	})
+}
 
 func TestRunSpawn_RejectsExistingLingtaiDir(t *testing.T) {
 	withTempHome(t)
@@ -86,6 +147,7 @@ func TestRunSpawn_CreatesInitJSON(t *testing.T) {
 	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
 	preset.RefreshTemplates()
 	preset.Bootstrap(globalDir)
+	stubSuccessfulSpawnCreate(t)
 
 	dir := filepath.Join(t.TempDir(), "test-project")
 	os.MkdirAll(dir, 0o755)
@@ -132,6 +194,13 @@ func TestRunSpawn_CreatesInitJSON(t *testing.T) {
 		t.Errorf("human .agent.json not created: %v", err)
 	}
 
+	// Kernel create owns the seed tree; headless compatibility must add the
+	// shared library directory without replacing any kernel-created entries.
+	libraryShared := filepath.Join(dir, ".lingtai", ".library_shared")
+	if info, err := os.Stat(libraryShared); err != nil || !info.IsDir() {
+		t.Errorf(".library_shared was not restored as a directory: info=%v err=%v", info, err)
+	}
+
 	// Fresh headless projects must still refresh user-level utility skills.
 	utilitySkill := filepath.Join(globalDir, "utilities", "lingtai-tui-help", "SKILL.md")
 	if _, err := os.Stat(utilitySkill); err != nil {
@@ -144,6 +213,7 @@ func TestRunSpawn_SuccessOutput_HasRequiredFields(t *testing.T) {
 	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
 	preset.RefreshTemplates()
 	preset.Bootstrap(globalDir)
+	stubSuccessfulSpawnCreate(t)
 
 	dir := filepath.Join(t.TempDir(), "test-project")
 	os.MkdirAll(dir, 0o755)
@@ -264,6 +334,7 @@ func TestRunSpawn_LanguageDefault(t *testing.T) {
 	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
 	preset.RefreshTemplates()
 	preset.Bootstrap(globalDir)
+	stubSuccessfulSpawnCreate(t)
 
 	dir := filepath.Join(t.TempDir(), "lang-test")
 	os.MkdirAll(dir, 0o755)
@@ -284,6 +355,187 @@ func TestRunSpawn_LanguageDefault(t *testing.T) {
 	manifest := initJSON["manifest"].(map[string]interface{})
 	if manifest["language"] != "zh" {
 		t.Errorf("language = %q, want %q", manifest["language"], "zh")
+	}
+}
+
+func TestRunSpawn_LanguageFailureReportsCreatedRecoveryAndDoesNotLaunch(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after a language compatibility failure")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+	stubSpawnRegister(t, func(string, string) error {
+		t.Fatal("registerProject was called after a language compatibility failure")
+		return nil
+	})
+
+	dir := filepath.Join(t.TempDir(), "project")
+	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+		agentDir := filepath.Join(request.Dir, ".lingtai", request.AgentName)
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			return process.ProjectCreateResult{}, err
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte("{"), 0o644); err != nil {
+			return process.ProjectCreateResult{}, err
+		}
+		return process.ProjectCreateResult{Status: "created", AgentName: request.AgentName, PresetRef: request.Preset, ExitCode: 0}, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+	}
+	agentDir := filepath.Join(dir, ".lingtai", "alice")
+	if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != "language_compatibility" || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir {
+		t.Fatalf("language recovery response = %#v", response)
+	}
+	if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
+		t.Fatalf("known-created seed was removed after language failure: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(dir, ".lingtai", ".library_shared")); err != nil || !info.IsDir() {
+		t.Fatalf("shared library was not preserved before language recovery: info=%v err=%v", info, err)
+	}
+}
+
+func TestRunSpawn_RecipeStateFailureReportsCreatedRecoveryAndDoesNotRegisterOrLaunch(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatal(err)
+	}
+	stubSuccessfulSpawnCreate(t)
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after recipe-state persistence failed")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+	stubSpawnRegister(t, func(string, string) error {
+		t.Fatal("registerProject was called after recipe-state persistence failed")
+		return nil
+	})
+	stubSpawnSaveRecipeState(t, func(string, preset.RecipeState) error {
+		return errors.New("recipe state storage unavailable")
+	})
+
+	dir := filepath.Join(t.TempDir(), "project")
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+	}
+	agentDir := filepath.Join(dir, ".lingtai", "alice")
+	if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != "recipe_state_persistence" || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir || response["cause"] != "recipe state storage unavailable" {
+		t.Fatalf("recipe-state recovery response = %#v", response)
+	}
+	if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
+		t.Fatalf("known-created seed was removed after recipe-state failure: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(dir, ".lingtai", ".library_shared")); err != nil || !info.IsDir() {
+		t.Fatalf("shared library was not preserved before recipe-state recovery: info=%v err=%v", info, err)
+	}
+}
+
+func TestRunSpawn_RegistrationFailureReportsCreatedRecoveryAndDoesNotLaunch(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatal(err)
+	}
+	stubSuccessfulSpawnCreate(t)
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after registration failed")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+	stubSpawnRegister(t, func(string, string) error { return errors.New("registry unavailable") })
+
+	dir := filepath.Join(t.TempDir(), "project")
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+	}
+	agentDir := filepath.Join(dir, ".lingtai", "alice")
+	if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != "registration" || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir || response["cause"] != "registry unavailable" {
+		t.Fatalf("registration recovery response = %#v", response)
+	}
+	if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
+		t.Fatalf("known-created seed was removed after registration failure: %v", err)
+	}
+}
+
+func TestRunSpawn_IncompleteCreateResultDoesNotRegisterOrLaunch(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after an incomplete create result")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+	stubSpawnRegister(t, func(string, string) error {
+		t.Fatal("registerProject was called after an incomplete create result")
+		return nil
+	})
+	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+		return process.ProjectCreateResult{Status: "created", AgentName: request.AgentName, ExitCode: 0}, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: filepath.Join(t.TempDir(), "project"), Preset: "minimax", AgentName: "alice", Language: "en"})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+	}
+	if response["code"] != "init_failed" || response["reason"] != "malformed_result" {
+		t.Fatalf("incomplete create response = %#v", response)
 	}
 }
 
@@ -351,6 +603,7 @@ func TestRunSpawn_AcceptsNormalAgentName(t *testing.T) {
 	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
 	preset.RefreshTemplates()
 	preset.Bootstrap(globalDir)
+	stubSuccessfulSpawnCreate(t)
 
 	dir := filepath.Join(t.TempDir(), "test-project")
 	os.MkdirAll(dir, 0o755)
@@ -368,5 +621,95 @@ func TestRunSpawn_AcceptsNormalAgentName(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".lingtai", "ok-agent", "init.json")); err != nil {
 		t.Errorf("init.json not created for normal agent name: %v", err)
+	}
+}
+
+func TestRunSpawn_HandlerCreateFailureWritesOneStructuredErrorAndDoesNotLaunch(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after a failed project create")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+
+	var covenantFile string
+	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+		covenantFile = request.CovenantFile
+		return process.ProjectCreateResult{}, &process.ProjectCreateError{
+			Kind: process.ProjectCreateHandlerFailure, Reason: "handler_error",
+			Code: "invalid_preset", Message: "kernel rejected preset", ExitCode: 1,
+			Stderr: `{"code":"invalid_preset","error":"kernel rejected preset","status":"error"}`,
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{
+		Dir: filepath.Join(t.TempDir(), "project"), Preset: "minimax", AgentName: "alice", Language: "en",
+	})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+	}
+	if response["code"] != "init_failed" || response["kernel_code"] != "invalid_preset" || response["error"] != "kernel rejected preset" {
+		t.Fatalf("handler error mapping = %#v", response)
+	}
+	if _, err := os.Stat(covenantFile); !os.IsNotExist(err) {
+		t.Fatalf("TUI-owned covenant file survived terminal child result: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(globalDir, "registry.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("failed create was registered: %v", err)
+	}
+}
+
+func TestRunSpawn_UnknownCreateFailureDoesNotTrustOrLaunch(t *testing.T) {
+	withTempHome(t)
+	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+	preset.RefreshTemplates()
+	if err := preset.Bootstrap(globalDir); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRuntimeReady := runtimeReady
+	runtimeReady = func(string) error { return nil }
+	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+	originalLaunch := launchAgent
+	launchAgent = func(string, string) (*exec.Cmd, error) {
+		t.Fatal("launchAgent was called after an unknown project create outcome")
+		return nil, nil
+	}
+	t.Cleanup(func() { launchAgent = originalLaunch })
+	stubSpawnCreate(t, func(context.Context, string, process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+		return process.ProjectCreateResult{}, &process.ProjectCreateError{
+			Kind: process.ProjectCreateTransportFailure, Reason: "argument_error", ExitCode: 2,
+			Stderr: "usage: lingtai-agent project create",
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := RunSpawn(&stdout, &stderr, SpawnOpts{
+		Dir: filepath.Join(t.TempDir(), "project"), Preset: "minimax", AgentName: "alice", Language: "en",
+	})
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+	}
+	var response map[string]interface{}
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+	}
+	if response["code"] != "init_failed" || response["reason"] != "argument_error" {
+		t.Fatalf("unknown failure mapping = %#v", response)
 	}
 }

--- a/tui/internal/headless/spawn_test.go
+++ b/tui/internal/headless/spawn_test.go
@@ -49,12 +49,8 @@ func stubSuccessfulSpawnCreate(t *testing.T) {
 		}
 		lingtaiDir := filepath.Join(request.Dir, ".lingtai")
 		for _, dir := range []string{
-			filepath.Join(lingtaiDir, "human", "mailbox", "inbox"),
-			filepath.Join(lingtaiDir, "human", "mailbox", "outbox"),
-			filepath.Join(lingtaiDir, "human", "mailbox", "sent"),
-			filepath.Join(lingtaiDir, "human", "mailbox", "archive"),
-			filepath.Join(lingtaiDir, "human", "mailbox", "schedules"),
-			filepath.Join(lingtaiDir, request.AgentName, "mailbox", "inbox"),
+			filepath.Join(lingtaiDir, "human"),
+			filepath.Join(lingtaiDir, request.AgentName),
 		} {
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return process.ProjectCreateResult{}, err
@@ -358,184 +354,181 @@ func TestRunSpawn_LanguageDefault(t *testing.T) {
 	}
 }
 
-func TestRunSpawn_LanguageFailureReportsCreatedRecoveryAndDoesNotLaunch(t *testing.T) {
-	withTempHome(t)
-	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
-	preset.RefreshTemplates()
-	if err := preset.Bootstrap(globalDir); err != nil {
-		t.Fatal(err)
+func TestRunSpawn_PostCreateFailureReportsCreatedRecoveryAndDoesNotLaunch(t *testing.T) {
+	cases := []struct {
+		name                string
+		recoveryStep        string
+		expectedCause       string
+		malformedInit       bool
+		failRecipeState     bool
+		failRegistration    bool
+		assertSharedLibrary bool
+	}{
+		{
+			name:                "language_compatibility",
+			recoveryStep:        "language_compatibility",
+			malformedInit:       true,
+			assertSharedLibrary: true,
+		},
+		{
+			name:                "recipe_state_persistence",
+			recoveryStep:        "recipe_state_persistence",
+			expectedCause:       "recipe state storage unavailable",
+			failRecipeState:     true,
+			assertSharedLibrary: true,
+		},
+		{
+			name:             "registration",
+			recoveryStep:     "registration",
+			expectedCause:    "registry unavailable",
+			failRegistration: true,
+		},
 	}
 
-	originalRuntimeReady := runtimeReady
-	runtimeReady = func(string) error { return nil }
-	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
-	originalLaunch := launchAgent
-	launchAgent = func(string, string) (*exec.Cmd, error) {
-		t.Fatal("launchAgent was called after a language compatibility failure")
-		return nil, nil
-	}
-	t.Cleanup(func() { launchAgent = originalLaunch })
-	stubSpawnRegister(t, func(string, string) error {
-		t.Fatal("registerProject was called after a language compatibility failure")
-		return nil
-	})
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			withTempHome(t)
+			globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+			preset.RefreshTemplates()
+			if err := preset.Bootstrap(globalDir); err != nil {
+				t.Fatal(err)
+			}
 
-	dir := filepath.Join(t.TempDir(), "project")
-	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
-		agentDir := filepath.Join(request.Dir, ".lingtai", request.AgentName)
-		if err := os.MkdirAll(agentDir, 0o755); err != nil {
-			return process.ProjectCreateResult{}, err
-		}
-		if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte("{"), 0o644); err != nil {
-			return process.ProjectCreateResult{}, err
-		}
-		return process.ProjectCreateResult{Status: "created", AgentName: request.AgentName, PresetRef: request.Preset, ExitCode: 0}, nil
-	})
+			originalRuntimeReady := runtimeReady
+			runtimeReady = func(string) error { return nil }
+			t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+			originalLaunch := launchAgent
+			launchAgent = func(string, string) (*exec.Cmd, error) {
+				t.Fatal("launchAgent was called after a post-create failure")
+				return nil, nil
+			}
+			t.Cleanup(func() { launchAgent = originalLaunch })
 
-	var stdout, stderr bytes.Buffer
-	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
-	if code != 1 || stdout.Len() != 0 {
-		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
-	}
-	var response map[string]interface{}
-	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
-		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
-	}
-	agentDir := filepath.Join(dir, ".lingtai", "alice")
-	if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != "language_compatibility" || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir {
-		t.Fatalf("language recovery response = %#v", response)
-	}
-	if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
-		t.Fatalf("known-created seed was removed after language failure: %v", err)
-	}
-	if info, err := os.Stat(filepath.Join(dir, ".lingtai", ".library_shared")); err != nil || !info.IsDir() {
-		t.Fatalf("shared library was not preserved before language recovery: info=%v err=%v", info, err)
+			if test.malformedInit {
+				stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+					agentDir := filepath.Join(request.Dir, ".lingtai", request.AgentName)
+					if err := os.MkdirAll(agentDir, 0o755); err != nil {
+						return process.ProjectCreateResult{}, err
+					}
+					if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte("{"), 0o644); err != nil {
+						return process.ProjectCreateResult{}, err
+					}
+					return process.ProjectCreateResult{Status: "created", AgentName: request.AgentName, PresetRef: request.Preset, ExitCode: 0}, nil
+				})
+			} else {
+				stubSuccessfulSpawnCreate(t)
+			}
+			if test.failRecipeState {
+				stubSpawnSaveRecipeState(t, func(string, preset.RecipeState) error {
+					return errors.New(test.expectedCause)
+				})
+			}
+			if test.failRegistration {
+				stubSpawnRegister(t, func(string, string) error { return errors.New(test.expectedCause) })
+			} else {
+				stubSpawnRegister(t, func(string, string) error {
+					t.Fatal("registerProject was called after a pre-registration post-create failure")
+					return nil
+				})
+			}
+
+			dir := filepath.Join(t.TempDir(), "project")
+			var stdout, stderr bytes.Buffer
+			code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
+			if code != 1 || stdout.Len() != 0 {
+				t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+			}
+			var response map[string]interface{}
+			if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+				t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+			}
+			agentDir := filepath.Join(dir, ".lingtai", "alice")
+			if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != test.recoveryStep || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir {
+				t.Fatalf("%s recovery response = %#v", test.name, response)
+			}
+			cause, ok := response["cause"].(string)
+			if !ok || cause == "" {
+				t.Fatalf("%s recovery response has no cause: %#v", test.name, response)
+			}
+			if test.expectedCause != "" && cause != test.expectedCause {
+				t.Fatalf("%s recovery cause = %q, want %q", test.name, cause, test.expectedCause)
+			}
+			if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
+				t.Fatalf("known-created seed was removed after %s failure: %v", test.name, err)
+			}
+			if test.assertSharedLibrary {
+				if info, err := os.Stat(filepath.Join(dir, ".lingtai", ".library_shared")); err != nil || !info.IsDir() {
+					t.Fatalf("shared library was not preserved before %s recovery: info=%v err=%v", test.name, info, err)
+				}
+			}
+		})
 	}
 }
 
-func TestRunSpawn_RecipeStateFailureReportsCreatedRecoveryAndDoesNotRegisterOrLaunch(t *testing.T) {
-	withTempHome(t)
-	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
-	preset.RefreshTemplates()
-	if err := preset.Bootstrap(globalDir); err != nil {
-		t.Fatal(err)
-	}
-	stubSuccessfulSpawnCreate(t)
-
-	originalRuntimeReady := runtimeReady
-	runtimeReady = func(string) error { return nil }
-	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
-	originalLaunch := launchAgent
-	launchAgent = func(string, string) (*exec.Cmd, error) {
-		t.Fatal("launchAgent was called after recipe-state persistence failed")
-		return nil, nil
-	}
-	t.Cleanup(func() { launchAgent = originalLaunch })
-	stubSpawnRegister(t, func(string, string) error {
-		t.Fatal("registerProject was called after recipe-state persistence failed")
-		return nil
-	})
-	stubSpawnSaveRecipeState(t, func(string, preset.RecipeState) error {
-		return errors.New("recipe state storage unavailable")
-	})
-
-	dir := filepath.Join(t.TempDir(), "project")
-	var stdout, stderr bytes.Buffer
-	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
-	if code != 1 || stdout.Len() != 0 {
-		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
-	}
-	var response map[string]interface{}
-	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
-		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
-	}
-	agentDir := filepath.Join(dir, ".lingtai", "alice")
-	if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != "recipe_state_persistence" || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir || response["cause"] != "recipe state storage unavailable" {
-		t.Fatalf("recipe-state recovery response = %#v", response)
-	}
-	if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
-		t.Fatalf("known-created seed was removed after recipe-state failure: %v", err)
-	}
-	if info, err := os.Stat(filepath.Join(dir, ".lingtai", ".library_shared")); err != nil || !info.IsDir() {
-		t.Fatalf("shared library was not preserved before recipe-state recovery: info=%v err=%v", info, err)
-	}
-}
-
-func TestRunSpawn_RegistrationFailureReportsCreatedRecoveryAndDoesNotLaunch(t *testing.T) {
-	withTempHome(t)
-	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
-	preset.RefreshTemplates()
-	if err := preset.Bootstrap(globalDir); err != nil {
-		t.Fatal(err)
-	}
-	stubSuccessfulSpawnCreate(t)
-
-	originalRuntimeReady := runtimeReady
-	runtimeReady = func(string) error { return nil }
-	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
-	originalLaunch := launchAgent
-	launchAgent = func(string, string) (*exec.Cmd, error) {
-		t.Fatal("launchAgent was called after registration failed")
-		return nil, nil
-	}
-	t.Cleanup(func() { launchAgent = originalLaunch })
-	stubSpawnRegister(t, func(string, string) error { return errors.New("registry unavailable") })
-
-	dir := filepath.Join(t.TempDir(), "project")
-	var stdout, stderr bytes.Buffer
-	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: dir, Preset: "minimax", AgentName: "alice", Language: "en"})
-	if code != 1 || stdout.Len() != 0 {
-		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
-	}
-	var response map[string]interface{}
-	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
-		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
-	}
-	agentDir := filepath.Join(dir, ".lingtai", "alice")
-	if response["code"] != "init_failed" || response["recovery_state"] != "created_unregistered" || response["recovery_step"] != "registration" || response["project_dir"] != dir || response["agent_name"] != "alice" || response["agent_dir"] != agentDir || response["cause"] != "registry unavailable" {
-		t.Fatalf("registration recovery response = %#v", response)
-	}
-	if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
-		t.Fatalf("known-created seed was removed after registration failure: %v", err)
-	}
-}
-
-func TestRunSpawn_IncompleteCreateResultDoesNotRegisterOrLaunch(t *testing.T) {
-	withTempHome(t)
-	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
-	preset.RefreshTemplates()
-	if err := preset.Bootstrap(globalDir); err != nil {
-		t.Fatal(err)
+func TestRunSpawn_UntrustedCreateOutcomeWritesOneErrorAndDoesNotRegisterOrLaunch(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+		create func(process.ProjectCreateRequest) (process.ProjectCreateResult, error)
+	}{
+		{
+			name:   "incomplete_exit_zero_result",
+			reason: "malformed_result",
+			create: func(request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+				return process.ProjectCreateResult{Status: "created", AgentName: request.AgentName, ExitCode: 0}, nil
+			},
+		},
+		{
+			name:   "argument_error_transport",
+			reason: "argument_error",
+			create: func(process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+				return process.ProjectCreateResult{}, &process.ProjectCreateError{
+					Kind: process.ProjectCreateTransportFailure, Reason: "argument_error", ExitCode: 2,
+					Stderr: "usage: lingtai-agent project create",
+				}
+			},
+		},
 	}
 
-	originalRuntimeReady := runtimeReady
-	runtimeReady = func(string) error { return nil }
-	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
-	originalLaunch := launchAgent
-	launchAgent = func(string, string) (*exec.Cmd, error) {
-		t.Fatal("launchAgent was called after an incomplete create result")
-		return nil, nil
-	}
-	t.Cleanup(func() { launchAgent = originalLaunch })
-	stubSpawnRegister(t, func(string, string) error {
-		t.Fatal("registerProject was called after an incomplete create result")
-		return nil
-	})
-	stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
-		return process.ProjectCreateResult{Status: "created", AgentName: request.AgentName, ExitCode: 0}, nil
-	})
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			withTempHome(t)
+			globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
+			preset.RefreshTemplates()
+			if err := preset.Bootstrap(globalDir); err != nil {
+				t.Fatal(err)
+			}
 
-	var stdout, stderr bytes.Buffer
-	code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: filepath.Join(t.TempDir(), "project"), Preset: "minimax", AgentName: "alice", Language: "en"})
-	if code != 1 || stdout.Len() != 0 {
-		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
-	}
-	var response map[string]interface{}
-	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
-		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
-	}
-	if response["code"] != "init_failed" || response["reason"] != "malformed_result" {
-		t.Fatalf("incomplete create response = %#v", response)
+			originalRuntimeReady := runtimeReady
+			runtimeReady = func(string) error { return nil }
+			t.Cleanup(func() { runtimeReady = originalRuntimeReady })
+			originalLaunch := launchAgent
+			launchAgent = func(string, string) (*exec.Cmd, error) {
+				t.Fatal("launchAgent was called after an untrusted create outcome")
+				return nil, nil
+			}
+			t.Cleanup(func() { launchAgent = originalLaunch })
+			stubSpawnRegister(t, func(string, string) error {
+				t.Fatal("registerProject was called after an untrusted create outcome")
+				return nil
+			})
+			stubSpawnCreate(t, func(_ context.Context, _ string, request process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
+				return test.create(request)
+			})
+
+			var stdout, stderr bytes.Buffer
+			code := RunSpawn(&stdout, &stderr, SpawnOpts{Dir: filepath.Join(t.TempDir(), "project"), Preset: "minimax", AgentName: "alice", Language: "en"})
+			if code != 1 || stdout.Len() != 0 {
+				t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
+			}
+			var response map[string]interface{}
+			if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+				t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
+			}
+			if response["code"] != "init_failed" || response["reason"] != test.reason {
+				t.Fatalf("%s response = %#v", test.name, response)
+			}
+		})
 	}
 }
 
@@ -671,45 +664,5 @@ func TestRunSpawn_HandlerCreateFailureWritesOneStructuredErrorAndDoesNotLaunch(t
 	}
 	if _, err := os.Stat(filepath.Join(globalDir, "registry.jsonl")); !os.IsNotExist(err) {
 		t.Fatalf("failed create was registered: %v", err)
-	}
-}
-
-func TestRunSpawn_UnknownCreateFailureDoesNotTrustOrLaunch(t *testing.T) {
-	withTempHome(t)
-	globalDir := filepath.Join(os.Getenv("HOME"), ".lingtai-tui")
-	preset.RefreshTemplates()
-	if err := preset.Bootstrap(globalDir); err != nil {
-		t.Fatal(err)
-	}
-
-	originalRuntimeReady := runtimeReady
-	runtimeReady = func(string) error { return nil }
-	t.Cleanup(func() { runtimeReady = originalRuntimeReady })
-	originalLaunch := launchAgent
-	launchAgent = func(string, string) (*exec.Cmd, error) {
-		t.Fatal("launchAgent was called after an unknown project create outcome")
-		return nil, nil
-	}
-	t.Cleanup(func() { launchAgent = originalLaunch })
-	stubSpawnCreate(t, func(context.Context, string, process.ProjectCreateRequest) (process.ProjectCreateResult, error) {
-		return process.ProjectCreateResult{}, &process.ProjectCreateError{
-			Kind: process.ProjectCreateTransportFailure, Reason: "argument_error", ExitCode: 2,
-			Stderr: "usage: lingtai-agent project create",
-		}
-	})
-
-	var stdout, stderr bytes.Buffer
-	code := RunSpawn(&stdout, &stderr, SpawnOpts{
-		Dir: filepath.Join(t.TempDir(), "project"), Preset: "minimax", AgentName: "alice", Language: "en",
-	})
-	if code != 1 || stdout.Len() != 0 {
-		t.Fatalf("exit/stdout = %d/%q, want 1 and no stdout document", code, stdout.String())
-	}
-	var response map[string]interface{}
-	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
-		t.Fatalf("stderr is not one structured JSON error: %v\n%s", err, stderr.String())
-	}
-	if response["code"] != "init_failed" || response["reason"] != "argument_error" {
-		t.Fatalf("unknown failure mapping = %#v", response)
 	}
 }

--- a/tui/internal/process/ANATOMY.md
+++ b/tui/internal/process/ANATOMY.md
@@ -23,7 +23,7 @@ maintenance: |
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`. Coding agents update this file in the same commit as code changes.
 
-`process` is the TUI's subprocess boundary with the Python kernel: the one place that turns "start this agent" into a real `python -m lingtai run <dir>` child under the managed runtime venv, and the one place that terminates such a child. It is the *only* direct process-level coupling between the two languages — after launch, the TUI observes the agent purely through its working directory (`tui/internal/fs/`). Detection logic itself lives one layer down in `tui/internal/processscan/`, which this package re-exports so low-level callers that cannot import `process` still share one tested implementation.
+`process` is the TUI's subprocess boundary with the Python kernel: it runs the noninteractive fresh-seed `lingtai-agent project create` command with literal argv and captured output, and it starts/terminates the guarded `lingtai-agent run <dir>` child under the managed runtime venv. It is the *only* direct process-level coupling between the two languages — after a create or launch, the TUI observes the agent purely through its working directory (`tui/internal/fs/`). Detection logic itself lives one layer down in `tui/internal/processscan/`, which this package re-exports so low-level callers that cannot import `process` still share one tested implementation.
 
 ## Components
 
@@ -32,18 +32,21 @@ maintenance: |
 | `AgentProcess` | `tui/internal/process/check.go:9` | type alias re-exporting `processscan.AgentProcess` so callers need only one import |
 | `FindAgentProcesses` | `tui/internal/process/check.go:18` | delegates to `processscan` for the running processes bound to one agent dir |
 | `IsAgentRunning` | `tui/internal/process/check.go:30` | the boolean launch/refresh gate built on that scan |
-| `ErrAgentAlreadyRunning` | `tui/internal/process/launcher.go:18` | the sentinel `LaunchAgent` returns instead of starting a second kernel in one workdir |
-| `InitProject` | `tui/internal/process/launcher.go:20` | creates/stamps a project's `.lingtai/` skeleton before the first launch |
-| `LaunchAgent` | `tui/internal/process/launcher.go:96` | the guarded launch: refuses when an agent is already running in the workdir, then spawns the kernel with the resolved venv interpreter, log redirection, and PID tracking |
-| `ForceLaunchAgent` | `tui/internal/process/launcher.go:109` | the same spawn with the already-running guard deliberately skipped, for explicit operator override |
+| `ErrAgentAlreadyRunning` | `tui/internal/process/launcher.go:21` | the sentinel `LaunchAgent` returns instead of starting a second kernel in one workdir |
+| `ProjectCreateRequest` / `ProjectCreateResult` / `ProjectCreateError` | `tui/internal/process/launcher.go:26,36,57` | literal create inputs plus captured accepted output or classified handler/transport failure |
+| `kernelCLI` / `kernelCLIForOS` | `tui/internal/process/launcher.go:151,157` | resolves the managed sibling executable; the production resolver supplies `runtime.GOOS` while the suffix decision remains platform-neutral and unit-testable |
+| `CreateProject` | `tui/internal/process/launcher.go:170` | synchronously runs `lingtai-agent project create --dir --name --preset --covenant-file --json`; accepts only exit-0 one-object `created` output for the requested agent with a nonempty canonical `preset_ref`, and preserves all other terminal outcomes for conservative callers |
+| `InitProject` | `tui/internal/process/launcher.go:83` | legacy TUI-owned `.lingtai/` skeleton helper retained for its independent callers; headless spawn does not use it |
+| `LaunchAgent` | `tui/internal/process/launcher.go:295` | the guarded launch: refuses when an agent is already running in the workdir, then spawns the kernel with the resolved venv interpreter, log redirection, and PID tracking |
+| `ForceLaunchAgent` | `tui/internal/process/launcher.go:308` | the same spawn with the already-running guard deliberately skipped, for explicit operator override |
 | `TerminateAgentProcesses` | `tui/internal/process/kill_unix.go:18`, `tui/internal/process/kill_windows.go:18` | per-OS termination of every process matched for an agent dir; `terminateError` (`kill_unix.go:54`, `kill_windows.go:43`) names the PIDs that survived |
 
 ## Connections
 
 - **Calls `tui/internal/processscan/`** for all process-table matching — this package adds launch/terminate policy, not parsing.
-- **Calls `tui/internal/config/`** to resolve the runtime venv interpreter (`~/.lingtai-tui/runtime/venv`) the kernel is launched from.
-- **Called by `tui/main.go`** (interactive start, `purge`, `suspend`), by `tui/internal/tui/` (`launcher.go`, the network home's start/stop actions), and by `tui/internal/headless/spawn.go` for the non-interactive path.
-- **Launches the kernel only.** It never speaks to a running agent afterward; all further communication is filesystem-only through `tui/internal/fs/`.
+- **Calls `tui/internal/config/`** to resolve the runtime venv interpreter (`~/.lingtai-tui/runtime/venv`) whose sibling `lingtai-agent` executable handles both create and run.
+- **Called by `tui/main.go`** (interactive start, `purge`, `suspend`), by `tui/internal/tui/` (`launcher.go`, the network home's start/stop actions), and by `tui/internal/headless/spawn.go`, which alone uses `CreateProject` for noninteractive fresh seeding before the existing launch path.
+- **Starts kernel CLI commands only.** It never speaks to a running agent afterward; all further communication is filesystem-only through `tui/internal/fs/`.
 
 ## Composition
 
@@ -53,6 +56,7 @@ maintenance: |
 
 ## Notes
 
+- **Create completion is process-authoritative.** `CreateProject` never deletes a root or `.lingtai/` tree after a child error: malformed output, a signal, cancellation, timeout, or another transport outcome can leave an uncertain tree for explicit recovery.
 - **One agent per workdir.** `LaunchAgent` fails with `ErrAgentAlreadyRunning` rather than starting a second kernel against the same `.lingtai/<agent>/`. `ForceLaunchAgent` is the explicit, operator-visible override — do not make it the default path.
 - **Process-table detection is advisory.** Same caveat as `processscan`: matching is best-effort and racy. The kernel's own workdir lock is the authoritative gate; never rely on `IsAgentRunning` alone for correctness under concurrency.
 - **Keep the import direction clean.** `processscan` exists precisely because `process` imports `migrate`; packages below that line must import `processscan`, never `process`.

--- a/tui/internal/process/launcher.go
+++ b/tui/internal/process/launcher.go
@@ -1,6 +1,8 @@
 package process
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +20,66 @@ import (
 // to the user rather than re-attempting the launch.
 var ErrAgentAlreadyRunning = errors.New("a lingtai agent is already running in this workdir")
 
+// ProjectCreateRequest is the literal input to `lingtai-agent project create`.
+// Callers must keep CovenantFile available until CreateProject returns because
+// the kernel reads its contents while the child is running.
+type ProjectCreateRequest struct {
+	Dir          string
+	AgentName    string
+	Preset       string
+	CovenantFile string
+}
+
+// ProjectCreateResult is a complete, accepted kernel create response. Child
+// output remains captured here rather than leaking into a headless caller's
+// stdout protocol.
+type ProjectCreateResult struct {
+	Status    string
+	AgentName string
+	PresetRef string
+	Stdout    string
+	Stderr    string
+	ExitCode  int
+}
+
+// ProjectCreateFailureKind distinguishes a kernel-declared application error
+// from an execution outcome for which the TUI must not infer project state.
+type ProjectCreateFailureKind string
+
+const (
+	ProjectCreateHandlerFailure   ProjectCreateFailureKind = "handler"
+	ProjectCreateTransportFailure ProjectCreateFailureKind = "transport"
+)
+
+// ProjectCreateError retains the child outcome for diagnostic rendering. A
+// Handler failure is trusted only for the kernel's documented exit-1 JSON
+// stderr protocol; all other failures are transport/unknown outcomes.
+type ProjectCreateError struct {
+	Kind     ProjectCreateFailureKind
+	Reason   string
+	Code     string
+	Message  string
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	Cause    error
+}
+
+func (e *ProjectCreateError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("project create %s: %v", e.Reason, e.Cause)
+	}
+	return fmt.Sprintf("project create %s", e.Reason)
+}
+
+func (e *ProjectCreateError) Unwrap() error { return e.Cause }
+
+// InitProject creates the legacy TUI-owned project skeleton. It remains for
+// its independent callers; headless spawn seeds fresh projects through
+// CreateProject instead.
 func InitProject(lingtaiDir string) error {
 	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
 		return fmt.Errorf("create .lingtai: %w", err)
@@ -85,6 +147,142 @@ func resolvePython(agentDir, fallbackCmd string) string {
 	return fallbackCmd
 }
 
+// kernelCLI resolves the managed kernel executable beside its interpreter.
+func kernelCLI(python string) string {
+	return kernelCLIForOS(python, runtime.GOOS)
+}
+
+// kernelCLIForOS keeps the platform suffix decision independently testable
+// without executing a platform-specific child process.
+func kernelCLIForOS(python, goos string) string {
+	name := "lingtai-agent"
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(filepath.Dir(python), name)
+}
+
+// CreateProject runs the kernel-owned fresh-project seed command with literal
+// argv. It captures all child output and accepts success only when exit 0 emits
+// exactly one expected JSON object. ctx cancellation or deadline expiry, signal
+// termination, parser failures, and unexpected exit statuses are deliberately
+// returned as transport outcomes rather than trusted create results.
+func CreateProject(ctx context.Context, lingtaiCmd string, request ProjectCreateRequest) (ProjectCreateResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cmd := exec.CommandContext(ctx, kernelCLI(lingtaiCmd),
+		"project", "create",
+		"--dir", request.Dir,
+		"--name", request.AgentName,
+		"--preset", request.Preset,
+		"--covenant-file", request.CovenantFile,
+		"--json",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	stdoutText, stderrText := stdout.String(), stderr.String()
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		reason := "cancelled"
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			reason = "timeout"
+		}
+		return ProjectCreateResult{}, &ProjectCreateError{
+			Kind: ProjectCreateTransportFailure, Reason: reason, ExitCode: -1,
+			Stdout: stdoutText, Stderr: stderrText, Cause: ctxErr,
+		}
+	}
+	if runErr == nil {
+		return parseProjectCreateSuccess(request.AgentName, stdoutText, stderrText)
+	}
+
+	exitErr, ok := runErr.(*exec.ExitError)
+	if !ok {
+		return ProjectCreateResult{}, &ProjectCreateError{
+			Kind: ProjectCreateTransportFailure, Reason: "start_failed", ExitCode: -1,
+			Stdout: stdoutText, Stderr: stderrText, Cause: runErr,
+		}
+	}
+	exitCode := exitErr.ProcessState.ExitCode()
+	if exitCode < 0 {
+		return ProjectCreateResult{}, &ProjectCreateError{
+			Kind: ProjectCreateTransportFailure, Reason: "signal", ExitCode: exitCode,
+			Stdout: stdoutText, Stderr: stderrText, Cause: runErr,
+		}
+	}
+	if exitCode == 1 {
+		return parseProjectCreateHandlerError(exitCode, stdoutText, stderrText)
+	}
+	reason := "unexpected_exit"
+	if exitCode == 2 {
+		reason = "argument_error"
+	}
+	return ProjectCreateResult{}, &ProjectCreateError{
+		Kind: ProjectCreateTransportFailure, Reason: reason, ExitCode: exitCode,
+		Stdout: stdoutText, Stderr: stderrText, Cause: runErr,
+	}
+}
+
+func parseProjectCreateSuccess(expectedAgentName, stdout, stderr string) (ProjectCreateResult, error) {
+	var response struct {
+		Status    string `json:"status"`
+		AgentName string `json:"agent_name"`
+		PresetRef string `json:"preset_ref"`
+	}
+	if err := decodeProjectCreateJSONObject([]byte(stdout), &response); err != nil {
+		return ProjectCreateResult{}, malformedProjectCreateError(0, stdout, stderr, err)
+	}
+	if response.Status != "created" || response.AgentName != expectedAgentName || response.PresetRef == "" || !filepath.IsAbs(response.PresetRef) {
+		return ProjectCreateResult{}, malformedProjectCreateError(0, stdout, stderr,
+			fmt.Errorf("unexpected success status %q, agent name %q, or canonical preset reference %q", response.Status, response.AgentName, response.PresetRef))
+	}
+	return ProjectCreateResult{
+		Status: response.Status, AgentName: response.AgentName, PresetRef: response.PresetRef,
+		Stdout: stdout, Stderr: stderr, ExitCode: 0,
+	}, nil
+}
+
+func parseProjectCreateHandlerError(exitCode int, stdout, stderr string) (ProjectCreateResult, error) {
+	var response struct {
+		Status  string `json:"status"`
+		Code    string `json:"code"`
+		Message string `json:"error"`
+	}
+	if err := decodeProjectCreateJSONObject([]byte(stderr), &response); err != nil {
+		return ProjectCreateResult{}, malformedProjectCreateError(exitCode, stdout, stderr, err)
+	}
+	if response.Status != "error" || response.Code == "" || response.Message == "" {
+		return ProjectCreateResult{}, malformedProjectCreateError(exitCode, stdout, stderr,
+			fmt.Errorf("unexpected handler error response"))
+	}
+	return ProjectCreateResult{}, &ProjectCreateError{
+		Kind: ProjectCreateHandlerFailure, Reason: "handler_error", Code: response.Code,
+		Message: response.Message, ExitCode: exitCode, Stdout: stdout, Stderr: stderr,
+	}
+}
+
+func malformedProjectCreateError(exitCode int, stdout, stderr string, cause error) error {
+	return &ProjectCreateError{
+		Kind: ProjectCreateTransportFailure, Reason: "malformed_result", ExitCode: exitCode,
+		Stdout: stdout, Stderr: stderr, Cause: cause,
+	}
+}
+
+func decodeProjectCreateJSONObject(data []byte, target interface{}) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return errors.New("expected one JSON object")
+	}
+	if err := json.Unmarshal(trimmed, target); err != nil {
+		return fmt.Errorf("parse JSON: %w", err)
+	}
+	return nil
+}
+
 // LaunchAgent starts an agent process. lingtaiCmd is the global fallback Python;
 // the agent's init.json venv_path is tried first.
 //
@@ -94,14 +292,6 @@ func resolvePython(agentDir, fallbackCmd string) string {
 // in that case. The kernel's flock guarantees correctness of on-disk state,
 // but a duplicate Python process still shows up in `ps`/`lingtai-tui list`
 // and can mislead users; this guard keeps the process accounting honest.
-func kernelCLI(python string) string {
-	name := "lingtai-agent"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
-	}
-	return filepath.Join(filepath.Dir(python), name)
-}
-
 func LaunchAgent(lingtaiCmd, agentDir string) (*exec.Cmd, error) {
 	if IsAgentRunning(agentDir) {
 		return nil, ErrAgentAlreadyRunning

--- a/tui/internal/process/launcher_test.go
+++ b/tui/internal/process/launcher_test.go
@@ -1,6 +1,8 @@
 package process
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -159,5 +161,118 @@ func TestLaunchAgentUnsafeValidAddonKeyKeepsLaunchBehavior(t *testing.T) {
 		if !strings.Contains(calls, want) {
 			t.Errorf("interpreter log missing %q; got:\n%s", want, calls)
 		}
+	}
+}
+
+func writeProjectCreateStub(t *testing.T, dir, logPath, stdout, stderr string, exitStatus int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX stub lingtai-agent not available on Windows")
+	}
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nprintf '%%b' %q\nprintf '%%b' %q >&2\nexit %d\n", logPath, stdout, stderr, exitStatus)
+	if err := os.WriteFile(filepath.Join(dir, "lingtai-agent"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKernelCLIForOS_UsesExpectedExecutableName(t *testing.T) {
+	python := filepath.Join("runtime", "venv", "bin", "python")
+	for _, tc := range []struct {
+		name     string
+		goos     string
+		filename string
+	}{
+		{name: "unix", goos: "linux", filename: "lingtai-agent"},
+		{name: "windows", goos: "windows", filename: "lingtai-agent.exe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kernelCLIForOS(python, tc.goos)
+			if filepath.Base(got) != tc.filename {
+				t.Errorf("kernelCLIForOS filename = %q, want %q", filepath.Base(got), tc.filename)
+			}
+			if filepath.Dir(got) != filepath.Dir(python) {
+				t.Errorf("kernelCLIForOS dir = %q, want %q", filepath.Dir(got), filepath.Dir(python))
+			}
+		})
+	}
+}
+
+func TestCreateProject_UsesLiteralArgvAndCapturesSuccess(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "create-argv.log")
+	stdout := "{\"agent_name\":\"alice\",\"preset_ref\":\"/presets/chosen.json\",\"status\":\"created\"}\n"
+	writeProjectCreateStub(t, dir, logPath, stdout, "", 0)
+
+	request := ProjectCreateRequest{
+		Dir:          filepath.Join(dir, "project with spaces"),
+		AgentName:    "alice",
+		Preset:       filepath.Join(dir, "chosen preset.json"),
+		CovenantFile: filepath.Join(dir, "covenant input.md"),
+	}
+	result, err := CreateProject(context.Background(), filepath.Join(dir, "python"), request)
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+	if result.Status != "created" || result.AgentName != request.AgentName || result.PresetRef != "/presets/chosen.json" || result.ExitCode != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.Stdout != stdout || result.Stderr != "" {
+		t.Fatalf("child output was not retained: %+v", result)
+	}
+	got := strings.Split(strings.TrimSuffix(readInvocationLog(t, logPath), "\n"), "\n")
+	want := []string{
+		"project", "create",
+		"--dir", request.Dir,
+		"--name", request.AgentName,
+		"--preset", request.Preset,
+		"--covenant-file", request.CovenantFile,
+		"--json",
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("literal argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestCreateProject_MapsOnlyExitOneJSONStderrAsHandlerFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectCreateStub(t, dir, filepath.Join(dir, "create-argv.log"), "untrusted stdout", `{"code":"invalid_preset","error":"bad preset","status":"error"}`, 1)
+
+	_, err := CreateProject(context.Background(), filepath.Join(dir, "python"), ProjectCreateRequest{})
+	var failure *ProjectCreateError
+	if !errors.As(err, &failure) {
+		t.Fatalf("error = %v, want ProjectCreateError", err)
+	}
+	if failure.Kind != ProjectCreateHandlerFailure || failure.Code != "invalid_preset" || failure.Message != "bad preset" || failure.Stdout != "untrusted stdout" {
+		t.Fatalf("unexpected handler failure: %+v", failure)
+	}
+}
+
+func TestCreateProject_RejectsMalformedSuccessAndExitTwoAsTransport(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		stdout    string
+		stderr    string
+		exit      int
+		agentName string
+		reason    string
+	}{
+		{name: "multiple stdout documents", stdout: "{\"agent_name\":\"alice\",\"preset_ref\":\"/presets/chosen.json\",\"status\":\"created\"}\n{\"extra\":true}", exit: 0, agentName: "alice", reason: "malformed_result"},
+		{name: "mismatched agent", stdout: "{\"agent_name\":\"bob\",\"preset_ref\":\"/presets/chosen.json\",\"status\":\"created\"}", exit: 0, agentName: "alice", reason: "malformed_result"},
+		{name: "missing preset reference", stdout: "{\"agent_name\":\"alice\",\"status\":\"created\"}", exit: 0, agentName: "alice", reason: "malformed_result"},
+		{name: "relative preset reference", stdout: "{\"agent_name\":\"alice\",\"preset_ref\":\"presets/chosen.json\",\"status\":\"created\"}", exit: 0, agentName: "alice", reason: "malformed_result"},
+		{name: "argparse exit two", stderr: "usage: lingtai-agent project create", exit: 2, reason: "argument_error"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeProjectCreateStub(t, dir, filepath.Join(dir, "create-argv.log"), tc.stdout, tc.stderr, tc.exit)
+			_, err := CreateProject(context.Background(), filepath.Join(dir, "python"), ProjectCreateRequest{AgentName: tc.agentName})
+			var failure *ProjectCreateError
+			if !errors.As(err, &failure) {
+				t.Fatalf("error = %v, want ProjectCreateError", err)
+			}
+			if failure.Kind != ProjectCreateTransportFailure || failure.Reason != tc.reason {
+				t.Fatalf("unexpected transport failure: %+v", failure)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Route noninteractive `lingtai-tui spawn` / `headless.RunSpawn` through the merged kernel `lingtai-agent project create` CLI rather than duplicating project seeding in the TUI.
- Validate the machine-readable create result before TUI metadata, registry registration, or agent launch; preserve the kernel-created seed and return structured `created_unregistered` recovery for known post-create TUI failures.
- Preserve the existing TUI interactive creation, draft, inventory, and global-migration flows.

## Validation
- `go test ./internal/headless ./internal/process`
- `git diff --check`
- Independent final static review: PASS

## Explicit Draft gate
This is intentionally a **Draft**. The kernel caller contract requires cross-process, per-root create serialization. This slice does not add a misleading process-local lock; the unresolved coordination contract (lock location, lifetime/crash recovery, ordering, and concurrency tests) is a merge blocker for separately authorized work.

## Out of scope
Interactive project creation/drafts, inventory UX, global migrations, kernel changes, destructive operations, and any cross-process lock design.