### PR TITLE
fix(installer): accept bundles without host archives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -795,7 +795,9 @@ fetch_bundle_manifest() {
 }
 
 # Validate the complete bundle contract at the trust boundary and print the
-# canonical digest for this host's one exact archive.
+# canonical digest for this host's archive when the release publishes one.
+# A host archive is optional: the same manifest still binds the exact kernel
+# while the TUI/Portal binaries fall back to an exact-tag source build.
 parse_bundle_manifest() {
   local body="$1" expected_tag="$2"
   BODY="$body" python3 - "$expected_tag" "$(detect_os)" "$(detect_arch)" <<'PY'
@@ -836,7 +838,6 @@ try:
         if not isinstance(archive["sha256"], str) or not re.fullmatch(r"[0-9a-f]{64}", archive["sha256"]): raise ValueError("archive sha256 must be lowercase 64-hex")
     target = f"lingtai-{expected_tag}-{os_name}-{arch}.tar.gz"
     hits = [archive for archive in data["archives"] if archive["filename"] == target]
-    if len(hits) != 1: raise ValueError(f"expected exactly one archive for {target}, found {len(hits)}")
     exact(data["providers"], ("github", "gitee"), "providers")
     exact(data["providers"]["github"], ("repo",), "github provider")
     exact(data["providers"]["gitee"], ("owner", "repo"), "gitee provider")
@@ -848,7 +849,7 @@ try:
     if not re.fullmatch(r"[A-Za-z0-9_.-]+", data["providers"]["gitee"]["repo"]): raise ValueError("gitee repo is invalid")
 except (ValueError, TypeError, json.JSONDecodeError) as exc:
     raise SystemExit(f"invalid strict bundle manifest: {exc}")
-print(hits[0]["sha256"])
+print(hits[0]["sha256"] if hits else "")
 print(data["kernel_tag"])
 print(data["kernel_version"])
 print(data["kernel_manifest_filename"])
@@ -2458,6 +2459,10 @@ try_release_asset() {
   fi
   if ! load_bundle_manifest "$BUNDLE_MANIFEST_JSON" "$tag"; then
     warn "validated bundle manifest could not be loaded for $name; refusing the release asset."
+    return 1
+  fi
+  if [[ -z "$BUNDLE_TUI_ARCHIVE_SHA" ]]; then
+    note "Validated bundle manifest does not list $name; will build TUI/Portal binaries from source."
     return 1
   fi
   if [[ ! "$BUNDLE_TUI_ARCHIVE_SHA" =~ ^[0-9a-f]{64}$ ]]; then

--- a/scripts/test-install-sh-gitee-bundle.sh
+++ b/scripts/test-install-sh-gitee-bundle.sh
@@ -69,6 +69,28 @@ assert_eq "v0.16.4" "$(bundle_manifest_field kernel_tag)" "strict parser stores 
 assert_eq "0.16.4" "$(bundle_manifest_field kernel_version)" "strict parser stores kernel version"
 assert_eq "lingtai-kernel-release-manifest.json" "$(bundle_manifest_field kernel_manifest_filename)" "strict parser stores kernel manifest filename"
 
+(
+  # GitHub's v1.0.7/v1.0.8 manifests publish the Windows archive only. On a
+  # POSIX host that is still a valid exact-tag kernel binding; the missing host
+  # binary digest must stay empty so try_release_asset falls back to source.
+  windows_only_manifest="$(printf '%s' "$strict_manifest" | python3 -c 'import json,sys; d=json.load(sys.stdin); d["archives"]=[{"filename":"lingtai-v0.11.0-windows-amd64.zip","sha256":"b"*64}]; print(json.dumps(d))')"
+  assert_eq "" "$(validate_bundle_manifest "$windows_only_manifest" v0.11.0)" \
+    "strict parser accepts a Windows-only manifest on POSIX without inventing a host digest"
+  load_bundle_manifest "$windows_only_manifest" v0.11.0 || \
+    fail "Windows-only manifest should remain a valid exact-tag kernel binding on POSIX"
+  assert_eq "" "$BUNDLE_TUI_ARCHIVE_SHA" \
+    "Windows-only manifest leaves the optional POSIX archive digest empty"
+  assert_eq "v0.16.4" "$(bundle_manifest_field kernel_tag)" \
+    "Windows-only manifest still stores the pinned kernel tag"
+  BUNDLE_MANIFEST_JSON="$windows_only_manifest"
+  BUNDLE_TAG="v0.11.0"
+  if out="$(try_release_asset v0.11.0 2>&1)"; then
+    fail "try_release_asset should fall back when the bundle omits this POSIX host archive"
+  fi
+  echo "$out" | grep -q "does not list.*will build.*from source" ||
+    fail "missing-host fallback should explain the source build, got: $out"
+)
+
 expect_bad_bundle() {
   local label="$1" body="$2" tag="${3:-v0.11.0}"
   if validate_bundle_manifest "$body" "$tag" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- keep a valid TUI bundle manifest as the exact kernel binding even when it does not publish a prebuilt archive for the current POSIX host
- leave the host archive digest empty so `install.sh` takes its existing exact-tag TUI/Portal source-build fallback while still installing the manifest-pinned kernel
- distinguish this supported fallback from a malformed archive digest in the user-facing diagnostic

This fixes the already-published Windows-only manifests for v1.0.7 and v1.0.8. It is complementary to #936's future macOS asset publication rather than overlapping that workflow change.

Fixes #937

## Validation
- `bash -n install.sh scripts/test-install-sh-gitee-bundle.sh`
- real public v1.0.7 and v1.0.8 manifests on a simulated `darwin/arm64` host: bundle accepted, kernel remains pinned to v1.0.4, host digest stays empty, binary path selects source fallback
- existing host-archive manifest still returns its authoritative digest
- `git diff --check`

A focused regression is added to `scripts/test-install-sh-gitee-bundle.sh` for the Windows-only-manifest case.