### PR TITLE
docs(skills): shorten top-level utility skill descriptions

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: lingtai-dev-guide
 description: >
-  Router for contributing to the LingTai project. Use this when you are about
-  to change LingTai code or docs, set up a dev environment, navigate the Go
-  TUI/portal repo or Python kernel, develop MCP addons, troubleshoot a
-  running network, audit security, run a runtime self-check, get a PR
-  review-ready, or steward a new skill. This is for developers and contributors;
-  for end-user lessons, use tutorial-guide.
+  Router for contributing to LingTai. Use when changing code or docs, setting
+  up a dev environment, navigating the TUI/portal repo or Python kernel,
+  developing MCP addons, troubleshooting a running network, auditing
+  security, running a runtime self-check, prepping a PR review, or
+  stewarding a new skill. For developers and contributors; for end-user
+  lessons, use tutorial-guide.
 version: 2.8.0
-last_changed_at: "2026-08-09T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: lingtai-issue-report
-description: Protocol router for reporting bugs, stale info, missing capabilities, or design issues you spot in any LingTai skill, capability, preset, or system behavior. Enter through this router, then load the one nested reference you need — evidence-checklist (when to report, what evidence to collect, secret hygiene), report-template (the report body/title structure), or filing-flow (human consent, the gh CLI path, and the paste-ready fallback). You always assemble a structured report and ask the human for permission before filing.
+description: Protocol router for reporting bugs, stale info, missing capabilities, or design issues in any LingTai skill, capability, preset, or system behavior. Enter through this router, then load the one nested reference you need — evidence-checklist, report-template, or filing-flow. You always assemble a structured report and ask the human for permission before filing.
 version: 1.4.0
-last_changed_at: "2026-07-18T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: lingtai-portal-guide
-description: Reference router for LingTai portal (lingtai-portal) internals. Read this to understand portal startup/opening, .portal/ files, topology/replay APIs, network response shape, and lifecycle/recording behavior. Useful when the human asks about visualization, network history, or the portal.
+description: Reference router for lingtai-portal internals — startup/opening, .portal/ files, topology/replay APIs, network response shape, and lifecycle/recording. Use when the human asks about visualization, network history, or the portal.
 version: 1.1.0
-last_changed_at: "2026-07-18T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: lingtai-preset-skill
 description: >
-  Thin dual-axis router for preset questions: which of the 13 TUI-shipped
-  built-in preset templates (provider axis), and which cross-cutting preset
-  lifecycle mechanic (operation axis) — saving, checking availability,
-  activating/refreshing, endpoint/capability facts, or troubleshooting. Read
-  a child only when it is relevant; this does not describe arbitrary saved
-  presets.
+  Dual-axis router for built-in preset questions: which of the 13
+  TUI-shipped provider templates, and which cross-cutting lifecycle
+  mechanic — saving, checking availability, activating/refreshing,
+  endpoint/capability facts, or troubleshooting. Read a child only when
+  relevant; this does not describe arbitrary saved presets.
 version: 2.1.0
-last_changed_at: "2026-08-09T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 related_files:
   - tui/internal/preset/skills/lingtai-preset-skill/SKILL.md
   - tui/internal/preset/preset.go

--- a/tui/internal/preset/skills/lingtai-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/SKILL.md
@@ -1,25 +1,16 @@
 ---
 name: lingtai-recipe
 description: >
-  Menu manual (not a tool) for everything recipe-related in LingTai. A
-  **recipe** is the named payload that shapes an orchestrator's
-  greeting, ongoing behaviour, and shipped library; every LingTai
-  project uses one (selected at `/setup` time, inherited from a clone,
-  or auto-discovered when a project already has `.recipe/` at its
-  root). Routes to two sub-guides — `reference/recipe-format/SKILL.md`
-  (read first when authoring or customising) and
-  `reference/export-recipe/SKILL.md` (shipping the methodology / culture
-  as a bundle others use to seed *new* networks) — and warns about the
-  three different recipe-shaped artifacts that can co-exist in one
-  project (inner network, outer applied recipe, captured applied
-  snapshot — easy to conflate). Read this skill when the human mentions
-  recipes, wants to author / customise one, or wants to publish a
-  recipe for seeding new networks. Do NOT use for one-off exports of a
-  single agent (that's just `cp -r`), or for in-network behaviour edits to the
-  live system (those go through the kernel's writes to the agent's
-  working directory, not through a recipe round-trip).
+  Menu manual (not a tool) for recipes — the named payload that shapes an
+  orchestrator's greeting, ongoing behaviour, and shipped library; every
+  LingTai project uses one. Routes to `reference/recipe-format/SKILL.md`
+  (authoring/customising) and `reference/export-recipe/SKILL.md`
+  (publishing for new networks), and warns about the three different
+  recipe-shaped artifacts that can co-exist in one project — easy to
+  conflate. Do NOT use for one-off exports of a single agent (that's
+  just `cp -r`), or for in-network behaviour edits to the live system.
 version: 3.2.0
-last_changed_at: "2026-07-18T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: lingtai-tui-anatomy
 description: >
-  Discoverable source-navigation guide for the LingTai Go monorepo that ships
+  Source-navigation guide for the LingTai Go monorepo that ships
   `lingtai-tui` and `lingtai-portal`. Read this for TUI/Portal structure,
   runtime-boundary evidence, exact Go ownership, or when updating an
-  `ANATOMY.md`. The repository-root `ANATOMY.md` is the normative convention and
-  top of the distributed graph; this skill teaches the route into that graph
-  without duplicating it. Kernel internals remain owned by
-  `lingtai-kernel-anatomy`.
+  `ANATOMY.md`. The repository-root `ANATOMY.md` is normative; this skill
+  routes into that graph without duplicating it. Kernel internals remain
+  owned by `lingtai-kernel-anatomy`.
 version: 0.2.0
 tags: [tui, portal, go, anatomy, source-navigation, reference]
-last_changed_at: "2026-07-19T02:41:00-07:00"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
@@ -2,15 +2,14 @@
 name: lingtai-tui-help
 description: >
   Anything you need to know about LingTai TUI. Read this first for the stable
-  mental model, major-feature map, interface and slash-command help, or the
-  correct source/manual route for a TUI question. It stays thin: exact command
-  prose lives in the localized help assets, precise Go structure lives in
-  `lingtai-tui-anatomy` plus the repository ANATOMY graph, and independent
-  domains such as presets, Portal, tutorials, updates, and addons keep their own
-  top-level skills.
+  mental model, feature map, interface/slash-command help, or the right
+  source/manual route for a TUI question. Exact command prose lives in the
+  localized help assets, Go structure lives in `lingtai-tui-anatomy`, and
+  presets, Portal, tutorials, updates, and addons keep their own top-level
+  skills.
 version: 1.1.0
 tags: [tui, help, routing, lifecycle, slash-commands, reference, lingtai-tui]
-last_changed_at: "2026-07-19T02:41:00-07:00"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: tutorial-guide
 description: >
-  The 12-lesson tutorial curriculum for teaching a human how Lingtai works.
-  Router for orientation, agent runtime, communication, memory/molt,
-  capabilities, operations, addons, and graduation. Invoke this skill when the
-  human is ready to begin or continue the tutorial.
+  The 12-lesson curriculum for teaching a human how LingTai works —
+  orientation, agent runtime, communication, memory/molt, capabilities,
+  operations, addons, and graduation. Invoke this skill when the human is
+  ready to begin or continue the tutorial.
 version: 2.0.1
-last_changed_at: "2026-07-18T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/lingtai-update/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-update/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: lingtai-update
 description: >
-  Use when updating, installing, building, or debugging lingtai-tui or
-  lingtai-portal, including /update-tui, install-method detection, Homebrew,
-  source builds, tap inspection, or mainland-China connectivity.
+  Use when installing, updating, building, or debugging lingtai-tui or
+  lingtai-portal — Homebrew, source builds, install-method detection, or
+  mainland-China connectivity.
 version: 1.0.0
-last_changed_at: "2026-07-25T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -1,24 +1,19 @@
 ---
 name: swiss-knife
 description: >
-  Umbrella router for small, focused CLI tools and integrations. Read this
-  when a task might need one of the bundled utility references, then load only
-  the nested reference that matches the need: minimax-cli for MiniMax media/TTS/vision; vision for
-  image understanding (describe/OCR/critique); listen for local audio
-  transcription and music analysis; academic-research for fetching papers,
-  citation networks, and LaTeX writing; dj for journal-inspired music
-  generation; token-usage for token/cost and tool-call/API-call trend reports; html-report for standalone
-  browser deliverables; xiaomi-mimo for Xiaomi MiMo provider discovery;
-  zhipu-coding-plan for Z.AI / BigModel coding-plan capabilities; headless-bot
-  for provisioning fresh LingTai bot projects such as Telegram bots from
-  `lingtai-tui spawn`; find-something-to-do for idle curiosity practice;
-  preset-health for read-only health checks of saved presets (classify expired
-  keys, missing credentials, unreachable endpoints, invalid model/config). This
-  parent is the route map; each nested reference is self-contained under
-  `reference/<name>/SKILL.md`.
+  Umbrella router for small, focused CLI tools: minimax-cli for MiniMax
+  media/TTS/vision; vision for image OCR/critique; listen for local audio
+  transcription and music analysis; academic-research for papers, citation
+  networks, and LaTeX; dj for music generation; token-usage for token/cost
+  and API-call trend reports; html-report for standalone browser
+  deliverables; xiaomi-mimo and zhipu-coding-plan for provider discovery;
+  headless-bot for provisioning fresh LingTai bot projects (e.g. Telegram);
+  find-something-to-do for idle curiosity; preset-health for read-only
+  saved-preset health checks. Each nested reference is self-contained
+  under `reference/<name>/SKILL.md`.
 version: 2.4.0
 tags: [utilities, umbrella, toolkit, nested-skill]
-last_changed_at: "2026-06-23T17:01:03-07:00"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tui/internal/preset/skills/textbook-distillation/SKILL.md
+++ b/tui/internal/preset/skills/textbook-distillation/SKILL.md
@@ -2,19 +2,15 @@
 name: textbook-distillation
 description: >
   Turn a textbook or long-form source into a self-paced learning track:
-  intake the material, build a chapter map, draft a lesson plan, then
-  generate self-contained HTML lecture notes in a style the human
-  specifies (layout, palette, emphasis), each lesson carrying worked
-  examples, exercises, and checkpoint questions. Read this when the human
-  wants to study a book without a teacher, asks for "lecture notes" /
-  "study notes" / "course" / "syllabus" from a textbook or PDF, wants a
-  customized HTML study guide, or wants a chapter distilled into
-  teachable lessons. Do NOT use to reproduce or redistribute a
-  copyrighted book verbatim, to "summarize so I don't have to buy it,"
-  or for one-off factual lookups (just answer those directly).
+  chapter map, lesson plan, then self-contained HTML lecture notes (styled
+  as the human specifies) with worked examples, exercises, and checkpoint
+  questions. Read this for "lecture notes" / "study notes" / "course" /
+  "syllabus" requests from a textbook or PDF. Do NOT use to reproduce or
+  redistribute a copyrighted book verbatim, to "summarize so I don't have
+  to buy it," or for one-off factual lookups (just answer those directly).
 version: 1.0.0
 tags: [learning, study, textbook, lecture-notes, html, curriculum, self-paced]
-last_changed_at: "2026-07-18T00:00:00Z"
+last_changed_at: "2026-09-05T00:00:00Z"
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 


### PR DESCRIPTION
## Summary

- Shorten the top-level frontmatter `description` of the 11 bundled TUI utility skills under `tui/internal/preset/skills/` (dev-guide, issue-report, portal-guide, preset-skill, recipe, tui-anatomy, tui-help, tutorial-guide, update, swiss-knife, textbook-distillation) to reduce catalog overhead.
- Total description length across the 11 skills drops from 5,928 to 4,169 characters (about 30% smaller).
- Kept router framing, cross-skill routing cues (e.g. "use tutorial-guide", "owned by lingtai-kernel-anatomy"), and safety/scope caveats (e.g. "not arbitrary saved presets", "Do NOT use to reproduce ... copyrighted book verbatim") intact so skill selection behavior is unchanged.
- Preserved the literal trigger phrases required by existing tests: `lingtai-update`'s "Use when ..." opener and `lingtai-tui-help`'s "Anything you need to know about LingTai TUI" opener.
- Bumped `last_changed_at` on each touched file to reflect the substantive edit, per this repo's skill-authoring convention. `version`, `name`, nested reference descriptions, installer/location paths, and skill bodies are all unchanged.

## Test plan

- [x] `cd tui && go test ./internal/preset/... ./internal/tui/...` — passes (includes frontmatter/metadata tests, router-catalog tests, and the `lingtai-update`/`lingtai-tui-help` trigger-phrase tests)
- [x] `go vet ./internal/preset/... ./internal/tui/...` — clean
- [x] `git diff --check` — clean
- [x] Manually parsed the frontmatter of all 11 changed files with PyYAML to confirm it's valid YAML and that `name`/`version` are unchanged
- [ ] Full repo build / broader test suite not run (out of scope for this docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
