### PR TITLE
feat(tui): refresh built-in preset models

### DIFF
--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -142,13 +142,25 @@ only ever grows rots into one.
 **Two-generation rule.** For every model family, the TUI ships only the
 **latest two generations**. This binds:
 
-- `providerModels` (`tui/internal/tui/preset_editor.go`) — the ←/→ picker
-  on the editor's model row;
+- `providerModels` (`tui/internal/tui/preset_editor.go`) — the canonical
+  native/default-route catalog for the ←/→ picker on the editor's model row;
+  every picker/display/free-text decision uses the exact
+  `modelOptions(provider, base_url)` lookup. A route override is present only
+  when evidence pins that exact endpoint; an uncurated route stays free text.
+  The protected OpenCode Go overrides for MiniMax and MiMo preserve their
+  pre-PR catalogs and are compatibility behavior, not native curation. When a
+  user changes routes, a known curated id that the destination picker cannot
+  serve falls back to that destination's first preserved option; arbitrary
+  off-list text is never rewritten. Kimi's free-text Go row instead clears a
+  known native Kimi id so the existing non-empty-model save gate requires an
+  explicit Go id.
 - the default `model` of every built-in preset constructor
   (`tui/internal/preset/preset.go`), which for a picker-bearing provider must
   itself be one of that provider's shipped ids;
 - `modelHasVision` (`tui/internal/tui/preset_editor.go`), which carries one
-  entry per id in `providerModels` and no entry for a retired one. The
+  entry per id in the native/default `providerModels` catalog and no entry for
+  a retired one. Route-only override ids intentionally carry no global
+  modality claim: native vision metadata is not inferred for OpenCode Go.
   bijection is what `TestModelHasVisionDeclaresEveryShippedModel` enforces,
   minus two deliberate exemptions it names: `nvidia` (a gateway catalog whose
   per-vendor vision facts we do not verify) and the `claude*` CLI-alias
@@ -156,25 +168,22 @@ only ever grows rots into one.
   entry — the reverse direction is not exempt: a `modelHasVision` entry for
   an id no picker ships still fails the test. Adding an exemption is a change
   to that test, not a silent omission;
-- **not** the providers whose model row is free text. `kimi`, `gemini`,
-  `openrouter`, and `custom` have no `providerModels` entry, so they have no
-  `modelHasVision` entries either and the bijection test never sees them.
-  Their default model is still expected to be a current generation
-  (`kimi-for-coding`, `gemini-3-flash-preview`, `z-ai/glm-5.1`, and `custom`'s
-  empty model), but the maps carry nothing for them and must not be given
-  entries to "complete" the table — for `kimi` in particular, adding a
-  `providerModels` entry flips its row from free text to picker-only and one
-  `→` silently overwrites a typed Moonshot id. That deletion is deliberate and
-  pinned by a negative assertion in `preset_editor_test.go`.
+- Kimi has no provider-global `providerModels` entry, so its OpenCode Go and
+  Custom rows remain free text; only the exact native Kimi Code route uses a
+  route override picker. Gemini, OpenRouter, and Custom remain free text on
+  their uncurated routes. Their defaults are still explicit current values
+  (`k3`, `gemini-3.8-flash`, `z-ai/glm-5.3`, and Custom's empty model), but
+  route-only IDs do not enter the global vision bijection. These boundaries
+  preserve typed off-list model ids and are pinned by focused editor tests.
 
 Reading of the rule:
 
 | Term | Meaning |
 |---|---|
 | family | one vendor's model line — `MiniMax-M*`, `GLM-*`, `mimo-v*`, `deepseek-v*`, `gpt-5.*`, `kimi-k*` |
-| generation | the version step within the family — `M3` vs `M2.7`; `GLM-5.2` vs `GLM-5.1`; `gpt-5.6` vs `gpt-5.5` |
-| **not** a generation | a variant inside one generation — `-highspeed`, `-pro`, `-flash`, `-mini`, `-Air`, the `gpt-5.6-sol/-terra/-luna` routes, or the same generation respelled for another endpoint (`GLM-5.2` / `glm-5.2`). All variants of a kept generation stay. |
-| exempt | catalogs with no generation ladder: CLI aliases naming concurrent tiers (`opus`/`fable`/`sonnet`/`haiku`), and gateway catalogs that list one current id per vendor (`nvidia`). The rule still applies per family inside such a list. Free-text model rows (`kimi`, `gemini`, `openrouter`, `custom`) are outside the `providerModels`/`modelHasVision` bindings entirely — see the fourth clause above. |
+| generation | the version step within the family — `M2.7` vs `M2.5`; `GLM-5.2` vs `GLM-5.1`; `gpt-6` vs `gpt-5.6` |
+| **not** a generation | a variant inside one generation — `-highspeed`, `-pro`, `-flash`, `-mini`, `-Air`, the `gpt-5.6-sol/-terra/-luna` routes, or the same generation respelled for another endpoint (`GLM-5.2` / `glm-5.2`). All variants of a kept native generation stay; a protected gateway override is separately locked to its pre-PR list. |
+| exempt | catalogs with no generation ladder: CLI aliases naming concurrent tiers (`opus`/`fable`/`sonnet`/`haiku`), and gateway catalogs that list one current id per vendor (`nvidia`). The rule still applies per family inside such a list. Route-only overrides and uncurated free-text rows are outside the global `providerModels`/`modelHasVision` binding — see the fourth clause above. |
 
 **Standing obligation.** Adding a new generation is the same change that
 removes the third-newest one — from `providerModels`, from `modelHasVision`,

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -630,7 +630,7 @@ var ProviderRegionURLs = map[string][]RegionURL{
 	},
 	// OpenCode Go serves the Kimi K-series (kimi-k3, kimi-k2.7-code, ...)
 	// under lowercase model ids; the native Kimi Code endpoint serves the
-	// subscription model `kimi-for-coding`. Kimi had free-text base_url
+	// current subscription model `k3`. Kimi had free-text base_url
 	// before it gained this table, so it carries the Custom sentinel too —
 	// a region table without one removes the only in-editor path to a
 	// corporate proxy or relay.
@@ -1252,10 +1252,10 @@ func minimaxPreset() Preset {
 	}
 	return Preset{
 		Name:        "minimax",
-		Description: PresetDescription{Summary: "MiniMax M3 — full multimodal capabilities"},
+		Description: PresetDescription{Summary: "MiniMax M2.7 — Anthropic-compatible text and tool use"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				"provider": "minimax", "model": "MiniMax-M3",
+				"provider": "minimax", "model": "MiniMax-M2.7",
 				"api_key": nil, "api_key_env": "MINIMAX_API_KEY",
 				"base_url": ProviderRegionURLs["minimax"][0].URL,
 			},
@@ -1265,7 +1265,6 @@ func minimaxPreset() Preset {
 			// belong here. See lingtai-kernel capabilities.CORE_DEFAULTS.
 			"capabilities": map[string]interface{}{
 				"web_search": mm,
-				"vision":     mm,
 				"skills":     skillsDefault(),
 			},
 		},
@@ -1360,7 +1359,7 @@ func geminiPreset() Preset {
 
 func kimiPreset() Preset {
 	// Kimi Code (Moonshot 月之暗面) — OpenAI-compatible coding API.
-	// Subscription-based (no per-token billing); model `kimi-for-coding`.
+	// Subscription-based (no per-token billing); current model `k3`.
 	// Tool calling supported. The kernel auto-sets User-Agent
 	// "LingTai-Agent/1.0" for the `kimi` provider per Kimi's ToS — UA
 	// spoofing risks account suspension. The model family has multimodal
@@ -1369,7 +1368,7 @@ func kimiPreset() Preset {
 	return openAICompatNoVisionPreset(
 		"kimi",
 		"Kimi Code (Moonshot) — OpenAI-compatible, subscription-based, tool calling",
-		"kimi-for-coding", "KIMI_CODE_API_KEY", ProviderRegionURLs["kimi"][0].URL, "3")
+		"k3", "KIMI_CODE_API_KEY", ProviderRegionURLs["kimi"][0].URL, "3")
 }
 
 func grokPreset() Preset {
@@ -1442,11 +1441,12 @@ func codexPreset() Preset {
 		Description: PresetDescription{Summary: "ChatGPT account — vision + web search + tools"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				// Use gpt-5.6-sol as the default after successful live testing.
-				// The other named GPT-5.6 routes remain selectable for accounts
-				// where they are enabled. The complete curated model list lives
-				// in preset_editor.go's providerModels; the bare gpt-5.6 alias
-				// is intentionally omitted.
+				// Keep gpt-5.6-sol as the default: gpt-6-astra is documented and
+				// picker-visible, but exact authenticated OAuth-route availability
+				// is not positive evidence for silently promoting it. The named
+				// GPT-5.6 routes remain selectable where enabled. The complete
+				// curated list lives in preset_editor.go; the bare gpt-5.6 alias is
+				// intentionally omitted.
 				"provider": "codex", "model": "gpt-5.6-sol",
 				"api_key": nil, "api_key_env": "",
 				"base_url": "https://chatgpt.com/backend-api/codex",
@@ -1479,9 +1479,10 @@ func codexPoolPreset() Preset {
 		Description: PresetDescription{Summary: "ChatGPT account pool — load-balances across your Codex accounts"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				// Same gpt-5.6-sol default and endpoint as the single-account
-				// codex preset; only the provider differs so the kernel routes
-				// through the pool. base_url stays the official Codex endpoint —
+				// Same gpt-5.6-sol default (Astra remains availability-gated) and
+				// endpoint as the single-account codex preset; only the provider
+				// differs so the kernel routes through the pool. base_url stays the
+				// official Codex endpoint —
 				// the pool selects among token files, not endpoints.
 				"provider": "codex-pool", "model": "gpt-5.6-sol",
 				"api_key": nil, "api_key_env": "",
@@ -1511,7 +1512,7 @@ func claudePreset() Preset {
 				// is judged by detecting an existing `claude` CLI login (see
 				// AuthState.ClaudeCodeAuthConfigured). Default model is the CLI
 				// alias "opus"; the editor also offers "fable", whose full ID
-				// is `claude-fable-5` in current Claude Code.
+				// is `claude-fable-5-1` in current Claude Code.
 				"provider": "claude-code", "model": "opus",
 				"api_key": nil, "api_key_env": "",
 			},

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1330,7 +1330,7 @@ func deepseekPreset() Preset {
 }
 
 func geminiPreset() Preset {
-	// Gemini 3 Flash (Google) — multimodal model with native vision,
+	// Gemini 3.8 Flash (Google) — multimodal model with native vision,
 	// tool calling, and streaming. Uses Google's own Gemini adapter in
 	// the kernel (not OpenAI-compat), so no base_url or api_compat.
 	gm := map[string]interface{}{
@@ -1339,10 +1339,10 @@ func geminiPreset() Preset {
 	}
 	return Preset{
 		Name:        "gemini",
-		Description: PresetDescription{Summary: "Gemini 3 Flash — Google's multimodal model, tool calls, vision", Tier: "3"},
+		Description: PresetDescription{Summary: "Gemini 3.8 Flash — Google's multimodal model, tool calls, vision", Tier: "3"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				"provider": "gemini", "model": "gemini-3-flash-preview",
+				"provider": "gemini", "model": "gemini-3.8-flash",
 				"api_key": nil, "api_key_env": "GEMINI_API_KEY",
 			},
 			// Gemini is multimodal/vision-capable — image inputs are
@@ -1398,10 +1398,9 @@ func nvidiaPreset() Preset {
 	// NVIDIA NIM / NVIDIA API Catalog (build.nvidia.com) — an
 	// OpenAI-compatible /chat/completions gateway hosting a large catalog
 	// of open-weight models (Llama, Qwen, Kimi, GPT-OSS, Nemotron, ...) at
-	// no per-token cost on the free developer tier. Default model is
-	// Llama 3.3 70B Instruct; users clone this preset to switch to any
-	// other catalog ID (e.g. qwen/qwen3-coder-480b-a35b-instruct,
-	// moonshotai/kimi-k2-thinking, openai/gpt-oss-120b). Provider is the
+	// no per-token cost on the free developer tier. Default model is the
+	// bounded stable agent snapshot's Nemotron 3 Ultra route; users clone this
+	// preset to switch among the curated IDs in the TUI picker. Provider is the
 	// generic "nvidia" string routed through the kernel's OpenAI-compatible
 	// client via api_compat=openai + the explicit base_url. Text-only — no
 	// media generation; use `listen` for audio, `mcp-manual` for media.
@@ -1411,17 +1410,17 @@ func nvidiaPreset() Preset {
 	// with HTTP 400. See lingtai-kernel llm/_register.py.
 	return openAICompatNoVisionPreset(
 		"nvidia",
-		"NVIDIA NIM — free OpenAI-compatible catalog (Llama, Qwen, Kimi, GPT-OSS, ...), tool calls",
-		"meta/llama-3.3-70b-instruct", "NVIDIA_API_KEY", "https://integrate.api.nvidia.com/v1", "")
+		"NVIDIA NIM — bounded route-served stable agent snapshot, tool calls",
+		"nvidia/nemotron-3-ultra-550b-a55b", "NVIDIA_API_KEY", "https://integrate.api.nvidia.com/v1", "")
 }
 
 func openrouterPreset() Preset {
 	return Preset{
 		Name:        "openrouter",
-		Description: PresetDescription{Summary: "OpenRouter — gateway to DeepSeek, GLM, Qwen, MiniMax, Kimi, Claude, ..."},
+		Description: PresetDescription{Summary: "OpenRouter — GLM 5.3 gateway route (interactive, non-batch)"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				"provider": "openrouter", "model": "z-ai/glm-5.1",
+				"provider": "openrouter", "model": "z-ai/glm-5.3",
 				"api_key": nil, "api_key_env": "OPENROUTER_API_KEY",
 				"base_url": nil,
 			},

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -676,13 +676,19 @@ func TestBuiltinPresetRequestedDefaultModels(t *testing.T) {
 		preset    Preset
 		wantModel string
 	}{
+		{"minimax", minimaxPreset(), "MiniMax-M2.7"},
 		{"zhipu", zhipuPreset(), "GLM-5.2"},
+		{"mimo", mimoPreset(), "mimo-v2.5"},
 		{"deepseek", deepseekPreset(), "deepseek-v4-pro"},
 		{"gemini", geminiPreset(), "gemini-3.8-flash"},
+		{"kimi", kimiPreset(), "k3"},
+		{"grok", grokPreset(), "grok-4.5"},
 		{"nvidia", nvidiaPreset(), "nvidia/nemotron-3-ultra-550b-a55b"},
 		{"openrouter", openrouterPreset(), "z-ai/glm-5.3"},
 		{"codex", codexPreset(), "gpt-5.6-sol"},
 		{"codex-pool", codexPoolPreset(), "gpt-5.6-sol"},
+		{"claude", claudePreset(), "opus"},
+		{"custom", customPreset(), ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1013,7 +1019,7 @@ func TestMiniMaxPresetCapabilitiesUseApiKeyEnv(t *testing.T) {
 	if !ok {
 		t.Fatalf("manifest.capabilities missing or wrong type: %T", manifest["capabilities"])
 	}
-	for _, name := range []string{"web_search", "vision"} {
+	for _, name := range []string{"web_search"} {
 		capCfg, ok := caps[name].(map[string]interface{})
 		if !ok {
 			t.Fatalf("capability %s missing or wrong type: %T", name, caps[name])
@@ -1024,6 +1030,9 @@ func TestMiniMaxPresetCapabilitiesUseApiKeyEnv(t *testing.T) {
 		if env, _ := capCfg["api_key_env"].(string); env != "MINIMAX_API_KEY" {
 			t.Errorf("%s.api_key_env = %v, want MINIMAX_API_KEY", name, capCfg["api_key_env"])
 		}
+	}
+	if _, ok := caps["vision"]; ok {
+		t.Fatal("minimax native text preset must not expose stock vision")
 	}
 }
 

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -678,6 +678,9 @@ func TestBuiltinPresetRequestedDefaultModels(t *testing.T) {
 	}{
 		{"zhipu", zhipuPreset(), "GLM-5.2"},
 		{"deepseek", deepseekPreset(), "deepseek-v4-pro"},
+		{"gemini", geminiPreset(), "gemini-3.8-flash"},
+		{"nvidia", nvidiaPreset(), "nvidia/nemotron-3-ultra-550b-a55b"},
+		{"openrouter", openrouterPreset(), "z-ai/glm-5.3"},
 		{"codex", codexPreset(), "gpt-5.6-sol"},
 		{"codex-pool", codexPoolPreset(), "gpt-5.6-sol"},
 	}

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/claude/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/claude/SKILL.md
@@ -30,7 +30,7 @@ installed claude CLI's documented model-selection/help surface to see aliases
 that the local CLI serves, and verify an alias with its normal print-mode
 selection. Do not replace an alias with a dated API ID or inspect credential
 contents. CLI alias support and API model availability are distinct facts.
-The current Claude Code mapping is fable to claude-fable-5; the TUI still
+The current Claude Code mapping is fable to claude-fable-5-1; the TUI still
 stores the alias, not that full API identifier. Underlying CLI image support
 does not establish forwarding through LingTai's CLI adapter.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex-pool/SKILL.md
@@ -35,7 +35,8 @@ account.
 
 Start at codexPoolPreset in tui/internal/preset/preset.go. Keep
 providerModels["codex-pool"] exactly aligned with providerModels["codex"],
-including matching modelHasVision entries and the Codex four-level
+including gpt-5.6-sol, gpt-6-astra, gpt-5.6-terra, and gpt-5.6-luna in that
+default-first order, with matching modelHasVision entries and the Codex four-level
 codexThinkingOptions in tui/internal/tui/preset_editor.go. Recheck the
 constructor's vision, /codex endpoint, OAuth-only fields, and the pool store
 only when pool selection or file behavior is part of the change. Follow
@@ -71,7 +72,8 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
 route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current codex-pool values or pool data.
+update the picker and vision metadata while keeping the constructor/default at
+gpt-5.6-sol behind the exact-route availability gate; pool data is unchanged.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/codex/SKILL.md
@@ -41,9 +41,12 @@ base_url suffix, empty api_key_env, OAuth identity, and explicit xhigh default.
 Follow the Codex-specific checklist in tui/internal/tui/SKILL.md and the
 latest-two-generation rule in tui/CONTRACT.md.
 
-The current picker is gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, and gpt-5.5;
-older gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, and gpt-5.2 are not offered.
-Saved presets are not rewritten. To inspect live OAuth quota, complete the
+The picker is gpt-5.6-sol, gpt-6-astra, gpt-5.6-terra, and gpt-5.6-luna;
+gpt-5.5 and older gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, and gpt-5.2 are not
+offered. The constructor/default remains gpt-5.6-sol: public Astra
+documentation is positive, but exact authenticated OAuth-route availability
+is not, so the editor does not silently promote Astra. Saved presets are not
+rewritten. To inspect live OAuth quota, complete the
 app-server initialize handshake, send account/rateLimits/read with
 structurally `null` params, and optionally observe account/rateLimits/updated;
 read usedPercent, windowDurationMins, and resetsAt without exposing secrets.
@@ -55,7 +58,8 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
 route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current codex values.
+update the picker and vision metadata while keeping the constructor/default at
+gpt-5.6-sol behind the exact-route availability gate.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/deepseek/SKILL.md
@@ -32,7 +32,9 @@ there; do not use the native list as proof for Go. Preserve the route-specific
 credential and model spelling.
 
 The picker currently carries deepseek-v4-pro and deepseek-v4-flash, both
-modelHasVision false. OpenCode Go is scoped to DeepSeek IDs for this provider;
+modelHasVision false. The experimental deepseek-v4-flash-vision-exp entry is
+not part of the stock picker or vision contract. OpenCode Go is scoped to
+DeepSeek IDs for this provider;
 other Go models belong in Custom. The native API row and Go row select
 DEEPSEEK_API_KEY and OPENCODE_GO_API_KEY respectively; an edited native
 built-in receives a numbered DEEPSEEK_1_API_KEY-style slot.
@@ -53,7 +55,8 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
 route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current deepseek values.
+not change the current deepseek values; it records the experimental vision
+exclusion.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/gemini/SKILL.md
@@ -17,8 +17,9 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 Use this child for the named built-in gemini preset. geminiPreset in
 tui/internal/preset/preset.go:1332 uses Google's native gemini adapter,
-gemini-3-flash-preview, GEMINI_API_KEY, web_search, skills, and a native
-vision capability. It has no base_url or OpenAI-compatibility override.
+the stable gemini-3.8-flash default, GEMINI_API_KEY, web_search, skills, and a
+native vision capability. gemini-3-flash-preview was the previous preview
+default. It has no base_url or OpenAI-compatibility override.
 
 Native inline image input is distinct from the explicit LingTai `vision`
 capability; both use the shipped Gemini provider rather than a fallback.
@@ -51,8 +52,9 @@ Prepare an evidence-bound manifest and explicit input, then run
 lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|apply
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
-route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current gemini values.
+route bindings, and evidence and preserves unowned bytes. This amendment
+revises the constructor default to gemini-3.8-flash; the model remains free
+text and is intentionally absent from providerModels and modelHasVision.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/grok/SKILL.md
@@ -52,7 +52,8 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
 route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current grok values.
+record the evidence-bound no-op: Grok remains OpenCode Go-only at grok-4.5,
+with no product refresh to an unverified Go model or vision route.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md
@@ -16,7 +16,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 # kimi preset revision
 
 Use this child for the named built-in kimi preset. kimiPreset in
-tui/internal/preset/preset.go:1361 ships Kimi Code's kimi-for-coding,
+tui/internal/preset/preset.go:1361 ships Kimi Code's k3,
 KIMI_CODE_API_KEY, https://api.kimi.com/coding/v1, OpenAI compatibility,
 tool use, web_search, and skills; it has no built-in LingTai vision key.
 ProviderRegionURLs["kimi"] also exposes OpenCode Go and Custom.
@@ -26,25 +26,26 @@ ProviderRegionURLs["kimi"] also exposes OpenCode Go and Custom.
 Read the official [Kimi Code docs](https://www.kimi.com/code/docs/en/),
 [Kimi Code quickstart](https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart),
 and [provider configuration](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/providers.html).
-The native route uses the documented CLI/provider alias kimi-for-coding; use
-the provider's own current model surface, not a guessed dated API ID. OpenCode
-Go is a separate gateway: query its authenticated
+The native route's reviewed two-generation picker uses the exact IDs k3,
+k3-256k, kimi-for-coding, and kimi-for-coding-highspeed. OpenCode Go is a
+separate gateway: query its authenticated
 GET https://opencode.ai/zen/go/v1/models and preserve its lowercase IDs.
-Because Kimi's row is deliberately free text, a gateway catalog does not
-become a TUI picker or prove native-route support.
+The exact native route lookup makes only the Kimi Code row a picker; the Go
+row remains free text, so a gateway catalog cannot become a Go picker or
+prove native-route support. Moving from Kimi Code to Go clears a known native
+Kimi id; enter an explicit Go id before saving. Arbitrary typed Go values and
+Custom remain free text.
 OpenCode Go's documented examples include lowercase kimi-k3 and
 kimi-k2.7-code; check its live list rather than treating these examples as a
-permanent catalog. The native Kimi Code row remains the subscription alias
-kimi-for-coding.
+permanent catalog. Do not add Go IDs to the native picker or infer Go vision.
 
 ## TUI surfaces to revise
 
-Start at kimiPreset in tui/internal/preset/preset.go. Kimi deliberately has
-no providerModels or modelHasVision entry, so keep the model row free text
-unless a reviewed UX change says otherwise. Revise ProviderRegionURLs and
-ProviderDefaultEnv for Kimi Code/OpenCode Go/Custom endpoint and credential
-behavior, and recheck the constructor's absent vision capability. Relevant
-picker behavior is openInline's free-text model/base_url path in
+Start at kimiPreset in tui/internal/preset/preset.go. The provider-global
+catalog remains absent, while the exact Kimi Code route override supplies the
+native picker and k3 default. Keep OpenCode Go and Custom free text, preserve
+their endpoint/credential behavior, and recheck the constructor's absent
+vision capability. Relevant route lookup and editor behavior live in
 tui/internal/tui/preset_editor.go; follow tui/CONTRACT.md.
 
 ## Reviewed deterministic revision
@@ -53,8 +54,9 @@ Prepare an evidence-bound manifest and explicit input, then run
 lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|apply
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
-route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current kimi values.
+route bindings, and evidence and preserves unowned bytes. This amendment
+curates the native two-generation picker while preserving the Go free-text
+route and Custom behavior.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/mimo/SKILL.md
@@ -31,11 +31,12 @@ Do not infer vision from a name such as omni; verify image input on the exact
 model and route. Custom is user-supplied and has no provider-wide latest
 answer.
 
-The picker carries the latest two generations: mimo-v2.5 and its text-only
-mimo-v2.5-pro sibling, plus mimo-v2-pro and mimo-v2-omni. Only mimo-v2.5 has
-verified LingTai-side vision; modelHasVision records the other three false.
-All four are served by Xiaomi and OpenCode Go, but the wired vision service is
-scoped to Xiaomi's own endpoint. No official MiMo vision MCP is established.
+The native MiMo picker carries mimo-v2.5 and text-only mimo-v2.5-pro. The
+deprecated mimo-v2-pro and mimo-v2-omni entries are removed from native
+curation only. Native mimo-v2.5 retains the reviewed LingTai-side vision
+capability; no Go modality is inferred. OpenCode Go keeps its exact pre-PR
+picker — mimo-v2.5, mimo-v2.5-pro, mimo-v2-pro, and mimo-v2-omni — and prior
+behavior. No official MiMo vision MCP is established.
 
 ## TUI surfaces to revise
 
@@ -58,7 +59,8 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan and diagnostics, use dry-run/check
 before apply, and apply only to a new explicit output directory. revision.go
 validates hashes, route bindings, and evidence and preserves unowned bytes. This
-amendment does not change the current mimo values.
+amendment narrows native curation while preserving the OpenCode Go list and
+endpoint, credential, and capability behavior.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/minimax/SKILL.md
@@ -16,9 +16,10 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 # minimax preset revision
 
 Use this child for the named built-in minimax preset. Its current constructor
-is minimaxPreset in tui/internal/preset/preset.go:1248: it ships MiniMax-M3,
-MINIMAX_API_KEY, the CN Anthropic-compatible default, and native vision. The
-regional rows are ProviderRegionURLs["minimax"]: CN, INTL, and OpenCode Go.
+is minimaxPreset in tui/internal/preset/preset.go:1248: it ships MiniMax-M2.7,
+MINIMAX_API_KEY, the CN Anthropic-compatible default, and text/tool
+capabilities. The regional rows are ProviderRegionURLs["minimax"]: CN, INTL,
+and OpenCode Go.
 
 ## Template-specific settings
 
@@ -45,9 +46,12 @@ capability rendering only if the constructor's vision wiring changes. Follow
 the curation and retired-model rules in tui/internal/tui/SKILL.md and
 tui/CONTRACT.md.
 
-The current picker is MiniMax-M3 plus MiniMax-M2.7 and its -highspeed variant;
-the corresponding modelHasVision entries are true. M3 accepts image/video
-blocks natively on the selected endpoint. Retired M2.5/M2.1/M2 IDs remain
+The native CN picker is MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5,
+and MiniMax-M2.5-highspeed, all explicitly text-only for the reviewed
+Anthropic-compatible route. INTL remains free text because native parity is
+not proven. OpenCode Go keeps its exact pre-PR picker — MiniMax-M3,
+MiniMax-M2.7, and MiniMax-M2.7-highspeed — and its prior behavior; native
+modality metadata is not copied into that gateway route. Retired IDs remain
 valid only when already pinned in a saved preset.
 
 ## Reviewed deterministic revision
@@ -57,8 +61,9 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan and diagnostics, run dry-run/check
 before apply, and apply only to a new explicit output directory. The adapter
 reads only those paths; revision.go validates hashes, route bindings, and
-evidence and preserves unowned JSON bytes. This amendment does not change the
-current minimax values.
+evidence and preserves unowned JSON bytes. This amendment revises native CN
+curation while preserving the OpenCode Go route and all endpoint/credential
+semantics.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/nvidia/SKILL.md
@@ -16,8 +16,8 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 # nvidia preset revision
 
 Use this child for the named built-in nvidia preset. nvidiaPreset in
-tui/internal/preset/preset.go:1397 ships the NVIDIA gateway model
-meta/llama-3.3-70b-instruct, https://integrate.api.nvidia.com/v1,
+tui/internal/preset/preset.go:1397 ships the bounded NVIDIA gateway snapshot
+nvidia/nemotron-3-ultra-550b-a55b, https://integrate.api.nvidia.com/v1,
 NVIDIA_API_KEY, OpenAI compatibility, web_search, and skills; it has no
 default vision capability. This is a gateway catalog, not a single NVIDIA
 model family.
@@ -33,16 +33,19 @@ the gateway catalog does not automatically add this preset's vision key.
 Keep catalog slugs distinct from provider names and never copy a volatile
 catalog wholesale into the picker.
 
-The curated picker also carries qwen/qwen3-coder-480b-a35b-instruct,
-moonshotai/kimi-k2-thinking, openai/gpt-oss-120b, NVIDIA Nemotron, Mistral
-Nemotron, and Phi-4 entries. The kernel's nvidia registration disables
+The curated picker is exactly the reviewed stable snapshot: Nemotron Ultra,
+Nemotron Super/Nano Omni, DeepSeek v4 pro/flash gateway slugs, Kimi K3,
+MiniMax M3, Mistral Nemotron, GPT-OSS 20B, and the Nemotron Ultra 253B entry.
+This is not an all-model universal generation ladder. The kernel's nvidia registration disables
 prompt_cache_key because NIM rejects that OpenAI-only field.
 
 ## TUI surfaces to revise
 
 Start at nvidiaPreset in tui/internal/preset/preset.go. Revise
-providerModels["nvidia"] in tui/internal/tui/preset_editor.go for curated
-gateway slugs. Do not add modelHasVision entries unless the TUI constructor
+providerModels["nvidia"] in tui/internal/tui/preset_editor.go for the exact
+route-served snapshot. This target is unsupported by the universal
+two-generation JSON revision engine; maintain it as manual code curation. Do
+not add modelHasVision entries unless the TUI constructor
 also wires a verified vision route; recheck the constructor's absent vision
 capability and explicit base_url/env fields. Follow the gateway exemption and
 curation rules in tui/internal/tui/SKILL.md and tui/CONTRACT.md.
@@ -53,8 +56,9 @@ Prepare an evidence-bound manifest and explicit input, then run
 lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|apply
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
-route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current nvidia values.
+route bindings, and evidence and preserves unowned bytes. This amendment is
+unsupported for universal JSON generation; the constructor and exact picker
+are manual route-served curation with stock no vision.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/openrouter/SKILL.md
@@ -17,7 +17,7 @@ maintenance: "If you find stale or incorrect information here, use the lingtai-i
 
 Use this child for the named built-in openrouter preset. openrouterPreset in
 tui/internal/preset/preset.go:1418 ships gateway provider openrouter, model
-z-ai/glm-5.1, provider-resolved base_url, OPENROUTER_API_KEY, web_search,
+z-ai/glm-5.3, provider-resolved base_url, OPENROUTER_API_KEY, web_search,
 and skills; the stock manifest has no vision capability.
 
 The stock template is text-only. A saved preset that explicitly adds
@@ -51,8 +51,10 @@ Prepare an evidence-bound manifest and explicit input, then run
 lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|apply
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
-route bindings, and evidence and preserves unowned bytes. This amendment does
-not change the current openrouter values.
+route bindings, and evidence and preserves unowned bytes. This amendment
+revises the constructor default to z-ai/glm-5.3. GLM 5.3, 5.3 Flash, and 5.2
+remain documented choices only; batch variants are excluded from interactive
+use and no universal picker is introduced.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-preset-skill/reference/zhipu/SKILL.md
@@ -46,9 +46,12 @@ ProviderDefaultEnv in preset.go. Recheck the constructor's intentionally
 absent vision key and the model-row/base_url behavior; follow
 tui/internal/tui/SKILL.md and tui/CONTRACT.md.
 
-The picker carries uppercase GLM-5.2/GLM-5.1 for native rows and lowercase
-glm-5.2/glm-5.1 for OpenCode Go. The constructor's absent vision key is
-intentional: the shipped GLM coding models are text-only.
+The picker retains uppercase GLM-5.2/GLM-5.1 and lowercase glm-5.2/glm-5.1
+in one mixed list. This is an evidence-backed no-op: the reviewed sources do
+not pin a native Coding Plan GLM-5.3 ID or casing strongly enough to split the
+native and Go routes safely, so no native GLM-5.3 entry is invented. The
+constructor's absent vision key is intentional: the shipped GLM coding models
+are text-only.
 
 ## Reviewed deterministic revision
 
@@ -57,7 +60,8 @@ lingtai-tui presets revise --manifest PATH --input PATH --mode dry-run|check|app
 [--output-dir PATH]. Review the JSON plan, use dry-run/check before apply, and
 apply only to a new explicit output directory. revision.go validates hashes,
 route bindings, and evidence and preserves unowned JSON bytes. This amendment
-does not change the current zhipu values.
+records the native-picker no-op and preserves the current constructor, Go
+behavior, endpoint, credential, and capability values.
 
 Maintenance: If the relevant TUI preset/page is revised, check whether this sub-skill also needs revision and, if so, include it in the same PR.
 

--- a/tui/internal/tui/SKILL.md
+++ b/tui/internal/tui/SKILL.md
@@ -1,10 +1,17 @@
 # SKILL.md — Preset model lists & provider integration
 
-Bookkeeping notes for keeping `providerModels`, `modelHasVision`, and friends in `preset_editor.go` aligned with each provider's real-world catalog. Read this **before** editing those maps so you don't bork an agent network with a typo or a retired model.
+Bookkeeping notes for keeping `providerModels`, route-specific model lookup,
+`modelHasVision`, and friends in `preset_editor.go` aligned with each
+provider's real-world catalog. Read this **before** editing those maps so you
+don't bork an agent network with a typo or a retired model.
 
 ## What this file is for
 
-Each LLM provider in `providerModels` (preset_editor.go:108) feeds a model picker on the preset editor's model row. When a user clones a template and cycles ←/→ on the model row, the candidates come straight from this map. The map is the source of truth.
+`providerModels` (preset_editor.go:108) is the canonical native/default-route
+catalog. Every model picker, display, and free-text decision calls
+`modelOptions(provider, base_url)`: exact route overrides keep a proven native
+catalog separate from a protected gateway catalog, while an uncurated route
+remains free text. The lookup is the source of truth for editor behavior.
 
 Drift here causes one of two failures:
 
@@ -17,14 +24,18 @@ The second failure mode is what this file exists to prevent.
 
 | Provider | Canonical list | Cadence | Notes |
 |---|---|---|---|
-| `minimax` | https://platform.minimaxi.com/document/Models | Quarterly | M-series, current = M3 |
-| `zhipu` | https://docs.bigmodel.cn/cn/guide/models | Quarterly | GLM-5.x family; OpenCode Go takes the same ids lowercased |
-| `mimo` | https://www.xiaomi-ai.com/cn/models | Quarterly | Xiaomi MiMo |
+| `minimax` | https://platform.minimaxi.com/document/Models | Quarterly | Native CN M-series, current = M2.7; Go keeps its protected pre-PR list |
+| `zhipu` | https://docs.bigmodel.cn/cn/guide/models | Quarterly | GLM-5.x family; mixed case list retained until exact native/Go evidence is pinned |
+| `mimo` | https://www.xiaomi-ai.com/cn/models | Quarterly | Native V2.5 curation; Go keeps its protected pre-PR list |
 | `deepseek` | https://api-docs.deepseek.com/quick_start/pricing | Quarterly | DS-V4 family |
 | `grok` | https://opencode.ai/docs/go/ | Monthly | reached only through OpenCode Go; no native xAI route is shipped |
 | `codex` | https://developers.openai.com/codex/models | Monthly | ChatGPT-OAuth only — not the standard OpenAI API list |
 
-`kimi` is deliberately absent from `providerModels`: its model row stays free text so a typed Moonshot id survives a `→`. Its OpenCode Go ids are documented in `internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md` instead.
+`kimi` is deliberately absent from provider-global `providerModels`: the exact
+Kimi Code route has a native override picker for `k3`, `k3-256k`,
+`kimi-for-coding`, and `kimi-for-coding-highspeed`, while OpenCode Go and Custom
+remain free text so typed gateway ids survive a `→`. Its route boundaries are
+documented in `internal/preset/skills/lingtai-preset-skill/reference/kimi/SKILL.md`.
 
 For codex specifically, **do not** consult `https://platform.openai.com/docs/models`. That's the standard API model list, which includes models the codex backend (`chatgpt.com/backend-api/codex/responses`) doesn't accept (e.g. `gpt-5.5-pro` exists in the standard API but 4xx's on the codex endpoint).
 
@@ -32,29 +43,44 @@ For codex specifically, **do not** consult `https://platform.openai.com/docs/mod
 
 **Rule 0 — latest two generations only.** `tui/CONTRACT.md` ("Model list curation") caps every family at its latest two generations. Adding a new generation is the same change that removes the third-newest. Variants inside a generation (`-highspeed`, `-pro`, `-mini`, the `gpt-5.6-sol/-terra/-luna` routes, a lowercase respelling for another endpoint) are not generations and all stay. Read that section before touching the maps; the checklist below decides inclusion *within* the two generations the rule allows.
 
+The native/default catalog is not automatically valid for every route. Keep a
+route override only when the exact endpoint is evidenced; an unlisted route
+must remain free text. The MiniMax and MiMo OpenCode Go overrides are locked
+pre-PR compatibility lists. On a route change, reconcile only values already
+known to a curated route: keep a value accepted by the destination, otherwise
+use its first preserved picker option. Never overwrite arbitrary off-list text.
+Kimi Go has no picker, so a known native Kimi id is cleared and must be replaced
+through the existing free-text model edit before save. Route-only IDs do not
+gain a global `modelHasVision` claim.
+
 For each candidate model, decide inclusion against this checklist:
 
 1. **Is it served on our endpoint?** Codex uses `/backend-api/codex/responses`. If a model is listed in OpenAI's general API docs but not in the Codex docs page above, **exclude it**. Same logic for any other provider where we use a non-standard endpoint.
 2. **Is it stable, not preview/research?** Skip "Research Preview" / "Beta" tiers — they get yanked without notice and our list rots. Example: `gpt-5.3-codex-spark` is currently a Research Preview, so it's omitted.
 3. **Is its vision capability documented?** Visit the model's page, find the "Modalities" / "Input" section, record `true`/`false` in `modelHasVision`. Don't guess — `gpt-5.3-codex` accepts images, which surprised us.
-4. **Will it 401 on a free tier?** Some models (`gpt-5.5` for codex) require ChatGPT Plus or higher. We still list them — the user discovers their tier on first use rather than the picker hiding the option. But mention any subscription gate in the comment next to the entry.
+4. **Will it 401 on a free tier or rollout gate?** `gpt-6-astra` is
+   documented, but exact authenticated Codex OAuth availability is not proven
+   for every account. Keep it picker-visible with metadata, retain
+   `gpt-5.6-sol` as the default-first/native default, and mention the gate
+   beside the entry. Do not silently promote it.
 
 ## Why some models you might expect are missing
 
 - **`gpt-5.5-pro`** — exists in OpenAI's standard API at `/api/docs/models/gpt-5.5-pro` ($30/$180 per 1M tokens), is available in ChatGPT for Pro/Business/Enterprise, but **is not listed under Codex models**. Adding it would cause 4xx on the codex endpoint. Excluded.
 - **`gpt-5.3-codex-spark`** — Research Preview as of 2026-05. Excluded until promoted to GA.
-- **`o3-pro` / `o4-mini` / older o-series** — none are in the Codex CLI catalog. Codex serves the GPT-5.x line only.
+- **`o3-pro` / `o4-mini` / older o-series** — none are in the Codex CLI catalog. Codex serves the documented GPT-6/GPT-5.6 line here.
 
 ## When you add a new model
 
 ```go
 // In providerModels:
-"codex": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", ...}, // default first
+"codex": {"gpt-5.6-sol", "gpt-6-astra", "gpt-5.6-terra", "gpt-5.6-luna"}, // default first; Astra availability-gated
 
 // In modelHasVision:
 "gpt-5.6-sol":   true, // keep named routes aligned with the verified GPT-5.6 family
 "gpt-5.6-terra": true,
 "gpt-5.6-luna":  true,
+"gpt-6-astra":   true, // docs metadata only; exact OAuth availability is not implied
 ```
 
 Order matters in `providerModels` only for the picker UX — left-to-right is the cycle order with ←/→. Putting the desired default first keeps fresh templates and the picker aligned. The `templates/codex.json` (built from `preset.go:codexPreset()`) should also have its `llm.model` bumped when you change that default. Existing saved presets keep whatever model they already declared — that's a feature, not a bug.

--- a/tui/internal/tui/e2e_opencode_go_test.go
+++ b/tui/internal/tui/e2e_opencode_go_test.go
@@ -142,6 +142,22 @@ func TestE2EOpenCodeGoOptionSurvivesSave(t *testing.T) {
 			if got := asString(m.llmMap()["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
 				t.Fatalf("[%s] working api_key_env = %q, want OPENCODE_GO_API_KEY", provider, got)
 			}
+			if provider == "kimi" {
+				if got := asString(m.llmMap()["model"]); got != "" {
+					t.Fatalf("[kimi] native model carried onto OpenCode Go = %q, want an explicit empty-model edit gate", got)
+				}
+				m.cursor = editorFieldOrderIndex(t, feModel)
+				opened, _ := m.openInline()
+				if opened.mode != emInline {
+					t.Fatalf("[kimi] OpenCode Go model row mode = %v, want emInline", opened.mode)
+				}
+				opened.input.SetValue("kimi-k3")
+				opened, _ = pressKey(t, opened, tea.KeyEnter)
+				if opened.mode != emBrowse {
+					t.Fatalf("[kimi] Enter did not finish the model edit; mode = %v", opened.mode)
+				}
+				m = opened
+			}
 
 			// Tab + Enter: the real save gate.
 			msg := saveViaKeyboard(t, m)
@@ -154,6 +170,11 @@ func TestE2EOpenCodeGoOptionSurvivesSave(t *testing.T) {
 			llm := committedLLM(t, msg.Preset)
 			if got := asString(llm["base_url"]); got != openCodeGoURL {
 				t.Fatalf("[%s] committed base_url = %q, want %q", provider, got, openCodeGoURL)
+			}
+			if provider == "kimi" {
+				if got := asString(llm["model"]); got != "kimi-k3" {
+					t.Fatalf("[kimi] committed OpenCode Go model = %q, want kimi-k3", got)
+				}
 			}
 			if got := asString(llm["api_key_env"]); got != "OPENCODE_GO_API_KEY" {
 				t.Fatalf("[%s] committed api_key_env = %q, want OPENCODE_GO_API_KEY (the option's whole point)", provider, got)

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -90,11 +90,10 @@ const (
 	emExitPrompt                    // three-way exit on Esc: save / discard / cancel
 )
 
-// providerModels maps a provider name to the canonical model lineup the
-// editor cycles through with ←/→ on the model row. Providers absent from
-// this map fall back to free-text inline edit on Enter — this lets
-// openrouter/custom/codex users type any model id, while built-in
-// providers with a known catalog get a guided picker.
+// providerModels maps a provider name to the canonical native/default-route
+// model lineup the editor cycles through with ←/→ on the model row. Exact
+// route catalogs that differ from this default live in routeModelOverrides
+// below; providers and routes without a matching catalog remain free text.
 //
 // Keep this in sync with each provider's official model list. When a
 // new flagship ships, add it (and remove deprecated entries — agents
@@ -107,12 +106,12 @@ const (
 // separate generations and all stay. See tui/internal/tui/SKILL.md for the
 // per-provider source list and the rest of the inclusion checklist.
 var providerModels = map[string][]string{
-	// MiniMax: official supported LLM model IDs (API Overview), newest first.
-	// Latest two generations: M3 (flagship/default) and M2.7 with its
-	// -highspeed variant. M2.5/M2.1/M2 are retired from the picker.
+	// MiniMax native CN: the latest two documented native text generations,
+	// newest first. OpenCode Go keeps its pre-PR catalog in the exact route
+	// override below; INTL remains free text until parity is proven.
 	"minimax": {
-		"MiniMax-M3",
 		"MiniMax-M2.7", "MiniMax-M2.7-highspeed",
+		"MiniMax-M2.5", "MiniMax-M2.5-highspeed",
 	},
 	// Zhipu — two mutually exclusive id sets in one cycle, because the model
 	// row is not coupled to the selected base_url row (known debt):
@@ -128,21 +127,13 @@ var providerModels = map[string][]string{
 		// OpenCode Go
 		"glm-5.2", "glm-5.1",
 	},
-	// kimi deliberately has NO entry. Adding one would flip the model row from
-	// free text to picker-only (see openInline's feModel case), and cycleString
-	// lands an off-list value on entry [0] — one → would silently overwrite a
-	// saved `kimi-latest` / `moonshot-v1-*` / `kimi-k3` id with no undo. The
-	// Moonshot catalog is far wider than any list we can verify, so kimi keeps
-	// the free-text row it had before it gained a region table. The OpenCode Go
-	// ids to type are documented in reference/kimi/SKILL.md.
+	// Kimi has no provider-global entry: its exact native Coding Plan route
+	// gets a picker from routeModelOverrides, while OpenCode Go and Custom stay
+	// free text so their distinct spellings and user values remain editable.
 	//
-	// MiMo: the latest TWO generations, per the curation rule — v2.5 (with
-	// its text-only -pro variant) and v2 (-pro, -omni). All four are served by
-	// Xiaomi's endpoint AND by OpenCode Go, so the picker is valid on either
-	// base_url row. The rule caps at two generations; it is not a floor, so v2
-	// stays until a generation newer than v2.5 ships and displaces it. The
-	// retired V2 Flash ids and anything older are not shipped.
-	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"},
+	// MiMo native: V2.5 and its text-only Pro variant. Deprecated V2 entries
+	// are retained only in the protected pre-PR OpenCode Go override below.
+	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro"},
 	"deepseek": {"deepseek-v4-pro", "deepseek-v4-flash"},
 	// Grok (xAI) via OpenCode Go — the Go /models list serves grok-4.5 and
 	// nothing older that we have verified.
@@ -169,26 +160,100 @@ var providerModels = map[string][]string{
 	// enables them. See SKILL.md next to this file for the canonical source list
 	// and why each model is included or excluded (e.g. pro-only variants can 4xx).
 	//
-	// Latest two generations of the GPT-5.x ladder: 5.6 (its three named
-	// routes are variants of one generation, not three generations) and 5.5.
-	// gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex / gpt-5.2 are older generations
-	// and are no longer offered; a saved preset pinned to one keeps working —
-	// we never rewrite saved/ (see SKILL.md, "When you remove a retired model").
-	"codex": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"},
+	// GPT-6 Astra is documented but not proven available on every authenticated
+	// OAuth route, so keep the proven gpt-5.6-sol default first. The named
+	// GPT-5.6 routes are variants of one generation; gpt-5.5 is retired from
+	// this latest-two curation. Saved presets are never rewritten.
+	"codex": {"gpt-5.6-sol", "gpt-6-astra", "gpt-5.6-terra", "gpt-5.6-luna"},
 	// codex-pool serves the same ChatGPT-OAuth models as codex — it only
 	// changes which token file each request routes through (the pool), not the
 	// model catalog. Keep the two lists identical.
-	"codex-pool": {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"},
+	"codex-pool": {"gpt-5.6-sol", "gpt-6-astra", "gpt-5.6-terra", "gpt-5.6-luna"},
 	// Claude Code uses CLI aliases, not dated API IDs — `opus`/`fable`/
 	// `sonnet`/`haiku` name concurrent tiers of one generation, so the
 	// two-generation rule has nothing to trim here. Current Claude Code
-	// resolves fable to claude-fable-5. Keep the old provider spellings only
+	// resolves fable to claude-fable-5-1. Keep the old provider spellings only
 	// so user-saved presets remain editable after the built-in moves to
 	// canonical provider "claude-code".
 	"claude-code":      {"opus", "fable", "sonnet", "haiku"},
 	"claude_code":      {"opus", "fable", "sonnet", "haiku"},
 	"claude-agent-sdk": {"opus", "fable", "sonnet", "haiku"},
 	"claude_agent_sdk": {"opus", "fable", "sonnet", "haiku"},
+}
+
+// routeModelOverrides contains the few exact route catalogs needed to keep
+// native curation separate from the protected OpenCode Go behavior. A
+// provider with an override returns no catalog for an unlisted route, which
+// deliberately leaves that route free text.
+var routeModelOverrides = map[string]map[string][]string{
+	"minimax": {
+		preset.ProviderRegionURLs["minimax"][0].URL: {"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"},
+		preset.ProviderRegionURLs["minimax"][2].URL: {"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"},
+	},
+	"mimo": {
+		preset.ProviderRegionURLs["mimo"][0].URL: {"mimo-v2.5", "mimo-v2.5-pro"},
+		preset.ProviderRegionURLs["mimo"][1].URL: {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"},
+	},
+	"kimi": {
+		preset.ProviderRegionURLs["kimi"][0].URL: {"k3", "k3-256k", "kimi-for-coding", "kimi-for-coding-highspeed"},
+	},
+}
+
+// modelOptions is the single catalog lookup used by every model picker
+// surface. Providers without route overrides use their canonical map; a
+// provider with overrides returns only the exact route entry.
+func modelOptions(provider, baseURL string) []string {
+	if routes, ok := routeModelOverrides[provider]; ok {
+		return routes[baseURL]
+	}
+	return providerModels[provider]
+}
+
+// reconcileModelForRoute keeps a known curated model valid when the user moves
+// between exact routes without overwriting arbitrary free text. A protected Go
+// picker receives its existing first entry when a model curated only for a
+// different route cannot run there. Kimi's Go route deliberately remains free
+// text, so a known native Kimi id is cleared and the existing non-empty-model
+// save validation requires the user to enter an explicit Go id.
+func reconcileModelForRoute(provider, baseURL, model string) string {
+	contains := func(models []string, candidate string) bool {
+		for _, option := range models {
+			if option == candidate {
+				return true
+			}
+		}
+		return false
+	}
+
+	destination := modelOptions(provider, baseURL)
+	if contains(destination, model) {
+		return model
+	}
+	routes, ok := routeModelOverrides[provider]
+	if !ok {
+		return model
+	}
+	known := false
+	for _, models := range routes {
+		if contains(models, model) {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return model
+	}
+	if len(destination) > 0 {
+		return destination[0]
+	}
+	if provider == "kimi" {
+		for _, region := range preset.ProviderRegionURLs[provider] {
+			if region.Label == "OpenCode Go" && region.URL == baseURL {
+				return ""
+			}
+		}
+	}
+	return model
 }
 
 var codexServiceTierOptions = []string{"normal", "fast"}
@@ -218,18 +283,21 @@ const presetEditorFieldLabelWidth = 18
 // per-model vision support is still a real fact worth asserting against
 // regressions in providerModels/the model catalog above.
 //
-// One entry per id in providerModels — a shipped model with no entry here
-// reads as text-only via Go's zero value, which is an omission, not a
-// declaration. Ids retired by the two-generation curation rule are removed
+// One entry per id in providerModels — a shipped native/default-route model
+// with no entry here reads as text-only via Go's zero value, which is an
+// omission, not a declaration. Route-only overrides intentionally do not add
+// global capability claims: OpenCode Go modality is not inferred from native
+// route metadata. Ids retired by the two-generation curation rule are removed
 // from both maps together (tui/internal/tui/SKILL.md, "When you remove a
 // retired model").
 var modelHasVision = map[string]bool{
-	// MiniMax: keyed to the official supported LLM model IDs. Both shipped
-	// generations are multimodal — M3 (current flagship) and the M2.7
-	// variants, which prior code treated as image-capable.
-	"MiniMax-M3":             true,
-	"MiniMax-M2.7":           true,
-	"MiniMax-M2.7-highspeed": true,
+	// MiniMax native CN's reviewed Anthropic text route rejects image/document
+	// input, so the curated native IDs are explicitly text-only. The protected
+	// OpenCode Go IDs have no inherited native modality claim.
+	"MiniMax-M2.7":           false,
+	"MiniMax-M2.7-highspeed": false,
+	"MiniMax-M2.5":           false,
+	"MiniMax-M2.5-highspeed": false,
 	// Zhipu coding-plan LLMs are text-only, in both the uppercase native
 	// spelling and the lowercase OpenCode Go spelling of the same model.
 	// Vision uses the separate GLM-4.6V model through the optional,
@@ -238,17 +306,11 @@ var modelHasVision = map[string]bool{
 	"GLM-5.1": false,
 	"glm-5.2": false,
 	"glm-5.1": false,
-	// MiMo: only the default has a verified image route. The -pro siblings are
-	// text-only, and mimo-v2-omni is a declared false rather than an
-	// omission — "omni" in a model name is not evidence of a wired vision
-	// route, and the previous generation's image mapping was never pinned
-	// here. All four are served on Xiaomi's endpoint and on OpenCode Go, and
-	// the Go route re-verifies none of them — the LingTai-side vision wiring
-	// in mimoPreset() is scoped to mimo-v2.5 on Xiaomi's own endpoint.
+	// MiMo: only native mimo-v2.5 has verified LingTai-side vision. The
+	// native Pro sibling is text-only; the protected Go list is not granted
+	// any additional modality claim.
 	"mimo-v2.5":     true,
 	"mimo-v2.5-pro": false,
-	"mimo-v2-pro":   false,
-	"mimo-v2-omni":  false,
 	// DeepSeek: text-only across the board.
 	"deepseek-v4-pro":   false,
 	"deepseek-v4-flash": false,
@@ -256,9 +318,11 @@ var modelHasVision = map[string]bool{
 	// is unverified, so this is a declared false, not an unknown. A model
 	// name is never evidence of a wired vision route.
 	"grok-4.5": false,
-	// Codex (ChatGPT OAuth): the whole shipped GPT-5.x lineup accepts images.
-	// Verify on each model's docs page when adding new entries; see SKILL.md.
-	"gpt-5.5":       true,
+	// Codex (ChatGPT OAuth): official model documentation records image input
+	// for the named routes, but this metadata does not assert account-specific
+	// OAuth availability. Astra therefore remains picker-only until that gate
+	// is satisfied for a given account.
+	"gpt-6-astra":   true,
 	"gpt-5.6-sol":   true,
 	"gpt-5.6-terra": true,
 	"gpt-5.6-luna":  true,
@@ -675,12 +739,9 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 		m.input.Focus()
 		m.mode = emInline
 	case feModel:
-		// Built-in providers with a known model lineup get the picker
-		// (Enter cycles, like for feProvider/feAPICompat). Free-text
-		// providers (custom, openrouter, codex) fall through to inline
-		// edit so the user can type any model id.
 		provider := asString(m.llmMap()["provider"])
-		if _, hasPicker := providerModels[provider]; hasPicker {
+		baseURL := asString(m.llmMap()["base_url"])
+		if models := modelOptions(provider, baseURL); len(models) > 0 {
 			m.cycleFocused(+1)
 		} else {
 			m.input.SetValue(m.fieldString(f))
@@ -1120,9 +1181,13 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		normalizeThinking(m.working.Manifest)
 		// Reset model to the new provider's first canonical entry when the
 		// current model isn't valid for the new provider. Without this, a
-		// minimax→zhipu switch leaves "MiniMax-M3" in model
+		// minimax→zhipu switch leaves "MiniMax-M2.7" in model
 		// and validation passes silently while the kernel later 4xxs.
-		if models, ok := providerModels[newProvider]; ok && len(models) > 0 {
+		baseURL := ""
+		if regions, ok := preset.ProviderRegionURLs[newProvider]; ok && len(regions) > 0 {
+			baseURL = regions[0].URL
+		}
+		if models := modelOptions(newProvider, baseURL); len(models) > 0 {
 			currentModel := asString(m.llmMap()["model"])
 			modelStillValid := false
 			for _, mdl := range models {
@@ -1175,11 +1240,9 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		}
 		m.regionEnvBeforeAdopt = ""
 	case feModel:
-		// If the current provider has a known model lineup, cycle through
-		// it. Otherwise no-op — Enter on free-text providers (custom,
-		// openrouter, codex) opens inline edit instead via openInline.
 		provider := asString(m.llmMap()["provider"])
-		if models, ok := providerModels[provider]; ok && len(models) > 0 {
+		baseURL := asString(m.llmMap()["base_url"])
+		if models := modelOptions(provider, baseURL); len(models) > 0 {
 			next := cycleString(models, m.fieldString(f), dir)
 			m.llmMap()["model"] = next
 		}
@@ -1219,6 +1282,8 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 				m.llmMap()["base_url"] = ""
 				break
 			}
+			currentModel := asString(m.llmMap()["model"])
+			m.llmMap()["model"] = reconcileModelForRoute(provider, next.URL, currentModel)
 			m.llmMap()["base_url"] = next.URL
 			// Region options can carry an implied credential env-var (e.g.
 			// DeepSeek API -> DEEPSEEK_API_KEY, OpenCode Go ->
@@ -1790,13 +1855,14 @@ func (m PresetEditorModel) capabilitiesGuidanceRow(width int) string {
 }
 
 // modelRadioStrip renders the model field as a horizontal radio strip
-// (● selected ○ unselected) when the current provider has a known
-// model lineup in providerModels. Returns "" when there's no picker —
-// caller falls back to the standard single-value render.
+// (● selected ○ unselected) when the current provider+route has a known
+// model lineup. Returns "" when there's no picker — caller falls back to the
+// standard single-value render.
 func (m PresetEditorModel) modelRadioStrip(focused bool, valStyle lipgloss.Style) string {
 	provider := asString(m.llmMap()["provider"])
-	models, ok := providerModels[provider]
-	if !ok || len(models) == 0 {
+	baseURL := asString(m.llmMap()["base_url"])
+	models := modelOptions(provider, baseURL)
+	if len(models) == 0 {
 		return ""
 	}
 	current := asString(m.llmMap()["model"])
@@ -1947,9 +2013,8 @@ func (m PresetEditorModel) responsesTransportRadioStrip(focused bool, valStyle l
 }
 
 // isCyclable reports whether a field accepts ←/→ to step through enum
-// values. The model row is conditional — only when the current provider
-// has a known model lineup. Free-text providers leave the model row as
-// inline-edit-only and we shouldn't suggest cycling.
+// values. The model row is conditional on the current provider+route having
+// a known model lineup; uncurated routes remain inline-edit-only.
 func (m PresetEditorModel) isCyclable(f editorField) bool {
 	switch f {
 	case feProvider, feAPICompat, feTier:
@@ -1968,8 +2033,8 @@ func (m PresetEditorModel) isCyclable(f editorField) bool {
 		return m.isCodexProvider() && len(m.codexAccountRefs()) > 1
 	case feModel:
 		provider := asString(m.llmMap()["provider"])
-		_, hasPicker := providerModels[provider]
-		return hasPicker
+		baseURL := asString(m.llmMap()["base_url"])
+		return len(modelOptions(provider, baseURL)) > 0
 	case feBaseURL:
 		provider := asString(m.llmMap()["provider"])
 		_, hasRegions := preset.ProviderRegionURLs[provider]

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -147,21 +147,21 @@ var providerModels = map[string][]string{
 	// Grok (xAI) via OpenCode Go — the Go /models list serves grok-4.5 and
 	// nothing older that we have verified.
 	"grok": {"grok-4.5"},
-	// NVIDIA NIM catalog IDs (build.nvidia.com) served on the free tier.
-	// Default flagship first; the rest are popular open-weight options.
-	// Users can also free-text any other catalog ID on this row.
-	// Already compliant with the two-generation rule: the only family with
-	// more than one entry is meta/llama (3.3 and 3.1, the two shipped
-	// generations); every other vendor contributes a single current id.
+	// NVIDIA uses a bounded snapshot of stable model IDs verified as served by
+	// the configured route. It is not a universal NVIDIA generation ladder;
+	// keep the default flagship first and update the snapshot only from fresh
+	// route evidence.
 	"nvidia": {
-		"meta/llama-3.3-70b-instruct",
-		"meta/llama-3.1-70b-instruct",
-		"qwen/qwen3-coder-480b-a35b-instruct",
-		"moonshotai/kimi-k2-thinking",
-		"openai/gpt-oss-120b",
-		"nvidia/llama-3.1-nemotron-ultra-253b-v1",
+		"nvidia/nemotron-3-ultra-550b-a55b",
+		"nvidia/nemotron-3-super-120b-a12b",
+		"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+		"deepseek-ai/deepseek-v4-pro-0813",
+		"deepseek-ai/deepseek-v4-flash-0731",
+		"moonshotai/kimi-k3",
+		"minimaxai/minimax-m3",
 		"mistralai/mistral-nemotron",
-		"microsoft/phi-4-mini-instruct",
+		"openai/gpt-oss-20b",
+		"nvidia/llama-3.1-nemotron-ultra-253b-v1",
 	},
 	// Codex: ChatGPT-OAuth-only models served by chatgpt.com/backend-api/codex.
 	// Keep gpt-5.6-sol first to match the TUI default; the other named GPT-5.6

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -122,29 +122,31 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	if got := providerModels["zhipu"]; !reflect.DeepEqual(got, wantZhipuModels) {
 		t.Fatalf("zhipu provider models = %#v, want %#v", got, wantZhipuModels)
 	}
-	// Latest two MiniMax generations: M3 and M2.7 (+ its -highspeed variant,
-	// which is not a separate generation).
-	wantMiniMaxModels := []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"}
+	// Native CN MiniMax generations: M2.7 and M2.5, with their highspeed
+	// variants. OpenCode Go keeps the protected pre-PR list below.
+	wantMiniMaxModels := []string{"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"}
 	if got := providerModels["minimax"]; !reflect.DeepEqual(got, wantMiniMaxModels) {
 		t.Fatalf("minimax provider models = %#v, want %#v", got, wantMiniMaxModels)
 	}
-	// MiMo ships the latest TWO generations: v2.5 (+ its text-only -pro
-	// variant) and v2 (-pro, -omni). All four are served by Xiaomi's endpoint
-	// AND by OpenCode Go, so the picker is valid on either base_url row. The
-	// curation rule caps at two generations and does not require trimming to
-	// one, so v2 stays until something newer than v2.5 displaces it.
-	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"}
+	for _, model := range wantMiniMaxModels {
+		if modelHasVision[model] {
+			t.Fatalf("MiniMax native text model %s must remain text-only", model)
+		}
+	}
+	// Native MiMo curation keeps V2.5 and its text-only Pro variant. The
+	// deprecated V2 entries remain only on the protected OpenCode Go route.
+	wantMiMoModels := []string{"mimo-v2.5", "mimo-v2.5-pro"}
 	if got := providerModels["mimo"]; !reflect.DeepEqual(got, wantMiMoModels) {
 		t.Fatalf("mimo provider models = %#v, want %#v", got, wantMiMoModels)
 	}
 	if got := providerModels["grok"]; !reflect.DeepEqual(got, []string{"grok-4.5"}) {
 		t.Fatalf("grok provider models = %#v, want [grok-4.5]", got)
 	}
-	// kimi must NOT gain a picker: an entry here flips its model row from
-	// free text to picker-only, and one → then overwrites a typed off-list
-	// Moonshot id (kimi-latest, moonshot-v1-*) with entry [0], unrecoverably.
-	if models, ok := providerModels["kimi"]; ok {
-		t.Fatalf("kimi must keep a free-text model row, got picker %#v", models)
+	// Kimi must NOT gain a provider-global picker: only the exact native
+	// Kimi Code route is curated, while OpenCode Go and Custom stay free text
+	// so a typed off-list gateway or proxy id remains editable.
+	if models := providerModels["kimi"]; models != nil {
+		t.Fatalf("kimi must keep no provider-global model row, got %#v", models)
 	}
 	wantClaudeModels := []string{"opus", "fable", "sonnet", "haiku"}
 	if got := providerModels["claude-code"]; !reflect.DeepEqual(got, wantClaudeModels) {
@@ -168,7 +170,7 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	if !modelHasVision["mimo-v2.5"] {
 		t.Fatal("MiMo picker must keep native vision for mimo-v2.5")
 	}
-	for _, model := range []string{"mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"} {
+	for _, model := range []string{"mimo-v2.5-pro"} {
 		if modelHasVision[model] {
 			t.Fatalf("MiMo %s has no verified image route; it must stay text-only (a name is not evidence)", model)
 		}
@@ -182,11 +184,11 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 		t.Fatal("grok-4.5 has no verified image-input route on OpenCode Go; it must stay text-only")
 	}
 
-	// Latest two GPT-5.x generations: 5.6 (three named routes of one
-	// generation) and 5.5. codex-pool changes account selection, not the
-	// catalog, so the two lists stay identical.
+	// GPT-6 Astra is documented but account/client rollout is not proven, so
+	// Sol remains the default-first entry. The named GPT-5.6 routes are one
+	// generation's variants; codex-pool changes account selection only.
 	wantCodexModels := []string{
-		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5",
+		"gpt-5.6-sol", "gpt-6-astra", "gpt-5.6-terra", "gpt-5.6-luna",
 	}
 	for _, provider := range []string{"codex", "codex-pool"} {
 		models := providerModels[provider]
@@ -196,18 +198,236 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	}
 	for _, model := range wantCodexModels {
 		if !modelHasVision[model] {
-			t.Fatalf("%s should be treated as vision-capable like the rest of the GPT-5.x Codex lineup", model)
+			t.Fatalf("%s should be treated as vision-capable like the documented Codex lineup", model)
 		}
 	}
 }
 
-// TestModelHasVisionDeclaresEveryShippedModel is the F8 contract: a shipped
-// model that is absent from modelHasVision reads as text-only through Go's
-// zero value, which is an omission rather than a declaration. `mimo-v2-omni`
-// was the case that made this matter — a name that suggests multimodality
-// with nothing in the map pushing back. Every id the picker can reach must
-// have an explicit entry, and the map must not accumulate entries for models
-// the two-generation curation rule has retired.
+func TestPresetEditorModelCatalogsAreExactByRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		label    string
+		want     []string
+		freeText bool
+	}{
+		{
+			name:     "minimax native CN",
+			provider: "minimax",
+			label:    "CN",
+			want:     []string{"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"},
+		},
+		{
+			name:     "minimax OpenCode Go protected list",
+			provider: "minimax",
+			label:    "OpenCode Go",
+			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"},
+		},
+		{
+			name:     "minimax INTL remains free text",
+			provider: "minimax",
+			label:    "INTL",
+			freeText: true,
+		},
+		{
+			name:     "mimo native",
+			provider: "mimo",
+			label:    "MiMo",
+			want:     []string{"mimo-v2.5", "mimo-v2.5-pro"},
+		},
+		{
+			name:     "mimo OpenCode Go protected list",
+			provider: "mimo",
+			label:    "OpenCode Go",
+			want:     []string{"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni"},
+		},
+		{
+			name:     "mimo Custom remains free text",
+			provider: "mimo",
+			label:    "Custom",
+			freeText: true,
+		},
+		{
+			name:     "kimi native",
+			provider: "kimi",
+			label:    "Kimi Code",
+			want:     []string{"k3", "k3-256k", "kimi-for-coding", "kimi-for-coding-highspeed"},
+		},
+		{
+			name:     "kimi OpenCode Go remains free text",
+			provider: "kimi",
+			label:    "OpenCode Go",
+			freeText: true,
+		},
+		{
+			name:     "kimi Custom remains free text",
+			provider: "kimi",
+			label:    "Custom",
+			freeText: true,
+		},
+		{
+			name:     "zhipu protected mixed catalog",
+			provider: "zhipu",
+			label:    "OpenCode Go",
+			want:     []string{"GLM-5.2", "GLM-5.1", "glm-5.2", "glm-5.1"},
+		},
+		{
+			name:     "custom remains free text",
+			provider: "custom",
+			freeText: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseURL := ""
+			if tc.label != "" {
+				for _, region := range preset.ProviderRegionURLs[tc.provider] {
+					if region.Label == tc.label {
+						baseURL = region.URL
+						break
+					}
+				}
+			}
+			if tc.label != "" && tc.label != "Custom" && baseURL == "" {
+				t.Fatalf("%s route %q has no URL", tc.provider, tc.label)
+			}
+			got := modelOptions(tc.provider, baseURL)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("modelOptions(%q, %q) = %#v, want %#v", tc.provider, baseURL, got, tc.want)
+			}
+
+			p := builtinPresetForEditorTest(t, tc.provider)
+			m := NewPresetEditorModelWithBuiltinFlag(p, "en", nil, "", false)
+			m.llmMap()["base_url"] = baseURL
+			model := "typed-route-model"
+			if len(tc.want) > 0 {
+				model = tc.want[0]
+			}
+			m.llmMap()["model"] = model
+			m.cursor = editorFieldOrderIndex(t, feModel)
+			if gotPicker := m.isCyclable(feModel); gotPicker != !tc.freeText {
+				t.Fatalf("isCyclable(feModel) = %v, freeText=%v", gotPicker, tc.freeText)
+			}
+			if strip := m.modelRadioStrip(false, lipgloss.NewStyle()); (strip == "") != tc.freeText {
+				t.Fatalf("modelRadioStrip() empty = %v, freeText=%v; strip=%q", strip == "", tc.freeText, strip)
+			}
+			opened, _ := m.openInline()
+			if tc.freeText {
+				if opened.mode != emInline {
+					t.Fatalf("free-text route Enter mode = %v, want emInline", opened.mode)
+				}
+				opened.applyInline("edited-route-model")
+				if got := asString(opened.llmMap()["model"]); got != "edited-route-model" {
+					t.Fatalf("free-text route model = %q, want edited-route-model", got)
+				}
+			} else if opened.mode != emBrowse {
+				t.Fatalf("picker route Enter mode = %v, want emBrowse", opened.mode)
+			} else if got := asString(opened.llmMap()["model"]); got != tc.want[1] {
+				t.Fatalf("picker route model after Enter = %q, want %q", got, tc.want[1])
+			}
+		})
+	}
+}
+
+func TestPresetEditorRegionChangePreservesModelText(t *testing.T) {
+	tests := []struct {
+		provider string
+		steps    int
+	}{
+		{provider: "minimax", steps: 2}, // CN -> INTL -> OpenCode Go
+		{provider: "mimo", steps: 1},    // native -> OpenCode Go
+		{provider: "kimi", steps: 1},    // native -> OpenCode Go
+	}
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			regions := preset.ProviderRegionURLs[tc.provider]
+			if len(regions) < 2 || regions[0].URL == "" || regions[1].URL == "" {
+				t.Fatalf("%s route table lacks two non-empty regions: %#v", tc.provider, regions)
+			}
+			m := NewPresetEditorModelWithBuiltinFlag(builtinPresetForEditorTest(t, tc.provider), "en", nil, "", false)
+			m.llmMap()["base_url"] = regions[0].URL
+			m.llmMap()["model"] = "user-typed-model"
+			m.cursor = editorFieldOrderIndex(t, feBaseURL)
+			for i := 0; i < tc.steps; i++ {
+				m.cycleFocused(+1)
+			}
+			if got := asString(m.llmMap()["model"]); got != "user-typed-model" {
+				t.Fatalf("model after %s region change = %q, want preserved user text", tc.provider, got)
+			}
+		})
+	}
+}
+
+func TestPresetEditorRegionChangeReconcilesKnownRouteModels(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   string
+		startIndex int
+		direction  int
+		steps      int
+		model      string
+		wantModel  string
+		wantIndex  int
+	}{
+		{
+			name:       "MiniMax native-only model falls back to protected Go default",
+			provider:   "minimax",
+			startIndex: 0,
+			direction:  +1,
+			steps:      2,
+			model:      "MiniMax-M2.5",
+			wantModel:  "MiniMax-M3",
+			wantIndex:  2,
+		},
+		{
+			name:       "MiMo retired Go model falls back to native default",
+			provider:   "mimo",
+			startIndex: 1,
+			direction:  -1,
+			steps:      1,
+			model:      "mimo-v2-omni",
+			wantModel:  "mimo-v2.5",
+			wantIndex:  0,
+		},
+		{
+			name:       "Kimi native id is cleared on free-text Go route",
+			provider:   "kimi",
+			startIndex: 0,
+			direction:  +1,
+			steps:      1,
+			model:      "k3",
+			wantModel:  "",
+			wantIndex:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			regions := preset.ProviderRegionURLs[tc.provider]
+			m := NewPresetEditorModelWithBuiltinFlag(builtinPresetForEditorTest(t, tc.provider), "en", nil, "", false)
+			m.llmMap()["base_url"] = regions[tc.startIndex].URL
+			m.llmMap()["model"] = tc.model
+			m.cursor = editorFieldOrderIndex(t, feBaseURL)
+			for i := 0; i < tc.steps; i++ {
+				m.cycleFocused(tc.direction)
+			}
+			if got := asString(m.llmMap()["base_url"]); got != regions[tc.wantIndex].URL {
+				t.Fatalf("base_url = %q, want %q", got, regions[tc.wantIndex].URL)
+			}
+			if got := asString(m.llmMap()["model"]); got != tc.wantModel {
+				t.Fatalf("model = %q, want %q", got, tc.wantModel)
+			}
+		})
+	}
+}
+
+// TestModelHasVisionDeclaresEveryShippedModel is the F8 contract for the
+// native/default catalog: a shipped model that is absent from modelHasVision
+// reads as text-only through Go's zero value, which is an omission rather than
+// a declaration. Route-only gateway overrides intentionally have no global
+// modality entries. The map must not accumulate entries for models the
+// two-generation curation rule has retired.
 func TestModelHasVisionDeclaresEveryShippedModel(t *testing.T) {
 	shipped := map[string]bool{}
 	for provider, models := range providerModels {
@@ -655,6 +875,7 @@ func TestModelSwitchNeverTouchesCapabilities(t *testing.T) {
 	// Cycling the model field (feModel + cycleFocused) must not touch
 	// capabilities either, in either direction.
 	m.llmMap()["provider"] = "mimo"
+	m.llmMap()["base_url"] = preset.ProviderRegionURLs["mimo"][0].URL
 	m.llmMap()["model"] = "mimo-v2.5-pro"
 	m.cycleFocused(+1) // mimo-v2.5-pro -> mimo-v2.5 (vision-capable)
 	assertCapsUnchanged(t, "cycleFocused to vision-capable model", m, before)

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -150,6 +150,21 @@ func TestPresetEditorProviderModelLineupsPinRequestedDefaults(t *testing.T) {
 	if got := providerModels["claude-code"]; !reflect.DeepEqual(got, wantClaudeModels) {
 		t.Fatalf("claude-code provider models = %#v, want %#v", got, wantClaudeModels)
 	}
+	wantNVIDIAModels := []string{
+		"nvidia/nemotron-3-ultra-550b-a55b",
+		"nvidia/nemotron-3-super-120b-a12b",
+		"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+		"deepseek-ai/deepseek-v4-pro-0813",
+		"deepseek-ai/deepseek-v4-flash-0731",
+		"moonshotai/kimi-k3",
+		"minimaxai/minimax-m3",
+		"mistralai/mistral-nemotron",
+		"openai/gpt-oss-20b",
+		"nvidia/llama-3.1-nemotron-ultra-253b-v1",
+	}
+	if got := providerModels["nvidia"]; !reflect.DeepEqual(got, wantNVIDIAModels) {
+		t.Fatalf("nvidia provider models = %#v, want %#v", got, wantNVIDIAModels)
+	}
 	if !modelHasVision["mimo-v2.5"] {
 		t.Fatal("MiMo picker must keep native vision for mimo-v2.5")
 	}
@@ -201,8 +216,8 @@ func TestModelHasVisionDeclaresEveryShippedModel(t *testing.T) {
 		if strings.HasPrefix(provider, "claude") {
 			continue
 		}
-		// The NVIDIA catalog is an open free-text gateway list, not a curated
-		// per-model vision inventory.
+		// NVIDIA's bounded route-served snapshot does not assert a curated
+		// per-model vision inventory, so this completeness gate does not apply.
 		if provider == "nvidia" {
 			continue
 		}


### PR DESCRIPTION
## Summary

Complete the TUI built-in preset refresh across all 13 named presets while preserving the explicit no-refresh boundary for OpenCode Go catalogs and Custom.

- refresh evidence-backed built-in defaults and picker options for the latest two represented generations
- make picker curation route-exact with `modelOptions(provider, base_url)` instead of applying native IDs to every endpoint
- keep arbitrary off-list/free-text model IDs intact while reconciling only known curated IDs when a user changes routes
- align the affected named-preset sub-skills, the TUI maintenance guide, and the TUI model-list contract

### All named-preset dispositions

| Preset | Result |
|---|---|
| Gemini | Default `gemini-3.8-flash`; uncurated route remains free text; native vision fact retained. |
| NVIDIA | Default `nvidia/nemotron-3-ultra-550b-a55b`; picker is the reviewed ordered 10-model route-served snapshot. |
| OpenRouter | Default `z-ai/glm-5.3`; route remains free text. |
| Codex | Default remains `gpt-5.6-sol`; picker is `gpt-5.6-sol`, `gpt-6-astra`, `gpt-5.6-terra`, `gpt-5.6-luna`. |
| Codex Pool | Same default-first four-model picker as Codex; user pool files are untouched. |
| Claude | CLI aliases/default remain `opus`, `fable`, `sonnet`, `haiku`; provider guide corrects Fable's mapping to `claude-fable-5-1`. |
| MiniMax | Native CN defaults to `MiniMax-M2.7` and offers M2.7/M2.5 plus high-speed variants; INTL stays free text; the OpenCode Go catalog remains its pre-PR list. |
| MiMo | Native picker is `mimo-v2.5` / `mimo-v2.5-pro`; the OpenCode Go catalog remains its pre-PR list. |
| Kimi | Native default is `k3` with `k3`, `k3-256k`, `kimi-for-coding`, and `kimi-for-coding-highspeed`; OpenCode Go and Custom remain free text. |
| DeepSeek | Existing v4 Pro/Flash picker remains the evidence-backed current two-variant set; no product-model change. |
| Grok | Existing OpenCode Go-only `grok-code-fast-4.5` behavior remains unchanged. |
| Zhipu | No product-model change because exact native Coding Plan 5.3 IDs/casing were not sufficiently evidenced. |
| Custom | Unchanged free-text behavior, empty default, and no curated catalog. |

## Route behavior and boundaries

- Exact native picker overrides exist only for MiniMax, MiMo, and Kimi. MiniMax and MiMo's existing OpenCode Go lists are preserved; Kimi's Go row stays free text.
- On a route change, only model IDs already known to a curated route table are reconciled. Destination-valid IDs stay; a protected destination picker falls back to its existing first option.
- A known native Kimi ID clears on the exact OpenCode Go row, so the existing non-empty-model validation requires an explicit Go ID instead of silently saving an unsupported native ID.
- Arbitrary off-list text and every Custom transition remain untouched.
- No saved preset, provider endpoint, credential source, account, pool file, runtime, auth, or configuration is migrated or rewritten.

## Validation

- exact 19-file full-branch scope; 16-file amendment commit; no untracked files
- `git diff --check 60c2078a8c872d748dab69d5271429bc702c4a45..HEAD`
- empty `gofmt -d` over every changed Go file
- every changed named-preset child guide is under 200 lines and retains the required same-PR maintenance line
- `go test ./internal/preset ./internal/tui`
  - `internal/preset`: PASS
  - `internal/tui`: PASS
- first independent Codex CLI Terra / fast review: **BLOCK** on one P2 native-to-Go carry-over defect
- minimum known-model-only reconciliation repair plus production Kimi inline-edit/save E2E coverage
- fresh independent Codex CLI Terra / fast confirmation: **PASS**, with no concrete P1/P2/P3 candidate

Commits: `09b01b3c` (initial Gemini/NVIDIA/OpenRouter slice) and `6d9dd922` (complete all-preset amendment).

No merge is included or authorized by this update.

Telegram: @nokvlingtaibot | Nickname: 心栈
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
