### PR TITLE
feat(tui): expose service tiers for all presets

### DIFF
--- a/tui/CONTRACT.md
+++ b/tui/CONTRACT.md
@@ -132,6 +132,21 @@ appears as the degraded state below.
    presence (R3.1), `.env` API keys (R2), `.secrets` for declared addons
    (R1), runtime/version (R1).
 
+## Preset editor service tier
+
+The preset editor exposes the same service-tier row for every provider in the
+13-name `BuiltinPresets()` catalog, including Codex Pool, API-key providers,
+CLI-backed Claude, and Custom. Its vocabulary is exactly `normal | fast` and
+the row is always visible, cyclable, and cursor-reachable; the TUI does not
+probe provider support or reject either choice. Lower layers may ignore an
+unsupported tier.
+
+Missing or `normal` `manifest.llm.service_tier` displays as `normal` and is
+omitted from the committed manifest. Selecting `fast` commits the string
+`"fast"` for every provider. Unknown legacy values display as `normal`; they
+retain the existing non-Codex preservation behavior unless the user cycles the
+row, while Codex continues to normalize unknown values to omission.
+
 ## Model list curation
 
 The model ids the TUI offers are a contract with the user: everything the

--- a/tui/internal/tui/SKILL.md
+++ b/tui/internal/tui/SKILL.md
@@ -20,6 +20,19 @@ Drift here causes one of two failures:
 
 The second failure mode is what this file exists to prevent.
 
+## Shared service-tier editor behavior
+
+`serviceTierOptions` (`preset_editor.go`) is the one `normal | fast` vocabulary
+used by the preset editor for every provider, including Codex Pool, API-key,
+CLI-backed, and Custom built-ins. The row is always visible and cyclable. A
+missing or `normal` value displays as `normal` and omits
+`manifest.llm.service_tier` on commit; `fast` persists as the string `"fast"`.
+The TUI deliberately performs no provider support check or filtering here — a
+lower layer may ignore an unsupported tier. This is independent of the
+provider model catalogs and does not change model, reasoning, credential, or
+endpoint behavior. Unknown legacy values display as `normal`; non-Codex values
+retain the existing preservation behavior unless the user cycles the row.
+
 ## Authoritative sources per provider
 
 | Provider | Canonical list | Cadence | Notes |

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -256,7 +256,9 @@ func reconcileModelForRoute(provider, baseURL, model string) string {
 	return model
 }
 
-var codexServiceTierOptions = []string{"normal", "fast"}
+// serviceTierOptions is shared by every provider row. The TUI intentionally
+// does not decide whether the lower layer supports either tier.
+var serviceTierOptions = []string{"normal", "fast"}
 
 var codexThinkingOptions = []string{"low", "medium", "high", "xhigh"}
 
@@ -750,9 +752,7 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 			m.mode = emInline
 		}
 	case feServiceTier:
-		if m.isCodexProvider() {
-			m.cycleFocused(+1)
-		}
+		m.cycleFocused(+1)
 	case feThinking:
 		if m.hasThinking() {
 			m.cycleFocused(+1)
@@ -970,7 +970,7 @@ func (m PresetEditorModel) codexCLIImportAvailable() bool {
 	_, ok := readCodexCLIAuthFile(codexCLIAuthPath())
 	return ok
 }
-func (m PresetEditorModel) codexServiceTier() string {
+func (m PresetEditorModel) serviceTier() string {
 	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
 	if asString(llm["service_tier"]) == "fast" {
 		return "fast"
@@ -978,9 +978,9 @@ func (m PresetEditorModel) codexServiceTier() string {
 	return "normal"
 }
 
-func (m *PresetEditorModel) setCodexServiceTier(tier string) {
+func (m *PresetEditorModel) setServiceTier(tier string) {
 	llm := m.llmMap()
-	if preset.ClassifyCredentialFamily(asString(llm["provider"])) != preset.CredentialFamilyCodexSingle || tier != "fast" {
+	if tier != "fast" {
 		delete(llm, "service_tier")
 		return
 	}
@@ -1060,13 +1060,20 @@ func (m *PresetEditorModel) setThinking(effort string) {
 
 func normalizeServiceTier(manifest map[string]interface{}) {
 	llm, _ := manifest["llm"].(map[string]interface{})
-	if llm == nil || preset.ClassifyCredentialFamily(asString(llm["provider"])) != preset.CredentialFamilyCodexSingle {
+	if llm == nil {
 		return
 	}
-	if asString(llm["service_tier"]) == "fast" {
+	tier := asString(llm["service_tier"])
+	if tier == "fast" {
 		return
 	}
-	delete(llm, "service_tier")
+	// Normal is the editor's omission sentinel for every provider. Preserve
+	// other legacy values on non-Codex manifests unless the user cycles the
+	// row, retaining the pre-existing non-Codex save compatibility; Codex's
+	// existing normalization continues to discard unknown values.
+	if tier == "normal" || preset.ClassifyCredentialFamily(asString(llm["provider"])) == preset.CredentialFamilyCodexSingle {
+		delete(llm, "service_tier")
+	}
 }
 
 func normalizeThinking(manifest map[string]interface{}) {
@@ -1347,9 +1354,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 			delete(m.llmMap(), "responses_transport")
 		}
 	case feServiceTier:
-		if m.isCodexProvider() {
-			m.setCodexServiceTier(cycleString(codexServiceTierOptions, m.codexServiceTier(), dir))
-		}
+		m.setServiceTier(cycleString(serviceTierOptions, m.serviceTier(), dir))
 	case feThinking:
 		if m.hasThinking() {
 			m.setThinking(cycleString(m.thinkingOptions(), m.thinkingValue(), dir))
@@ -1556,7 +1561,7 @@ func (m PresetEditorModel) fieldString(f editorField) string {
 		s, _ := llm["model"].(string)
 		return s
 	case feServiceTier:
-		return m.codexServiceTier()
+		return m.serviceTier()
 	case feThinking:
 		return m.thinkingValue()
 	case feAPICompat:
@@ -1737,7 +1742,7 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 	rows = append(rows, row(feProvider, m.row(feProvider, lbl("provider"), asString(llm["provider"]), width-4)))
 	rows = append(rows, row(feModel, m.row(feModel, lbl("model"), asString(llm["model"]), width-4)))
 	if m.fieldVisible(feServiceTier) {
-		rows = append(rows, row(feServiceTier, m.row(feServiceTier, lbl("service_tier"), m.codexServiceTier(), width-4)))
+		rows = append(rows, row(feServiceTier, m.row(feServiceTier, lbl("service_tier"), m.serviceTier(), width-4)))
 	}
 	if m.fieldVisible(feThinking) {
 		rows = append(rows, row(feThinking, m.row(feThinking, lbl("thinking"), m.thinkingValue(), width-4)))
@@ -1883,13 +1888,10 @@ func (m PresetEditorModel) modelRadioStrip(focused bool, valStyle lipgloss.Style
 }
 
 func (m PresetEditorModel) serviceTierRadioStrip(focused bool, valStyle lipgloss.Style) string {
-	if !m.isCodexProvider() {
-		return ""
-	}
-	current := m.codexServiceTier()
+	current := m.serviceTier()
 	subtle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	parts := make([]string, 0, len(codexServiceTierOptions))
-	for _, tier := range codexServiceTierOptions {
+	parts := make([]string, 0, len(serviceTierOptions))
+	for _, tier := range serviceTierOptions {
 		if tier == current {
 			if focused {
 				parts = append(parts, valStyle.Render("● "+tier))
@@ -2020,7 +2022,7 @@ func (m PresetEditorModel) isCyclable(f editorField) bool {
 	case feProvider, feAPICompat, feTier:
 		return true
 	case feServiceTier:
-		return m.isCodexProvider()
+		return true
 	case feThinking:
 		return m.hasThinking()
 	case feWireAPI:
@@ -2150,7 +2152,7 @@ func (m *PresetEditorModel) ensureFocusedVisible() {
 func (m PresetEditorModel) fieldVisible(f editorField) bool {
 	switch f {
 	case feServiceTier:
-		return m.isCodexProvider()
+		return true
 	case feThinking:
 		return m.hasThinking()
 	case feWireAPI:

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -1128,36 +1128,116 @@ func TestPresetEditorProviderSwitchClearsThinking(t *testing.T) {
 	}
 }
 
-func TestPresetEditorServiceTierHiddenForNonCodexAndPreserved(t *testing.T) {
-	// gemini has no api_compat and is outside the thinking scope, so the field
-	// layout matches the classic non-codex editor (thinking row hidden).
-	m := NewPresetEditorModelWithBuiltinFlag(testLevelThinkingPreset("gemini", "", nil), "en", nil, "", false)
-	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
-	view := m.View()
-
-	if m.fieldVisible(feServiceTier) {
-		t.Fatalf("service tier row should be hidden for non-codex provider")
+func TestPresetEditorServiceTierAvailableForEveryBuiltin(t *testing.T) {
+	wantNames := []string{
+		"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "grok",
+		"nvidia", "openrouter", "codex", "codex-pool", "claude", "custom",
 	}
-	if strings.Contains(view, "service_tier") {
-		t.Fatalf("non-codex editor should not render service_tier row; view:\n%s", view)
+	gotNames := make([]string, 0, len(preset.BuiltinPresets()))
+	for _, p := range preset.BuiltinPresets() {
+		gotNames = append(gotNames, p.Name)
 	}
-
-	m.cursor = editorFieldOrderIndex(t, feModel)
-	m.moveCursor(+1)
-	if editorFieldOrder[m.cursor] == feServiceTier {
-		t.Fatalf("cursor landed on hidden service tier field for non-codex preset")
-	}
-	if editorFieldOrder[m.cursor] != feAPICompat {
-		t.Fatalf("cursor after model = %v, want feAPICompat", editorFieldOrder[m.cursor])
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("BuiltinPresets() names = %#v, want %#v", gotNames, wantNames)
 	}
 
-	llm := m.working.Manifest["llm"].(map[string]interface{})
-	llm["service_tier"] = "provider-specific"
-	_, cmd := m.commit()
-	commit := cmd().(PresetEditorCommitMsg)
-	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
-	if got, _ := committedLLM["service_tier"].(string); got != "provider-specific" {
-		t.Fatalf("non-codex commit should preserve llm.service_tier; got %#v", committedLLM["service_tier"])
+	for _, name := range wantNames {
+		t.Run(name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(builtinPresetForEditorTest(t, name), "en", nil, "", false)
+			// The custom template intentionally starts with an empty model; give
+			// this editor behavior test a valid user value before commit.
+			if asString(m.llmMap()["model"]) == "" {
+				m.llmMap()["model"] = "test-model"
+			}
+			m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+			view := m.View()
+
+			if !m.fieldVisible(feServiceTier) {
+				t.Fatalf("service tier row should be visible for %s", name)
+			}
+			if !m.isCyclable(feServiceTier) {
+				t.Fatalf("service tier row should be cyclable for %s", name)
+			}
+			if !strings.Contains(view, i18n.T("preset_editor.field_service_tier")) {
+				t.Fatalf("view missing service tier label for %s; view:\n%s", name, view)
+			}
+			for _, option := range serviceTierOptions {
+				if !strings.Contains(view, option) {
+					t.Fatalf("view missing service tier option %q for %s; view:\n%s", option, name, view)
+				}
+			}
+
+			// The cursor must be able to reach the shared row directly after the
+			// model row, including free-text and CLI-backed built-ins.
+			m.cursor = editorFieldOrderIndex(t, feModel)
+			m.moveCursor(+1)
+			if editorFieldOrder[m.cursor] != feServiceTier {
+				t.Fatalf("cursor after model = %v for %s, want feServiceTier", editorFieldOrder[m.cursor], name)
+			}
+			if got := m.fieldString(feServiceTier); got != "normal" {
+				t.Fatalf("missing service tier displays %q for %s, want normal", got, name)
+			}
+
+			m.llmMap()["service_tier"] = "normal"
+			_, cmd := m.commit()
+			if cmd == nil {
+				t.Fatalf("explicit normal commit returned nil command for %s", name)
+			}
+			committed := cmd().(PresetEditorCommitMsg).Preset.Manifest["llm"].(map[string]interface{})
+			if _, ok := committed["service_tier"]; ok {
+				t.Fatalf("explicit normal commit should omit service_tier for %s: %#v", name, committed["service_tier"])
+			}
+
+			m.cycleFocused(+1)
+			if got := m.llmMap()["service_tier"]; got != "fast" {
+				t.Fatalf("normal -> fast stored %#v for %s, want string fast", got, name)
+			}
+			_, cmd = m.commit()
+			if cmd == nil {
+				t.Fatalf("fast commit returned nil command for %s", name)
+			}
+			committed = cmd().(PresetEditorCommitMsg).Preset.Manifest["llm"].(map[string]interface{})
+			if got := committed["service_tier"]; got != "fast" {
+				t.Fatalf("fast commit stored %#v for %s, want string fast", got, name)
+			}
+
+			m.cycleFocused(+1)
+			if got := m.fieldString(feServiceTier); got != "normal" {
+				t.Fatalf("fast -> normal displays %q for %s, want normal", got, name)
+			}
+			if _, ok := m.llmMap()["service_tier"]; ok {
+				t.Fatalf("fast -> normal kept service_tier for %s: %#v", name, m.llmMap()["service_tier"])
+			}
+			_, cmd = m.commit()
+			if cmd == nil {
+				t.Fatalf("normal commit returned nil command for %s", name)
+			}
+			committed = cmd().(PresetEditorCommitMsg).Preset.Manifest["llm"].(map[string]interface{})
+			if _, ok := committed["service_tier"]; ok {
+				t.Fatalf("normal commit should omit service_tier for %s: %#v", name, committed["service_tier"])
+			}
+
+			// Unknown legacy/provider-specific values are displayed as normal. Keep
+			// the old non-Codex preservation behavior until the user cycles the row;
+			// Codex retains its existing normalization to omission.
+			m.llmMap()["service_tier"] = "provider-specific"
+			if got := m.fieldString(feServiceTier); got != "normal" {
+				t.Fatalf("unknown service tier displays %q for %s, want normal", got, name)
+			}
+			_, cmd = m.commit()
+			if cmd == nil {
+				t.Fatalf("unknown service tier commit returned nil command for %s", name)
+			}
+			committed = cmd().(PresetEditorCommitMsg).Preset.Manifest["llm"].(map[string]interface{})
+			_, saved := committed["service_tier"]
+			if name == "codex" {
+				if saved {
+					t.Fatalf("unknown Codex service tier should be omitted: %#v", committed["service_tier"])
+				}
+			} else if !saved || committed["service_tier"] != "provider-specific" {
+				t.Fatalf("unknown non-Codex service tier should be preserved for %s: %#v", name, committed["service_tier"])
+			}
+		})
 	}
 }
 
@@ -2173,12 +2253,12 @@ func TestPresetEditorCredentialFamilyGates(t *testing.T) {
 	}{
 		{"codex", true, true, true},
 		{"codex_oauth", true, true, true},
-		{"codex-pool", false, true, false},
-		{"codex_pool", false, true, false},
-		{"claude-code", false, false, false},
-		{"claude_code", false, false, false},
-		{"claude-agent-sdk", false, false, false},
-		{"claude_agent_sdk", false, false, false},
+		{"codex-pool", false, true, true},
+		{"codex_pool", false, true, true},
+		{"claude-code", false, false, true},
+		{"claude_code", false, false, true},
+		{"claude-agent-sdk", false, false, true},
+		{"claude_agent_sdk", false, false, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
@@ -2192,7 +2272,7 @@ func TestPresetEditorCredentialFamilyGates(t *testing.T) {
 			if got := m.hasCodexThinking(); got != tc.thinking {
 				t.Fatalf("hasCodexThinking() = %v, want %v", got, tc.thinking)
 			}
-			m.setCodexServiceTier("fast")
+			m.setServiceTier("fast")
 			workingLLM := m.llmMap()
 			_, hasTier := workingLLM["service_tier"]
 			if hasTier != tc.serviceTierKey {


### PR DESCRIPTION
## Summary

Expose the existing `normal | fast` service-tier selector across all 13 built-in preset editor contexts.

- Show the row for Codex Pool, API-key providers, Claude CLI, and Custom as well as single-account Codex.
- Keep `normal` as the default/omission sentinel; choosing `fast` writes `manifest.llm.service_tier: "fast"`.
- Deliberately avoid provider capability checks or TUI rejection so unsupported tiers can be ignored by lower layers.
- Preserve model catalogs/defaults, endpoints, credentials/auth, reasoning, routing, vision, saved presets, runtime, and lower-layer behavior.

## Behavior coverage

A table-driven regression test pins the exact 13-name `BuiltinPresets()` catalog and verifies, for each preset:

- row visibility and cursor reachability;
- exact `normal | fast` options and cycling;
- missing/explicit `normal` display plus omission on commit;
- exact string persistence for `fast`;
- compatibility behavior for unknown legacy values.

## Validation

- `gofmt -d internal/tui/preset_editor.go internal/tui/preset_editor_test.go`
- `git diff --check`
- `go test ./internal/tui -run 'TestPresetEditor(ServiceTier|CodexServiceTier|CredentialFamilyGates)' -count=1`
- `go test ./internal/preset ./internal/tui -count=1`
- `go vet ./...`

All commands above pass. A full `go test ./... -count=1` also passes `internal/tui` and fails only the pre-existing root Anatomy coverage guard for three unrelated tracked files not touched by this PR.

Fresh independent Codex CLI Terra / fast final review: **PASS**, with no P1/P2/P3 candidate defect.

Telegram: @nokvlingtaibot | Nickname: 心栈

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
